### PR TITLE
feat: make markdown versions discoverable by AI agents

### DIFF
--- a/apps/docs/app/[...slug]/page.tsx
+++ b/apps/docs/app/[...slug]/page.tsx
@@ -47,6 +47,9 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     description,
     alternates: {
       canonical: path,
+      types: {
+        'text/markdown': `${path}.md`,
+      },
     },
     openGraph: {
       type: 'article',

--- a/apps/docs/app/guides/[slug]/page.tsx
+++ b/apps/docs/app/guides/[slug]/page.tsx
@@ -34,6 +34,9 @@ export async function generateMetadata({
     description,
     alternates: {
       canonical: `/guides/${slug}`,
+      types: {
+        'text/markdown': `/guides/${slug}.md`,
+      },
     },
     openGraph: {
       type: 'article',

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
   description: 'Создавайте уникальные решения на одной платформе',
   alternates: {
     canonical: '/',
+    types: {
+      'text/markdown': '/.md',
+    },
   },
   openGraph: {
     images: ['/api/og'],

--- a/apps/docs/app/robots.txt/route.ts
+++ b/apps/docs/app/robots.txt/route.ts
@@ -6,8 +6,6 @@ export async function GET(): Promise<Response> {
 Allow: /
 Disallow: /api/
 Disallow: /openapi.yaml
-Disallow: /llms.txt
-Disallow: /llms-full.txt
 
 Sitemap: ${BASE_URL}/sitemap.xml
 `;

--- a/apps/docs/components/api/endpoint-header.tsx
+++ b/apps/docs/components/api/endpoint-header.tsx
@@ -2,6 +2,8 @@
 
 import { MarkdownActions } from './markdown-actions';
 import { MethodBadge } from './method-badge';
+import { CopyButton } from './copy-button';
+
 interface EndpointHeaderProps {
   title: string;
   pageUrl: string;
@@ -10,6 +12,8 @@ interface EndpointHeaderProps {
 }
 
 export function EndpointHeader({ title, pageUrl, method, path }: EndpointHeaderProps) {
+  const fullUrl = typeof window !== 'undefined' ? `${window.location.origin}${pageUrl}` : pageUrl;
+
   return (
     <div className="mb-8">
       <h1 className="text-text-primary mb-2!">{title}</h1>
@@ -18,11 +22,16 @@ export function EndpointHeader({ title, pageUrl, method, path }: EndpointHeaderP
       </div>
 
       {method && path && (
-        <div className="flex items-center gap-2 mt-4">
-          <MethodBadge
-            method={method.toUpperCase() as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'}
-          />
-          <span className="font-mono text-[13px] text-text-primary font-bold truncate">{path}</span>
+        <div className="flex items-center justify-between gap-2 px-3 min-h-[var(--boxed-header-height)] rounded-md text-[13px] font-medium text-text-primary border border-background-border bg-background mt-4">
+          <div className="flex gap-2 items-center overflow-hidden">
+            <MethodBadge
+              method={method.toUpperCase() as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'}
+            />
+            <span className="font-mono text-[13px] text-text-primary font-bold truncate">
+              {path}
+            </span>
+          </div>
+          <CopyButton text={`[${title} - ${method.toUpperCase()} ${path}](${fullUrl})`} />
         </div>
       )}
     </div>

--- a/apps/docs/components/api/markdown-actions.tsx
+++ b/apps/docs/components/api/markdown-actions.tsx
@@ -60,14 +60,6 @@ export function MarkdownActions({ pageUrl, pageTitle, method, path }: MarkdownAc
     }
   };
 
-  const handleCopyMethodPath = async () => {
-    if (pageTitle && method && path) {
-      const text = `${pageTitle} (${method.toUpperCase()} ${path})`;
-      await copyToClipboard(text);
-    }
-    setDropdownOpen(false);
-  };
-
   const handleCopyPageUrl = async () => {
     const fullUrl = typeof window !== 'undefined' ? window.location.href : pageUrl;
     await copyToClipboard(fullUrl);
@@ -138,15 +130,6 @@ export function MarkdownActions({ pageUrl, pageTitle, method, path }: MarkdownAc
                   >
                     Версию страницы для LLM
                   </DropdownMenu.Item>
-
-                  {pageTitle && method && path && (
-                    <DropdownMenu.Item
-                      onClick={handleCopyMethodPath}
-                      className="flex items-center px-2.5 py-1.5 text-[13px] font-medium rounded-md cursor-pointer outline-none transition-colors text-text-secondary hover:bg-background-tertiary hover:text-text-primary"
-                    >
-                      Название метода и путь
-                    </DropdownMenu.Item>
-                  )}
 
                   <DropdownMenu.Item
                     onClick={handleCopyPageUrl}

--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const response = NextResponse.next();
+
+  // Add Link header pointing to markdown version of the page
+  const mdUrl = pathname === '/' ? '/.md' : `${pathname}.md`;
+  response.headers.set('Link', `<${mdUrl}>; rel="alternate"; type="text/markdown"`);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Match all pages except static files, API routes, and .md rewrites
+    '/((?!api/|_next/|favicon|apple-touch-icon|llms|feed\\.xml|sitemap\\.xml|robots\\.txt|openapi\\.yaml|.*\\.(?:ico|svg|png|jpg|webp|md)).*)',
+  ],
+};


### PR DESCRIPTION
- Unblock /llms.txt and /llms-full.txt in robots.txt
- Add <link rel="alternate" type="text/markdown"> to all page heads
- Add HTTP Link header via middleware for markdown page versions
- Restyle endpoint header method/path as boxed panel with copy button
- Remove redundant "copy method name and path" dropdown item