### PR TITLE
fix: handle npm view for unpublished CLI package

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -130,12 +130,15 @@ jobs:
         id: version
         run: |
           VERSION=$(node -e "
+            const { execSync } = require('child_process');
             const d = new Date();
             const base = d.getFullYear() + '.' + (d.getMonth()+1);
-            const published = require('child_process')
-              .execSync('npm view @pachca/cli versions --json 2>/dev/null || echo []')
-              .toString().trim();
-            const versions = JSON.parse(published);
+            let versions = [];
+            try {
+              const raw = execSync('npm view @pachca/cli versions --json', { stdio: ['pipe', 'pipe', 'pipe'] }).toString().trim();
+              const parsed = JSON.parse(raw);
+              versions = Array.isArray(parsed) ? parsed : [parsed];
+            } catch {}
             const patch = versions.filter(v => v.startsWith(base + '.')).length;
             console.log(base + '.' + patch);
           ")


### PR DESCRIPTION
## Summary

- `npm view @pachca/cli versions --json` для несуществующего пакета выводит warnings в stdout
- `JSON.parse` падал на мусоре перед `[]`
- Заменено на `try/catch` с `stdio: ['pipe', 'pipe', 'pipe']` — stderr не попадает в stdout, а при ошибке (404) catch возвращает пустой массив

Фикс для publish-cli job из #117.