### PR TITLE
Исправлены лоадеры навигации и парсинг заголовков

### DIFF
--- a/apps/docs/hooks/use-navigation-loading.ts
+++ b/apps/docs/hooks/use-navigation-loading.ts
@@ -1,39 +1,43 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 
 export function useNavigationLoading(href: string, delay: number = 200) {
-  const [isLoading, setIsLoading] = useState(false);
+  const [showLoader, setShowLoader] = useState(false);
   const pathname = usePathname();
-  const pendingHrefRef = useRef<string | null>(null);
+  const targetHrefRef = useRef<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (pendingHrefRef.current && pathname === pendingHrefRef.current) {
-      // Reset loading state when navigation is complete
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: syncing with navigation state
-      setIsLoading(false);
-      pendingHrefRef.current = null;
+    if (targetHrefRef.current && pathname === targetHrefRef.current) {
+      targetHrefRef.current = null;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      setShowLoader(false);
     }
   }, [pathname]);
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (href === pathname) {
-      return;
-    }
-
-    // Устанавливаем загрузку с задержкой
-    const timeoutId = setTimeout(() => {
-      setIsLoading(true);
-      pendingHrefRef.current = href;
-    }, delay);
-
-    // Сохраняем таймер для возможной отмены
-    const target = e.currentTarget as HTMLAnchorElement & {
-      __loadingTimeout?: ReturnType<typeof setTimeout>;
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-    target.__loadingTimeout = timeoutId;
-  };
+  }, []);
 
-  return { isLoading, handleClick };
+  const handleClick = useCallback(() => {
+    if (href === pathname) return;
+
+    targetHrefRef.current = href;
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      if (targetHrefRef.current === href) {
+        setShowLoader(true);
+      }
+    }, delay);
+  }, [href, pathname, delay]);
+
+  return { isLoading: showLoader, handleClick };
 }

--- a/apps/docs/lib/updates-parser.ts
+++ b/apps/docs/lib/updates-parser.ts
@@ -55,11 +55,11 @@ export function parseUpdatesFromMdx(mdxContent: string): ParsedUpdate[] {
     if (!date || !rawContent) continue;
 
     // Extract title from ## heading
-    const titleMatch = rawContent.match(/^[\s\n]*##\s+(.+?)[\s\n]/);
+    const titleMatch = rawContent.match(/^[\s\n]*##\s+(.+)$/m);
     const title = titleMatch ? titleMatch[1].trim() : 'Обновление';
 
     // Get content after the title line
-    const contentAfterTitle = rawContent.replace(/^[\s\n]*##\s+.+?\n/, '').trim();
+    const contentAfterTitle = rawContent.replace(/^[\s\n]*##\s+.+$/m, '').trim();
 
     updates.push({
       date,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves reliability of navigation loaders and parsing of update titles.
> 
> - Refactors `useNavigationLoading` to use delayed loader with cancellable `setTimeout`, track target href, clear timers on route change/unmount, and expose `isLoading` from `showLoader` via `useCallback`-based `handleClick`
> - Adjusts `updates-parser` regex to robustly capture `##` titles and strip the title line using multiline anchors, handling headings without trailing newlines
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e38443194679616b8483ed89e01c8796a11b00c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->