### PR TITLE
chore: add context7 public key

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -5,11 +5,14 @@
   "folders": ["apps/docs/content", "apps/docs/public", "packages/spec", "sdk"],
   "excludeFolders": ["node_modules"],
   "excludeFiles": ["typespec.tsp", "tspconfig.yaml"],
+  "url": "https://context7.com/pachca/openapi",
+  "public_key": "pk_XD0EuPOww8Nx2l9uC2i5c",
   "rules": [
     "Base URL: https://api.pachca.com/api/shared/v1",
     "All requests require Bearer token in Authorization header",
-    "API documentation (MDX guides) is written in Russian",
-    "Full documentation: https://dev.pachca.com/llms-full.txt",
-    "OpenAPI spec: https://dev.pachca.com/openapi.yaml"
+    "Pagination is cursor-based: use 'limit' (1-50) and 'cursor' params, check meta.paginate.next_page",
+    "Error response format: { errors: [{ key: 'field', value: 'description' }] }",
+    "On 429 rate limit, respect the Retry-After header",
+    "Full docs: https://dev.pachca.com/llms-full.txt | OpenAPI: https://dev.pachca.com/openapi.yaml"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `url` and `public_key` to `context7.json` for library claim/verification