### PR TITLE
fix: disable browser caching for static routes to prevent stale content

### DIFF
--- a/apps/docs/app/.well-known/security.txt/route.ts
+++ b/apps/docs/app/.well-known/security.txt/route.ts
@@ -9,7 +9,7 @@ Canonical: https://dev.pachca.com/.well-known/security.txt
   return new Response(securityTxt, {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
-      'Cache-Control': 'public, max-age=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }

--- a/apps/docs/app/feed.xml/route.ts
+++ b/apps/docs/app/feed.xml/route.ts
@@ -51,7 +51,7 @@ ${items.join('\n')}
   return new Response(xml, {
     headers: {
       'Content-Type': 'application/rss+xml; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }

--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -87,7 +87,7 @@ export async function GET() {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
       'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -63,7 +63,7 @@ export async function GET() {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
       'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }

--- a/apps/docs/app/openapi.yaml/route.ts
+++ b/apps/docs/app/openapi.yaml/route.ts
@@ -10,7 +10,7 @@ export async function GET(): Promise<Response> {
       'Content-Type': 'text/yaml; charset=utf-8',
       'Content-Disposition': 'inline; filename="openapi.yaml"',
       'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }

--- a/apps/docs/app/robots.txt/route.ts
+++ b/apps/docs/app/robots.txt/route.ts
@@ -15,7 +15,7 @@ Sitemap: ${BASE_URL}/sitemap.xml
   return new Response(productionRobots, {
     headers: {
       'Content-Type': 'text/plain',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }

--- a/apps/docs/app/sitemap.xml/route.ts
+++ b/apps/docs/app/sitemap.xml/route.ts
@@ -35,7 +35,7 @@ ${urls.map((u) => `  <url>\n    <loc>${u.loc}</loc>\n    <lastmod>${lastmod}</la
   return new Response(xml, {
     headers: {
       'Content-Type': 'application/xml',
-      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
     },
   });
 }


### PR DESCRIPTION
Replace max-age=3600 with max-age=0, must-revalidate across all static routes so browsers always fetch fresh content after deploys. CDN caching via s-maxage=86400 is preserved.