### PR TITLE
Добавлена поддержка markdown-ссылок в описаниях параметров

### DIFF
--- a/apps/docs/components/api/inline-code-text.tsx
+++ b/apps/docs/components/api/inline-code-text.tsx
@@ -1,14 +1,53 @@
 import React from 'react';
+import Link from 'next/link';
 
 interface InlineCodeTextProps {
   text: string;
   className?: string;
 }
 
+function renderTextWithLinks(text: string): React.ReactNode[] {
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  const result: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = linkRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      result.push(text.slice(lastIndex, match.index));
+    }
+    const [, linkText, url] = match;
+    const isExternal = url.startsWith('http');
+    result.push(
+      isExternal ? (
+        <a
+          key={match.index}
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent-emphasis hover:underline"
+        >
+          {linkText}
+        </a>
+      ) : (
+        <Link key={match.index} href={url} className="text-accent-emphasis hover:underline">
+          {linkText}
+        </Link>
+      )
+    );
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    result.push(text.slice(lastIndex));
+  }
+
+  return result.length > 0 ? result : [text];
+}
+
 export function InlineCodeText({ text, className }: InlineCodeTextProps) {
   if (!text) return null;
 
-  // Split text by backticks: `code`
   const parts = text.split(/(`[^`]+`)/g);
 
   return (
@@ -25,7 +64,7 @@ export function InlineCodeText({ text, className }: InlineCodeTextProps) {
             </code>
           );
         }
-        return <React.Fragment key={index}>{part}</React.Fragment>;
+        return <React.Fragment key={index}>{renderTextWithLinks(part)}</React.Fragment>;
       })}
     </span>
   );

--- a/apps/docs/components/api/markdown-content.tsx
+++ b/apps/docs/components/api/markdown-content.tsx
@@ -4,8 +4,8 @@ import { GuideCodeBlock } from './guide-code-block';
 import { InternalLink } from './smooth-scroll-link';
 import { replaceSpecialTagsForMDX } from '@/lib/replace-special-tags';
 import type { Endpoint } from '@/lib/openapi/types';
-import { generateUrlFromOperation } from '@/lib/openapi/mapper';
 import { parseOpenAPI } from '@/lib/openapi/parser';
+import { resolveEndpointLinks } from '@/lib/openapi/resolve-links';
 import {
   SchemaBlock,
   HttpCodes,
@@ -18,39 +18,6 @@ import {
   Warning,
   Info,
 } from '@/components/mdx/mdx-components';
-
-/**
- * Convert special link syntax to standard markdown links
- * Syntax: [description](METHOD /path) -> [description](/resolved-url)
- */
-function resolveEndpointLinks(text: string, allEndpoints?: Endpoint[]): string {
-  return text.replace(
-    /\[([^\]]+)\]\((GET|POST|PUT|DELETE|PATCH)\s+(\/[^\)]+)\)/g,
-    (match, description, method, path) => {
-      // Check if it's a guide path
-      if (path.startsWith('/guides/')) {
-        return `[${description.trim()}](${path})`;
-      }
-
-      // If allEndpoints provided, try to resolve the URL
-      if (allEndpoints) {
-        const endpoint = allEndpoints.find(
-          (ep) => ep.method.toUpperCase() === method.toUpperCase() && ep.path === path
-        );
-
-        if (endpoint) {
-          const url = generateUrlFromOperation(endpoint);
-          return `[${description.trim()}](${url})`;
-        }
-      }
-
-      // If endpoint not found, return description without link
-      // Escape curly braces to prevent {id} from being interpreted as JSX
-      const escapedPath = path.replace(/\{/g, '&#123;').replace(/\}/g, '&#125;');
-      return `${description.trim()} (${method} ${escapedPath})`;
-    }
-  );
-}
 
 // Simple markdown components for server rendering
 const components = {

--- a/apps/docs/components/api/method-template.tsx
+++ b/apps/docs/components/api/method-template.tsx
@@ -11,6 +11,7 @@ import {
   getDescriptionWithoutTitle,
   generateUrlFromOperation,
 } from '@/lib/openapi/mapper';
+import { resolveEndpointDescriptionLinks } from '@/lib/openapi/resolve-links';
 
 interface ApiMethodTemplateProps {
   endpoint: Endpoint;
@@ -28,7 +29,8 @@ export function ApiMethodTemplate({
   allEndpoints,
   baseUrl,
 }: ApiMethodTemplateProps) {
-  const fullDescription = getDescriptionWithoutTitle(endpoint);
+  const processedEndpoint = resolveEndpointDescriptionLinks(endpoint, allEndpoints);
+  const fullDescription = getDescriptionWithoutTitle(processedEndpoint);
 
   return (
     <div className="flex flex-col flex-1 min-h-full">
@@ -55,9 +57,9 @@ export function ApiMethodTemplate({
               )}
 
               <div className="space-y-8">
-                <ParametersSection endpoint={endpoint} />
-                <RequestBodySection endpoint={endpoint} />
-                <ResponseSection endpoint={endpoint} />
+                <ParametersSection endpoint={processedEndpoint} />
+                <RequestBodySection endpoint={processedEndpoint} />
+                <ResponseSection endpoint={processedEndpoint} />
               </div>
             </div>
           </div>

--- a/apps/docs/lib/openapi/resolve-links.ts
+++ b/apps/docs/lib/openapi/resolve-links.ts
@@ -1,0 +1,134 @@
+import type { Endpoint, Schema, Parameter, RequestBody, Response, MediaType } from './types';
+import { generateUrlFromOperation } from './mapper';
+
+export function resolveEndpointLinks(text: string, allEndpoints: Endpoint[]): string {
+  return text.replace(
+    /\[([^\]]+)\]\((GET|POST|PUT|DELETE|PATCH)\s+(\/[^)]+)\)/g,
+    (match, description, method, path) => {
+      if (path.startsWith('/guides/')) {
+        return `[${description.trim()}](${path})`;
+      }
+      const endpoint = allEndpoints.find(
+        (ep) => ep.method.toUpperCase() === method.toUpperCase() && ep.path === path
+      );
+      if (endpoint) {
+        return `[${description.trim()}](${generateUrlFromOperation(endpoint)})`;
+      }
+      const escapedPath = path.replace(/\{/g, '&#123;').replace(/\}/g, '&#125;');
+      return `${description.trim()} (${method} ${escapedPath})`;
+    }
+  );
+}
+
+function processSchema(schema: Schema, allEndpoints: Endpoint[]): Schema {
+  const result = { ...schema };
+
+  if (result.description) {
+    result.description = resolveEndpointLinks(result.description, allEndpoints);
+  }
+
+  if (result.properties) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([key, value]) => [
+        key,
+        processSchema(value, allEndpoints),
+      ])
+    );
+  }
+
+  if (result.items) {
+    result.items = processSchema(result.items, allEndpoints);
+  }
+
+  if (result.allOf) {
+    result.allOf = result.allOf.map((s) => processSchema(s, allEndpoints));
+  }
+  if (result.oneOf) {
+    result.oneOf = result.oneOf.map((s) => processSchema(s, allEndpoints));
+  }
+  if (result.anyOf) {
+    result.anyOf = result.anyOf.map((s) => processSchema(s, allEndpoints));
+  }
+
+  if (result.additionalProperties && typeof result.additionalProperties !== 'boolean') {
+    result.additionalProperties = processSchema(result.additionalProperties, allEndpoints);
+  }
+
+  return result;
+}
+
+function processMediaType(mediaType: MediaType, allEndpoints: Endpoint[]): MediaType {
+  return {
+    ...mediaType,
+    schema: processSchema(mediaType.schema, allEndpoints),
+  };
+}
+
+function processRequestBody(body: RequestBody, allEndpoints: Endpoint[]): RequestBody {
+  const result: RequestBody = {
+    ...body,
+    content: {},
+  };
+  if (body.description) {
+    result.description = resolveEndpointLinks(body.description, allEndpoints);
+  }
+  for (const [key, value] of Object.entries(body.content)) {
+    result.content[key] = processMediaType(value, allEndpoints);
+  }
+  return result;
+}
+
+function processResponse(response: Response, allEndpoints: Endpoint[]): Response {
+  const result: Response = {
+    ...response,
+  };
+  if (response.description) {
+    result.description = resolveEndpointLinks(response.description, allEndpoints);
+  }
+  if (response.content) {
+    result.content = {};
+    for (const [key, value] of Object.entries(response.content)) {
+      result.content[key] = processMediaType(value, allEndpoints);
+    }
+  }
+  return result;
+}
+
+function processParameter(param: Parameter, allEndpoints: Endpoint[]): Parameter {
+  const result: Parameter = {
+    ...param,
+    schema: processSchema(param.schema, allEndpoints),
+  };
+  if (param.description) {
+    result.description = resolveEndpointLinks(param.description, allEndpoints);
+  }
+  return result;
+}
+
+export function resolveEndpointDescriptionLinks(
+  endpoint: Endpoint,
+  allEndpoints: Endpoint[]
+): Endpoint {
+  const result: Endpoint = { ...endpoint };
+
+  if (endpoint.description) {
+    result.description = resolveEndpointLinks(endpoint.description, allEndpoints);
+  }
+
+  if (endpoint.parameters) {
+    result.parameters = endpoint.parameters.map((p) => processParameter(p, allEndpoints));
+  }
+
+  if (endpoint.requestBody) {
+    result.requestBody = processRequestBody(endpoint.requestBody, allEndpoints);
+  }
+
+  if (endpoint.responses) {
+    result.responses = {};
+    for (const [code, response] of Object.entries(endpoint.responses)) {
+      result.responses[code] = processResponse(response, allEndpoints);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
- InlineCodeText теперь рендерит markdown-ссылки [text](url)
- Вынесен resolveEndpointLinks в общую утилиту resolve-links.ts
- Добавлен препроцессинг описаний схем для резолва [text](METHOD /path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to docs rendering and link resolution, but could alter how API descriptions/schemas display if the new parsing or endpoint resolution behaves unexpectedly.
> 
> **Overview**
> Adds support for rendering markdown-style links (`[text](url)`) inside `InlineCodeText`, using `next/link` for internal URLs and `<a target="_blank">` for external ones.
> 
> Refactors special API-link resolution (`[desc](METHOD /path)`) into a shared `resolve-links.ts` utility and applies it more broadly by preprocessing endpoint descriptions, parameters, request bodies, responses, and nested schemas before rendering in `ApiMethodTemplate` and `MarkdownContent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f095e3840609f90688fb7e7fd95bf9f18d795109. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->