### PR TITLE
fix: исправлен пайплайн публикации SDK

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -75,13 +75,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: v${{ needs.generate.outputs.version }}
+      - uses: oven-sh/setup-bun@v2
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
-      - run: npm install
-        working-directory: sdk/typescript
-      - run: npm run build
+      - run: bun install --frozen-lockfile
+      - run: bun run build
         working-directory: sdk/typescript
       - run: npm publish --provenance --access public
         working-directory: sdk/typescript

--- a/sdk/python/generated/pyproject.toml
+++ b/sdk/python/generated/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "pachca"
+name = "pachca-sdk"
 version = "1.0.0"
 description = "A client library for accessing Pachca API"
 authors = []

--- a/sdk/python/openapi-python-client.yaml
+++ b/sdk/python/openapi-python-client.yaml
@@ -1,3 +1,3 @@
-project_name_override: pachca
+project_name_override: pachca-sdk
 package_name_override: pachca
 use_modern_python_tooling: true


### PR DESCRIPTION
## Summary
- **publish-npm**: добавлен bun для разрешения `workspace:*` зависимостей (npm не поддерживает этот протокол)
- **publish-pypi**: переименован пакет в `pachca-sdk` (имя `pachca` занято на PyPI)

## Test plan
- [ ] Убедиться что `publish-npm` проходит install/build
- [ ] Первая публикация `pachca-sdk` на PyPI вручную, затем CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)