### PR TITLE
feat: refine UI — simplify callouts, update boxed panel headers, show…

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -123,6 +123,16 @@ html.dark {
   .bg-callout-warning-bg\! code {
     @apply bg-callout-warning-header-bg! text-callout-warning-text! border-callout-warning-text/20!;
   }
+
+  .bg-callout-info-bg li::before,
+  .bg-callout-info-bg\! li::before {
+    @apply bg-callout-info-text/50!;
+  }
+
+  .bg-callout-warning-bg li::before,
+  .bg-callout-warning-bg\! li::before {
+    @apply bg-callout-warning-text/50!;
+  }
 }
 
 * {

--- a/apps/docs/components/api/callout.tsx
+++ b/apps/docs/components/api/callout.tsx
@@ -1,36 +1,24 @@
 import React from 'react';
-import { BoxedPanel } from './boxed-panel';
 
 interface CalloutProps {
   children: React.ReactNode;
-  title?: string;
   type?: 'info' | 'warning';
 }
 
-export function Callout({ children, title, type = 'info' }: CalloutProps) {
-  const defaultTitle = type === 'warning' ? 'ВНИМАНИЕ' : 'ПРИМЕЧАНИЕ';
+export function Callout({ children, type = 'info' }: CalloutProps) {
   const isWarning = type === 'warning';
 
-  const bgClass = isWarning ? 'bg-callout-warning-bg!' : 'bg-callout-info-bg!';
-  const borderClass = isWarning ? 'border-callout-warning-border!' : 'border-callout-info-border!';
-  const headerBgClass = isWarning ? 'bg-callout-warning-header-bg!' : 'bg-callout-info-header-bg!';
-  const headerTextClass = isWarning ? 'text-callout-warning-text' : 'text-callout-info-text';
+  const bgClass = isWarning ? 'bg-callout-warning-bg' : 'bg-callout-info-bg';
+  const borderClass = isWarning ? 'border-callout-warning-border' : 'border-callout-info-border';
   const contentTextClass = isWarning
-    ? '[&_p]:text-callout-warning-text/90! text-callout-warning-text/90! [&_em]:text-callout-warning-text/70 [&]:text-inherit [&_p]:mb-0! [&_p]:last:mb-0 [&_code]:text-callout-warning-text [&_a]:text-callout-warning-text [&_a]:underline [&_p+ul]:mt-4! [&_p+ul]:mb-0! [&_p+ol]:mt-4! [&_.endpoint-badge]:text-callout-warning-text! [&_.endpoint-badge]:bg-callout-warning-text/10!'
-    : '[&_p]:text-callout-info-text/90! text-callout-info-text/90! [&_em]:text-callout-info-text/70 [&]:text-inherit [&_p]:mb-0! [&_p]:last:mb-0 [&_code]:text-callout-info-text [&_a]:text-callout-info-text [&_a]:underline [&_p+ul]:mt-4! [&_p+ul]:mb-0! [&_p+ol]:mt-4! [&_.endpoint-badge]:text-callout-info-text! [&_.endpoint-badge]:bg-callout-info-text/10!';
+    ? '[&_p]:text-callout-warning-text/90! text-callout-warning-text/90! [&_em]:text-callout-warning-text/70 [&]:text-inherit [&_p]:mb-0! [&_p]:last:mb-0 [&_code]:text-callout-warning-text [&_a]:text-callout-warning-text [&_a]:underline [&_p+ul]:mt-4! [&_p+ul]:mb-0! [&_p+ol]:mt-4! [&_.endpoint-badge]:text-callout-warning-text! [&_.endpoint-badge]:bg-callout-warning-text/10! [&_li]:text-callout-warning-text/90! [&_li]:text-[13px]!'
+    : '[&_p]:text-callout-info-text/90! text-callout-info-text/90! [&_em]:text-callout-info-text/70 [&]:text-inherit [&_p]:mb-0! [&_p]:last:mb-0 [&_code]:text-callout-info-text [&_a]:text-callout-info-text [&_a]:underline [&_p+ul]:mt-4! [&_p+ul]:mb-0! [&_p+ol]:mt-4! [&_.endpoint-badge]:text-callout-info-text! [&_.endpoint-badge]:bg-callout-info-text/10! [&_li]:text-callout-info-text/90! [&_li]:text-[13px]!';
 
   return (
-    <BoxedPanel
-      header={
-        <span className={`text-[10px] font-bold uppercase tracking-widest ${headerTextClass}`}>
-          {title || defaultTitle}
-        </span>
-      }
-      className={`my-8 ${bgClass} ${borderClass}`}
-      headerClassName={`${headerBgClass} ${borderClass}`}
-      contentClassName={`p-4 [&_p]:text-[13px]! text-[13px]! leading-relaxed [&_em]:not-italic ${contentTextClass}`}
+    <div
+      className={`my-8 rounded-lg border overflow-hidden not-prose py-3 px-4 [&_p]:text-[13px]! text-[13px]! leading-relaxed [&_em]:not-italic ${bgClass} ${borderClass} ${contentTextClass}`}
     >
       {children}
-    </BoxedPanel>
+    </div>
   );
 }

--- a/apps/docs/components/api/code-examples.tsx
+++ b/apps/docs/components/api/code-examples.tsx
@@ -16,7 +16,6 @@ import { generateDotNet } from '@/lib/code-generators/dotnet';
 import { generateResponseExample } from '@/lib/openapi/example-generator';
 import { CopyButton } from './copy-button';
 import { CodeBlock } from './code-block';
-import { MethodBadge } from './method-badge';
 import { BoxedPanel } from './boxed-panel';
 
 interface CodeExamplesProps {
@@ -75,12 +74,9 @@ export function CodeExamples({ endpoint, baseUrl }: CodeExamplesProps) {
         className="mt-0 mb-10"
         header={
           <>
-            <div className="flex items-center gap-3 overflow-hidden mr-4">
-              <MethodBadge method={endpoint.method} />
-              <code className="text-[13px] font-mono text-text-primary font-bold truncate">
-                {endpoint.path}
-              </code>
-            </div>
+            <span className="text-[13px] font-medium text-text-primary truncate mr-4">
+              {endpoint.title || endpoint.summary || endpoint.path}
+            </span>
 
             <div className="flex items-center gap-0 shrink-0">
               <DropdownMenu.Root>
@@ -132,8 +128,8 @@ export function CodeExamples({ endpoint, baseUrl }: CodeExamplesProps) {
           className="my-0"
           header={
             <>
-              <span className="py-2 text-[10px] font-bold uppercase tracking-widest text-text-primary">
-                пример ответа
+              <span className="text-[13px] font-medium text-text-primary truncate">
+                Ответ {successCode}
               </span>
               <CopyButton text={JSON.stringify(responseExample, null, 2)} />
             </>

--- a/apps/docs/components/api/endpoint-header.tsx
+++ b/apps/docs/components/api/endpoint-header.tsx
@@ -2,31 +2,11 @@
 
 import { MarkdownActions } from './markdown-actions';
 import { MethodBadge } from './method-badge';
-import { MoveDown } from 'lucide-react';
-
 interface EndpointHeaderProps {
   title: string;
   pageUrl: string;
   method?: string;
   path?: string;
-}
-
-function scrollToSection(id: string) {
-  const element = document.getElementById(id);
-  const scrollContainer = document.querySelector('main');
-  if (element && scrollContainer) {
-    const offset = 80; // отступ сверху
-    const elementPosition = element.getBoundingClientRect().top;
-    const containerScrollTop = scrollContainer.scrollTop;
-    const containerTop = scrollContainer.getBoundingClientRect().top;
-
-    scrollContainer.scrollTo({
-      top: containerScrollTop + elementPosition - containerTop - offset,
-      behavior: 'smooth',
-    });
-    // Update URL hash without triggering scroll
-    window.history.pushState(null, '', `#${id}`);
-  }
 }
 
 export function EndpointHeader({ title, pageUrl, method, path }: EndpointHeaderProps) {
@@ -38,24 +18,11 @@ export function EndpointHeader({ title, pageUrl, method, path }: EndpointHeaderP
       </div>
 
       {method && path && (
-        <div className="flex items-center gap-2 mt-4 xl:hidden">
-          <button
-            onClick={() => scrollToSection('request-examples')}
-            className="group flex items-center justify-between gap-2 px-3 min-h-[var(--boxed-header-height)] rounded-md text-[13px] font-medium text-text-primary hover:bg-background-tertiary  transition-all outline-none border border-background-border bg-background cursor-pointer w-full"
-          >
-            <div className="flex gap-2 items-center overflow-hidden">
-              <MethodBadge
-                method={method.toUpperCase() as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'}
-              />
-              <span className="font-mono text-[13px] text-text-primary font-bold truncate">
-                {path}
-              </span>
-            </div>
-            <MoveDown
-              className="w-3.5 h-3.5 shrink-0 text-text-secondary group-hover:text-text-primary"
-              strokeWidth={2.5}
-            />
-          </button>
+        <div className="flex items-center gap-2 mt-4">
+          <MethodBadge
+            method={method.toUpperCase() as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'}
+          />
+          <span className="font-mono text-[13px] text-text-primary font-bold truncate">{path}</span>
         </div>
       )}
     </div>

--- a/apps/docs/components/api/guide-code-block.tsx
+++ b/apps/docs/components/api/guide-code-block.tsx
@@ -16,9 +16,7 @@ export function GuideCodeBlock({ code, language, title }: GuideCodeBlockProps) {
       header={
         <>
           {title ? (
-            <span className="py-2 text-[10px] font-bold uppercase tracking-widest text-text-primary">
-              {title}
-            </span>
+            <span className="text-[13px] font-medium text-text-primary truncate">{title}</span>
           ) : (
             <div />
           )}

--- a/apps/docs/components/api/limit-card.tsx
+++ b/apps/docs/components/api/limit-card.tsx
@@ -13,9 +13,7 @@ export function LimitCard({ title, howItWorks, limit, period, entity }: LimitCar
     <div className="my-6 border border-background-border rounded-xl overflow-hidden bg-background">
       {title && (
         <div className="flex items-center justify-between px-3 bg-background-secondary border-b border-background-border h-[var(--boxed-header-height)]">
-          <div className="py-2 text-[10px] font-bold uppercase tracking-widest text-text-primary">
-            {title}
-          </div>
+          <div className="text-[13px] font-medium text-text-primary truncate">{title}</div>
         </div>
       )}
       {howItWorks && (

--- a/apps/docs/components/api/request-body-section.tsx
+++ b/apps/docs/components/api/request-body-section.tsx
@@ -68,8 +68,8 @@ export function RequestBodySection({ endpoint }: RequestBodySectionProps) {
             className="my-4"
             header={
               <>
-                <span className="py-2 text-[10px] font-bold uppercase tracking-widest text-text-primary">
-                  пример тела запроса
+                <span className="text-[13px] font-medium text-text-primary truncate">
+                  Пример тела запроса
                 </span>
                 <CopyButton text={JSON.stringify(requestExample, null, 2)} />
               </>

--- a/apps/docs/components/api/response-codes-list.tsx
+++ b/apps/docs/components/api/response-codes-list.tsx
@@ -15,9 +15,7 @@ export function ResponseCodesList({ title, items }: ResponseCodesListProps) {
   return (
     <div className="not-prose my-8 border border-background-border rounded-lg overflow-hidden">
       <div className="flex items-center justify-between px-3 bg-background-secondary border-b border-background-border h-[var(--boxed-header-height)]">
-        <span className="py-2 text-[10px] font-bold uppercase tracking-widest text-text-primary">
-          {title}
-        </span>
+        <span className="text-[13px] font-medium text-text-primary truncate">{title}</span>
       </div>
       <div className="divide-y divide-background-border/40">
         {items.map((item, index) => (


### PR DESCRIPTION
… endpoint info

- Remove callout title bar (ПРИМЕЧАНИЕ/ВНИМАНИЕ), keep colored border only
- Style callout list items and bullet dots to match callout theme color
- Show endpoint method+path as plain text in header (always visible)
- Replace code example header with endpoint title, response header with "Ответ {code}"
- Unify all BoxedPanel headers to 13px font-medium style (remove uppercase/tracking-widest)