### PR TITLE
fix: add packages/cli to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY bun.lock package.json turbo.json ./
 COPY apps/docs/package.json apps/docs/package.json
 COPY packages/spec/package.json packages/spec/package.json
+COPY packages/cli/package.json packages/cli/package.json
 
 RUN bun install
 


### PR DESCRIPTION
## Summary

- Dockerfile не копировал `packages/cli/package.json` перед `bun install`
- Из-за этого `turbo check` падал с exit 127 (`tsc` not found) при Docker-сборке

Пропущено при мерже #117.