### PR TITLE
chore: gitignore generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ Thumbs.db
 # Generated docs (rebuilt during deploy)
 apps/docs/public/llms.txt
 apps/docs/public/llms-full.txt
+apps/docs/public/*.md
 apps/docs/public/**/*.md


### PR DESCRIPTION
## Summary
- Добавлены в `.gitignore` генерируемые файлы: `llms.txt`, `llms-full.txt`, md-страницы
- Файлы удалены из git-трекинга (генерируются при сборке через `turbo build` → `generate-llms`)