### PR TITLE
fix: correct file upload response status 204 → 201

### DIFF
--- a/packages/spec/openapi.yaml
+++ b/packages/spec/openapi.yaml
@@ -1376,12 +1376,12 @@ paths:
         **Процесс загрузки состоит из трёх шагов:**
 
         1. [Получение подписи, ключа и других параметров](POST /uploads) — сделать `POST`-запрос без тела запроса для получения параметров загрузки.
-        2. **Загрузка файла** — после получения всех параметров, нужно сделать `POST` запрос c форматом `multipart/form-data` на адрес `direct_url`, включая те же поля, что пришли (content-disposition, acl, policy, x-amz-credential, x-amz-algorithm, x-amz-date, x-amz-signature, key) и сам файл. При успешной загрузке — `HTTP` статус `204`, тело ответа отсутствует.
+        2. **Загрузка файла** — после получения всех параметров, нужно сделать `POST` запрос c форматом `multipart/form-data` на адрес `direct_url`, включая те же поля, что пришли (content-disposition, acl, policy, x-amz-credential, x-amz-algorithm, x-amz-date, x-amz-signature, key) и сам файл. При успешной загрузке — `HTTP` статус `201`.
         3. **Прикрепление файла к сообщению или другой сущности** — после загрузки файла, чтобы прикрепить его к сообщению или другой сущности API, необходимо сформировать путь файла. Для этого в поле `key`, полученном на этапе подписи, заменить шаблон `$filename` на фактическое имя файла. Пример: Если ваш файл называется `Логотип для сайта.png`, а в ответе на метод `/uploads` ключ был `attaches/files/93746/e354-...-5e6f/$filename`, итоговый ключ будет `attaches/files/93746/e354-...-5e6f/Логотип для сайта.png`.
       parameters: []
       responses:
-        '204':
-          description: 'There is no content to send for this request, but the headers may be useful. '
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
       tags:
         - Common
       requestBody:
@@ -3572,6 +3572,7 @@ paths:
                 x-amz-date: 20211122T065734Z
                 x-amz-signature: 87e8f3ba4083c937c0e891d7a11tre932d8c33cg4bacf5380bf27624c1ok1475
                 key: attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/$filename
+                success_action_status: '201'
                 direct_url: https://api.pachca.com/api/v3/direct_upload
         '401':
           description: Access is unauthorized.
@@ -6173,6 +6174,7 @@ components:
         - x-amz-date
         - x-amz-signature
         - key
+        - success_action_status
         - direct_url
       properties:
         Content-Disposition:
@@ -6207,6 +6209,10 @@ components:
           type: string
           description: Уникальный ключ для загрузки файла
           example: attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/$filename
+        success_action_status:
+          type: string
+          description: HTTP-статус, который вернёт S3 при успешной загрузке
+          example: '201'
         direct_url:
           type: string
           description: Адрес для загрузки файла

--- a/packages/spec/typespec.tsp
+++ b/packages/spec/typespec.tsp
@@ -1073,7 +1073,12 @@ model UploadParams {
   @doc("Уникальный ключ для загрузки файла")
   @example("attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/$filename")
   key: string;
-  
+
+  @doc("HTTP-статус, который вернёт S3 при успешной загрузке")
+  @example("201")
+  @encodedName("application/json", "success_action_status")
+  successActionStatus: string;
+
   @doc("Адрес для загрузки файла")
   @example("https://api.pachca.com/api/v3/direct_upload")
   @encodedName("application/json", "direct_url")
@@ -2351,6 +2356,7 @@ interface UploadOperations {
         xAmzDate: "20211122T065734Z",
         xAmzSignature: "87e8f3ba4083c937c0e891d7a11tre932d8c33cg4bacf5380bf27624c1ok1475",
         key: "attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/$filename",
+        successActionStatus: "201",
         directUrl: "https://api.pachca.com/api/v3/direct_upload"
       }
     }
@@ -2414,14 +2420,14 @@ interface DirectUploadOperations {
 **Процесс загрузки состоит из трёх шагов:**
 
 1. [Получение подписи, ключа и других параметров](POST /uploads) — сделать `POST`-запрос без тела запроса для получения параметров загрузки.
-2. **Загрузка файла** — после получения всех параметров, нужно сделать `POST` запрос c форматом `multipart/form-data` на адрес `direct_url`, включая те же поля, что пришли (content-disposition, acl, policy, x-amz-credential, x-amz-algorithm, x-amz-date, x-amz-signature, key) и сам файл. При успешной загрузке — `HTTP` статус `204`, тело ответа отсутствует.
+2. **Загрузка файла** — после получения всех параметров, нужно сделать `POST` запрос c форматом `multipart/form-data` на адрес `direct_url`, включая те же поля, что пришли (content-disposition, acl, policy, x-amz-credential, x-amz-algorithm, x-amz-date, x-amz-signature, key) и сам файл. При успешной загрузке — `HTTP` статус `201`.
 3. **Прикрепление файла к сообщению или другой сущности** — после загрузки файла, чтобы прикрепить его к сообщению или другой сущности API, необходимо сформировать путь файла. Для этого в поле `key`, полученном на этапе подписи, заменить шаблон `$filename` на фактическое имя файла. Пример: Если ваш файл называется `Логотип для сайта.png`, а в ответе на метод `/uploads` ключ был `attaches/files/93746/e354-...-5e6f/$filename`, итоговый ключ будет `attaches/files/93746/e354-...-5e6f/Логотип для сайта.png`.
 """)
   @post
   @route("direct_url")
   uploadFile(
     @multipartBody request: FileUploadRequest
-  ): {@statusCode _: 204, ...EmptyResponse};
+  ): {@statusCode _: 201};
 }
 
 @route("/chats/exports")


### PR DESCRIPTION
## Summary
- Исправлен статус ответа загрузки файла на S3: 204 → 201 (S3 возвращает 201 из-за `success_action_status` в presigned post)
- Добавлено поле `success_action_status` в `UploadParams`