### PR TITLE
fix: use GitHub-hosted runner for PR checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check:
     name: Lint, typecheck, format
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Replace `self-hosted` with `ubuntu-latest` in the `check.yml` workflow
- Prevents arbitrary code execution from fork PRs when the repository is made public

## Context
When a repo is public, anyone can fork it and open a PR. If the check workflow uses a self-hosted runner, the PR author's code runs on our infrastructure. Switching to GitHub-hosted runners eliminates this attack vector.

## Test plan
- [ ] Verify PR checks still pass on `ubuntu-latest`
- [ ] After merging, re-enable branch protection rules on `main` before making the repo public

🤖 Generated with [Claude Code](https://claude.com/claude-code)