### PR TITLE
fix: подсветка пункта сайдбара для вложенных роутов

### DIFF
--- a/apps/docs/components/layout/sidebar-item.tsx
+++ b/apps/docs/components/layout/sidebar-item.tsx
@@ -41,7 +41,7 @@ interface SidebarItemProps {
 
 export function SidebarItem({ item, onItemClick }: SidebarItemProps) {
   const pathname = usePathname();
-  const isActive = pathname === item.href;
+  const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
   const itemRef = useRef<HTMLAnchorElement>(null);
   const { isLoading, handleClick } = useNavigationLoading(item.href, 200);
 


### PR DESCRIPTION
startsWith для isActive — /guides/updates/2026-02-24 подсвечивает «Последние обновления»