### PR TITLE
feat: add context7.json for AI documentation discovery

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Pachca API",
+  "description": "REST API for Pachca corporate messenger — send messages, manage chats, users, tags, tasks, handle webhooks, upload files, and build bots.",
+  "folders": ["apps/docs/content", "packages/spec", "sdk"],
+  "excludeFolders": ["node_modules"],
+  "excludeFiles": ["typespec.tsp", "tspconfig.yaml"],
+  "rules": [
+    "Base URL: https://api.pachca.com/api/shared/v1",
+    "All requests require Bearer token in Authorization header",
+    "API documentation (MDX guides) is written in Russian",
+    "Full documentation: https://dev.pachca.com/llms-full.txt",
+    "OpenAPI spec: https://dev.pachca.com/openapi.yaml"
+  ]
+}


### PR DESCRIPTION
## Summary
- Context7 config for AI-assistant documentation discovery
- Indexes: MDX guides, OpenAPI spec, SDKs
- Rules: base URL, auth, links to full docs

## Next steps (after merge)
1. Submit repo URL at https://context7.com
2. Claim library at admin panel → add `public_key` to config
3. Optionally apply for verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a standalone metadata/config file only; no runtime or API behavior changes.
> 
> **Overview**
> Adds `context7.json` to configure Context7-based AI documentation discovery/indexing.
> 
> The config points indexing at `apps/docs/content`, `packages/spec`, and `sdk`, excludes `node_modules` and a couple TypeSpec-related files, and defines rules for base URL/auth plus links to the full docs and OpenAPI spec.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8deb8f8ef693f58b16b29dd090bfa3d8bf7861a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->