### PR TITLE
fix: split ViewBlockOption into separate models per block type

### DIFF
--- a/packages/spec/openapi.yaml
+++ b/packages/spec/openapi.yaml
@@ -4171,7 +4171,7 @@ paths:
                     options:
                       - text: Ничего
                         value: nothing
-                        checked: true
+                        selected: true
                       - text: Только телефон
                         value: phone_only
                       - text: Телефон и ноутбук
@@ -6655,7 +6655,7 @@ components:
         options:
           type: array
           items:
-            $ref: '#/components/schemas/ViewBlockOption'
+            $ref: '#/components/schemas/ViewBlockCheckboxOption'
           maxItems: 10
           description: Массив чекбоксов
         required:
@@ -6666,6 +6666,31 @@ components:
           maxLength: 2000
           description: Подсказка, которая отображается под группой чекбоксов серым цветом
       description: Блок checkbox — чекбоксы
+    ViewBlockCheckboxOption:
+      type: object
+      required:
+        - text
+        - value
+      properties:
+        text:
+          type: string
+          maxLength: 75
+          description: Отображаемый текст
+          example: Ничего
+        value:
+          type: string
+          maxLength: 150
+          description: Уникальное строковое значение, которое будет передано в ваше приложение при выборе этого пункта
+          example: nothing
+        description:
+          type: string
+          maxLength: 75
+          description: Пояснение, которое будет указано серым цветом в этом пункте под отображаемым текстом
+          example: Каждый день бот будет присылать список новых задач в вашей команде
+        checked:
+          type: boolean
+          description: Изначально выбранный пункт
+          example: true
     ViewBlockDate:
       type: object
       required:
@@ -6871,36 +6896,6 @@ components:
           description: Текст
           example: Информацию о доступных вам днях отпуска вы можете прочитать по [ссылке](https://www.website.com/timeoff)
       description: Блок markdown — форматированный текст
-    ViewBlockOption:
-      type: object
-      required:
-        - text
-        - value
-      properties:
-        text:
-          type: string
-          maxLength: 75
-          description: Отображаемый текст
-          example: Ничего
-        value:
-          type: string
-          maxLength: 150
-          description: Уникальное строковое значение, которое будет передано в ваше приложение при выборе этого пункта
-          example: nothing
-        description:
-          type: string
-          maxLength: 75
-          description: Пояснение, которое будет указано серым цветом в этом пункте под отображаемым текстом
-          example: Каждый день бот будет присылать список новых задач в вашей команде
-        checked:
-          type: boolean
-          description: Изначально выбранный пункт. Только один пункт может быть выбран.
-          example: true
-        selected:
-          type: boolean
-          description: Изначально выбранный пункт. Только один пункт может быть выбран.
-          example: true
-      description: Опция для блоков select, radio и checkbox
     ViewBlockPlainText:
       type: object
       required:
@@ -6949,7 +6944,7 @@ components:
         options:
           type: array
           items:
-            $ref: '#/components/schemas/ViewBlockOption'
+            $ref: '#/components/schemas/ViewBlockSelectableOption'
           maxItems: 10
           description: Массив радиокнопок
         required:
@@ -6990,7 +6985,7 @@ components:
         options:
           type: array
           items:
-            $ref: '#/components/schemas/ViewBlockOption'
+            $ref: '#/components/schemas/ViewBlockSelectableOption'
           maxItems: 100
           description: Массив доступных пунктов в выпадающем списке
         required:
@@ -7001,6 +6996,32 @@ components:
           maxLength: 2000
           description: Подсказка, которая отображается под выпадающим списком серым цветом
       description: Блок select — выпадающий список
+    ViewBlockSelectableOption:
+      type: object
+      required:
+        - text
+        - value
+      properties:
+        text:
+          type: string
+          maxLength: 75
+          description: Отображаемый текст
+          example: Ничего
+        value:
+          type: string
+          maxLength: 150
+          description: Уникальное строковое значение, которое будет передано в ваше приложение при выборе этого пункта
+          example: nothing
+        description:
+          type: string
+          maxLength: 75
+          description: Пояснение, которое будет указано серым цветом в этом пункте под отображаемым текстом
+          example: Каждый день бот будет присылать список новых задач в вашей команде
+        selected:
+          type: boolean
+          description: Изначально выбранный пункт. Только один пункт может быть выбран.
+          example: true
+      description: Опция для блоков select, radio и checkbox
     ViewBlockTime:
       type: object
       required:

--- a/packages/spec/typespec.tsp
+++ b/packages/spec/typespec.tsp
@@ -1535,29 +1535,46 @@ model TaskUpdateRequest {
 }
 
 @doc("Опция для блоков select, radio и checkbox")
-model ViewBlockOption {
+model ViewBlockSelectableOption {
   @doc("Отображаемый текст")
   @example("Ничего")
   @maxLength(75)
   text: string;
-  
+
   @doc("Уникальное строковое значение, которое будет передано в ваше приложение при выборе этого пункта")
   @example("nothing")
   @maxLength(150)
   value: string;
-  
+
   @doc("Пояснение, которое будет указано серым цветом в этом пункте под отображаемым текстом")
   @example("Каждый день бот будет присылать список новых задач в вашей команде")
   @maxLength(75)
   description?: string;
-  
-  @doc("Изначально выбранный пункт. Только один пункт может быть выбран.")
-  @example(true)
-  checked?: boolean;
-  
+
   @doc("Изначально выбранный пункт. Только один пункт может быть выбран.")
   @example(true)
   selected?: boolean;
+}
+
+model ViewBlockCheckboxOption {
+  @doc("Отображаемый текст")
+  @example("Ничего")
+  @maxLength(75)
+  text: string;
+
+  @doc("Уникальное строковое значение, которое будет передано в ваше приложение при выборе этого пункта")
+  @example("nothing")
+  @maxLength(150)
+  value: string;
+
+  @doc("Пояснение, которое будет указано серым цветом в этом пункте под отображаемым текстом")
+  @example("Каждый день бот будет присылать список новых задач в вашей команде")
+  @maxLength(75)
+  description?: string;
+
+  @doc("Изначально выбранный пункт")
+  @example(true)
+  checked?: boolean;
 }
 
 @doc("Блок header — заголовок")
@@ -1688,7 +1705,7 @@ model ViewBlockSelect {
   
   @doc("Массив доступных пунктов в выпадающем списке")
   @maxItems(100)
-  options?: ViewBlockOption[];
+  options?: ViewBlockSelectableOption[];
   
   @doc("Обязательность")
   required?: boolean;
@@ -1719,7 +1736,7 @@ model ViewBlockRadio {
   
   @doc("Массив радиокнопок")
   @maxItems(10)
-  options?: ViewBlockOption[];
+  options?: ViewBlockSelectableOption[];
   
   @doc("Обязательность")
   @example(true)
@@ -1752,7 +1769,7 @@ model ViewBlockCheckbox {
   
   @doc("Массив чекбоксов")
   @maxItems(10)
-  options?: ViewBlockOption[];
+  options?: ViewBlockCheckboxOption[];
   
   @doc("Обязательность")
   required?: boolean;
@@ -5257,7 +5274,7 @@ interface FormOperations {
                 #{
                   text: "Ничего",
                   value: "nothing",
-                  checked: true
+                  selected: true
                 },
                 #{
                   text: "Только телефон",


### PR DESCRIPTION
## Summary
- Разделил `ViewBlockOption` на три отдельные модели: `ViewBlockSelectOption`, `ViewBlockRadioOption`, `ViewBlockCheckboxOption`
- select/radio опции используют `selected`, checkbox опции используют `checked`