### PR TITLE
sidebar: русские названия секций, английские подписи и сортировка по …

### DIFF
--- a/apps/docs/components/layout/sidebar-nav.tsx
+++ b/apps/docs/components/layout/sidebar-nav.tsx
@@ -99,10 +99,15 @@ export function SidebarNav({ navigation }: SidebarNavProps) {
               className="navigation-section overflow-hidden"
             >
               <Accordion.Header>
-                <Accordion.Trigger className="flex w-full items-center justify-between px-2 py-1.5 text-[14px] leading-[1.4] rounded-md text-text-primary hover:bg-background-tertiary transition-colors duration-200 font-medium tracking-tight group cursor-pointer outline-none group">
-                  <span className="truncate">{section.title}</span>
+                <Accordion.Trigger className="flex gap-1.5 w-full items-center justify-between px-2 py-1.5 text-[14px] leading-[1.4] rounded-md text-text-primary hover:bg-background-tertiary transition-colors duration-200 font-medium tracking-tight group cursor-pointer outline-none group">
+                  <span className="min-w-0 flex items-center gap-1.5">
+                    <span className="truncate">{section.title}</span>
+                    {section.originalTitle && (
+                      <span className="shrink-0 text-text-secondary">{section.originalTitle}</span>
+                    )}
+                  </span>
                   <ChevronDown
-                    className="w-3.5 h-3.5 text-text-secondary group-hover:text-text-primary transition-all duration-200 -rotate-90 group-data-[state=open]:rotate-0"
+                    className="w-3.5 h-3.5 text-text-secondary group-hover:text-text-primary transition-all duration-200 -rotate-90 group-data-[state=open]:rotate-0 shrink-0"
                     strokeWidth={2.5}
                   />
                 </Accordion.Trigger>

--- a/apps/docs/lib/navigation.ts
+++ b/apps/docs/lib/navigation.ts
@@ -4,6 +4,26 @@ import type { NavigationSection } from './openapi/types';
 import { getOrderedGuidePages, sortTagsByOrder } from './guides-config';
 import { loadUpdates, isNewUpdate } from './updates-parser';
 
+const METHOD_ORDER: Record<string, number> = { POST: 0, GET: 1, PUT: 2, PATCH: 3, DELETE: 4 };
+
+const TAG_TRANSLATIONS: Record<string, string> = {
+  Common: 'Общие методы',
+  Profile: 'Профиль и статус',
+  Users: 'Сотрудники',
+  'Group tags': 'Теги',
+  Chats: 'Чаты',
+  Members: 'Участники чатов',
+  Thread: 'Комментарии',
+  Messages: 'Сообщения',
+  'Read member': 'Прочтение сообщения',
+  Reactions: 'Реакции на сообщения',
+  'Link Previews': 'Ссылки',
+  Tasks: 'Напоминания',
+  Views: 'Формы',
+  Bots: 'Боты и Webhook',
+  Security: 'Безопасность',
+};
+
 export async function generateNavigation(): Promise<NavigationSection[]> {
   const api = await parseOpenAPI();
 
@@ -34,11 +54,13 @@ export async function generateNavigation(): Promise<NavigationSection[]> {
   // Create sections from tags
   for (const tag of sortedTags) {
     const endpoints = grouped.get(tag)!;
-    // Tags are already in Russian in OpenAPI
-    const title = tag;
+    endpoints.sort((a, b) => (METHOD_ORDER[a.method] ?? 99) - (METHOD_ORDER[b.method] ?? 99));
+    const translation = TAG_TRANSLATIONS[tag];
+    const title = translation || tag;
 
     sections.push({
       title,
+      originalTitle: translation ? tag : undefined,
       items: endpoints.map((endpoint) => ({
         title: generateTitle(endpoint),
         href: generateUrlFromOperation(endpoint),

--- a/apps/docs/lib/openapi/types.ts
+++ b/apps/docs/lib/openapi/types.ts
@@ -120,6 +120,7 @@ export interface SecurityRequirement {
 
 export interface NavigationSection {
   title: string;
+  originalTitle?: string;
   items: NavigationItem[];
 }
 


### PR DESCRIPTION
…методу

- Добавлен маппинг TAG_TRANSLATIONS для перевода тегов OpenAPI
- Показывается оригинальное английское название рядом с переводом
- Эндпоинты внутри секций сортируются по типу метода (POST → GET → PUT → PATCH → DELETE)