### PR TITLE
docs: update README and README-SHORT

### DIFF
--- a/README-SHORT.md
+++ b/README-SHORT.md
@@ -1,82 +1,76 @@
 # Пачка API Documentation
 
-Turborepo монорепозиторий с документацией API.
+Turborepo монорепозиторий: документация API, SDK для 5 языков, AI-интеграции.
+
+**Сайт**: https://dev.pachca.com
 
 ## Структура
 
 ```
-├── apps/docs/         # Next.js сайт (@pachca/docs)
-├── packages/spec/     # TypeSpec спецификация (@pachca/spec)
-└── turbo.json         # Turborepo конфиг
+├── apps/docs/         # Next.js 16 сайт (@pachca/docs)
+├── packages/spec/     # TypeSpec → openapi.yaml (@pachca/spec)
+├── sdk/               # SDK (TypeScript, Python, Go, Kotlin, Swift)
+│   ├── typescript/    # npm: @pachca/sdk
+│   ├── python/        # PyPI: pachca
+│   ├── go/            # Go modules: github.com/pachca/go-sdk
+│   ├── kotlin/        # JitPack: com.pachca:sdk
+│   └── swift/         # SPM: PachcaSDK
+├── .github/workflows/ # CI: check, sdk, deploy, gitlab mirror
+├── Package.swift      # Корневой Swift Package (для SPM)
+├── jitpack.yml        # JitPack конфиг (Kotlin)
+├── Dockerfile         # Docker-сборка и деплой docs
+└── turbo.json         # Turborepo пайплайн
 ```
 
-## Установка
+## Установка и команды
 
 ```bash
 bun install
-```
 
-## Команды
-
-```bash
 bun turbo dev          # Разработка (localhost:3000)
 bun turbo build        # Production сборка
-bun turbo start        # Запуск production
-```
-
-### Проверки
-
-```bash
 bun turbo check        # Все проверки (lint + typecheck + knip + format)
-bun turbo lint         # ESLint
-bun turbo typecheck    # TypeScript
-bun turbo knip         # Неиспользуемый код
-bun turbo format:check # Prettier
-bun turbo check-urls   # Конфликты URL
+bun turbo generate     # TypeSpec → openapi.yaml + SDK
 ```
 
-### Генерация
+## Пайплайн
 
-```bash
-bun turbo generate     # TypeSpec → openapi.yaml
+```
+typespec.tsp
+    │
+    │ tsp compile
+    ▼
+openapi.yaml ──────────────────┐
+    │                          │
+    ▼                          ▼
+apps/docs                   sdk/* (5 языков)
+    │                          │
+    │ next build               │ CI: generate + publish
+    ▼                          ▼
+  Сайт документации          npm, PyPI, JitPack,
+  + llms.txt                 SPM, Go modules
+  + llms-full.txt
+  + skill.md
+  + /openapi.yaml
+  + RSS feed
+  + sitemap.xml
+  + OG-изображения
+  + per-endpoint .md
 ```
 
-## Фильтрация
+## CI/CD
 
-```bash
-bun turbo dev --filter=@pachca/docs    # Только docs
-bun turbo generate --filter=@pachca/spec
-```
+| Workflow | Триггер | Что делает |
+|----------|---------|------------|
+| `check.yml` | PR в `main` | lint + typecheck + knip + format |
+| `sdk.yml` | Push в `main` | Генерация SDK → коммит → теги → публикация |
+| `deploy.yml` | Push в `main` | Docker build → GitLab registry → SSH deploy |
+| `gitlab.yml` | Push в `main` | Зеркало в GitLab |
 
-## Как работает
+## AI-интеграции
 
-1. `@pachca/spec` генерирует `openapi.yaml` из TypeSpec
-2. `@pachca/docs` читает OpenAPI и строит сайт
-3. Turborepo кеширует результаты и управляет зависимостями
-
-## Добавить гайд
-
-Создать `apps/docs/content/guides/{slug}.mdx`:
-
-```mdx
----
-title: Название
----
-
-# Название
-
-Контент...
-```
-
-Автоматически появится в навигации, поиске и llms.txt.
-
-## Добавить обновление
-
-В `apps/docs/content/guides/updates.mdx`:
-
-```md
-<!-- update:2025-12-01 -->
-## Название
-
-Описание.
-```
+- `/llms.txt` — краткий индекс API для LLM
+- `/llms-full.txt` — полная документация одним файлом
+- `/skill.md` — skill-дескриптор для AI-агентов
+- `/{section}/{action}.md` — отдельные .md-файлы для каждого endpoint'а и гайда
+- [Context7](https://context7.com/pachca/openapi) — AI-native document discovery


### PR DESCRIPTION
## Summary
- Обновлены README.md и README-SHORT.md под текущее состояние проекта
- SDK для 5 языков (TypeScript, Python, Go, Kotlin, Swift) с описанием пайплайна публикации
- AI-интеграции (llms.txt, llms-full.txt, skill.md, Context7, per-endpoint .md)
- CI/CD (check, sdk, deploy, gitlab mirror)
- Архитектура docs-сайта: маршрутизация, URL маппинг, SEO, безопасность, библиотеки
- Все MDX-компоненты с примерами использования