### PR TITLE
fix: preserve default values in allOf schemas + rename audit route

### DIFF
--- a/apps/docs/components/api/schema-tree.tsx
+++ b/apps/docs/components/api/schema-tree.tsx
@@ -843,6 +843,7 @@ export function PropertyRow({ name, schema, required, level, parentPath }: Prope
       description: schema.description || singleSchema.description,
       nullable: schema.nullable !== undefined ? schema.nullable : singleSchema.nullable,
       example: schema.example !== undefined ? schema.example : singleSchema.example,
+      default: schema.default !== undefined ? schema.default : singleSchema.default,
     };
     return (
       <PropertyRow

--- a/packages/spec/openapi.yaml
+++ b/packages/spec/openapi.yaml
@@ -19,7 +19,7 @@ tags:
   - name: Bots
   - name: Security
 paths:
-  /audit-events:
+  /audit_events:
     get:
       operationId: SecurityOperations_getAuditEvents
       description: |-

--- a/packages/spec/typespec.tsp
+++ b/packages/spec/typespec.tsp
@@ -5456,7 +5456,7 @@ interface BotOperations {
 // Security Operations
 // ============================================================================
 
-@route("/audit-events")
+@route("/audit_events")
 @tag("Security")
 interface SecurityOperations {
   @doc("""


### PR DESCRIPTION
## Summary
- **schema-tree.tsx**: при мерже single-element `allOf` терялось значение `default` — добавлено в merge
- **typespec.tsp**: `/audit-events` → `/audit_events`

## Test plan
- [ ] Проверить отображение "По умолчанию: desc" на странице /chats/list
- [ ] Проверить отображение дефолтных значений на /chats/members/list и /messages/list