### PR TITLE
fix: закрытие мобильного меню при клике на активный пункт

### DIFF
--- a/apps/docs/components/layout/mobile-sidebar.tsx
+++ b/apps/docs/components/layout/mobile-sidebar.tsx
@@ -91,7 +91,7 @@ export function MobileSidebar({ navigation }: MobileSidebarProps) {
           id="mobile-sidebar-scroll-container"
         >
           <div className="p-4 space-y-4 flex-1">
-            <SidebarNav navigation={navigation} />
+            <SidebarNav navigation={navigation} onNavigate={() => setIsOpen(false)} />
           </div>
         </div>
       </div>

--- a/apps/docs/components/layout/sidebar-nav.tsx
+++ b/apps/docs/components/layout/sidebar-nav.tsx
@@ -9,9 +9,10 @@ import { useState, useEffect, useRef } from 'react';
 
 interface SidebarNavProps {
   navigation: NavigationSection[];
+  onNavigate?: () => void;
 }
 
-export function SidebarNav({ navigation }: SidebarNavProps) {
+export function SidebarNav({ navigation, onNavigate }: SidebarNavProps) {
   const pathname = usePathname();
   const isInternalNav = useRef(false);
 
@@ -25,6 +26,7 @@ export function SidebarNav({ navigation }: SidebarNavProps) {
 
   const handleItemClick = () => {
     isInternalNav.current = true;
+    onNavigate?.();
   };
 
   // При внешней навигации: раскрываем секцию и прокручиваем к ней


### PR DESCRIPTION
## Summary
- Прокинут callback `onNavigate` из `MobileSidebar` → `SidebarNav` → `SidebarItem`
- Теперь клик по любому пункту (включая текущий активный) закрывает мобильное меню
- На десктопе поведение не изменилось — `onNavigate` не передаётся