### PR TITLE
feat: add /skill.md route + fix endpoint paths in SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -51,6 +51,7 @@ Tokens are long-lived and do not expire. They can be reset by the admin/owner in
 - `DELETE /messages/{id}/reactions` — remove emoji reaction
 - `GET /messages/{id}/reactions` — list reactions on a message
 - `GET /messages/{id}/read_member_ids` — list users who read a message
+- `POST /messages/{id}/link_previews` — add link preview to a message
 
 ### Threads
 - `POST /messages/{id}/thread` — create a thread on a message
@@ -108,7 +109,7 @@ Tokens are long-lived and do not expire. They can be reset by the admin/owner in
 
 ### File Uploads
 - `POST /uploads` — get S3 upload signature and parameters
-- `POST /uploads/direct_url` — upload a file directly (multipart/form-data, no auth required)
+- `POST /direct_url` — upload a file directly (multipart/form-data, no auth required)
 
 ### Interactive Forms
 - `POST /views/open` — open a modal form for a user (requires trigger_id from button click)
@@ -119,7 +120,7 @@ Tokens are long-lived and do not expire. They can be reset by the admin/owner in
 ### Export & Audit (Corporation plan, owner token)
 - `POST /chats/exports` — request message export as JSON/ZIP
 - `GET /chats/exports/{id}` — download export archive (returns 302 redirect)
-- `GET /audit-events` — query security audit log (90-day retention)
+- `GET /audit_events` — query security audit log (90-day retention)
 
 ## Common Workflows
 
@@ -192,7 +193,7 @@ Form submission results arrive via the `view.submission` webhook event.
 - User management, tag management, and message deletion require an **admin** token.
 - Audit events and data export require an **owner** token and **Corporation** pricing plan.
 - Link preview (unfurling) requires a dedicated unfurling bot token with whitelisted domains.
-- `POST /uploads/direct_url` is the only endpoint that does not require authentication.
+- `POST /direct_url` is the only endpoint that does not require authentication.
 
 ### Error Handling
 - `400` — validation error

--- a/apps/docs/app/skill.md/route.ts
+++ b/apps/docs/app/skill.md/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const dynamic = 'force-static';
+
+export async function GET() {
+  const content = await readFile(join(process.cwd(), '../../SKILL.md'), 'utf-8');
+
+  return new NextResponse(content, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
+    },
+  });
+}


### PR DESCRIPTION
- Serve SKILL.md at /skill.md for AI agent discovery
- Fix POST /uploads/direct_url → POST /direct_url
- Fix GET /audit-events → GET /audit_events
- Add missing POST /messages/{id}/link_previews

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a static docs route and makes small documentation corrections; minimal impact beyond ensuring the file path resolves correctly at build/runtime.
> 
> **Overview**
> Exposes the repository `SKILL.md` as a public, cacheable `GET /skill.md` endpoint in the docs app (served as `text/markdown` with permissive CORS).
> 
> Updates `SKILL.md` to correct/align endpoint paths (`POST /direct_url`, `GET /audit_events`) and documents the missing `POST /messages/{id}/link_previews` capability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c874e491e77bc4dfd22e9d08b18dfba7eb6156f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->