### PR TITLE
fix: убрал exclude yaml из Swift Package — plugin не находил конфиг

### DIFF
--- a/sdk/swift/Package.swift
+++ b/sdk/swift/Package.swift
@@ -21,8 +21,7 @@ let package = Package(
                 .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
-            path: "generated/Sources/Pachca",
-            exclude: ["openapi.yaml", "openapi-generator-config.yaml"]
+            path: "generated/Sources/Pachca"
         )
     ]
 )


### PR DESCRIPTION
## Summary
- Убрал `exclude: ["openapi.yaml", "openapi-generator-config.yaml"]` из `Package.swift`
- Command plugin `generate-code-from-openapi` ищет эти файлы в source directory таргета, и `exclude` делал их невидимыми для плагина

## Context
PR #94 замержился с `exclude`, который ломал генерацию на CI:
```
error: No config file found in the target named 'PachcaSDK'
error: No OpenAPI document found in the target named 'PachcaSDK'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)