### PR TITLE
fix: replace npm version with direct write in publish-cli

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -143,7 +143,7 @@ jobs:
             console.log(base + '.' + patch);
           ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          cd packages/cli && npm version $VERSION --no-git-tag-version
+          cd packages/cli && node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='$VERSION';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
       - name: Generate changelog
         run: npx tsx scripts/diff-endpoints.ts
         working-directory: packages/cli
@@ -159,7 +159,7 @@ jobs:
               CURRENT=$(node -e "console.log(require('./package.json').version)")
               PATCH=$(echo $CURRENT | cut -d. -f3)
               BASE=$(echo $CURRENT | cut -d. -f1-2)
-              npm version ${BASE}.$((PATCH + 1)) --no-git-tag-version
+              node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='${BASE}.$((PATCH+1))';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
               npm publish --access public --provenance
             else
               exit $CODE


### PR DESCRIPTION
## Summary
- `npm version` fails in bun monorepo because it encounters `workspace:*` protocol in bun.lock which npm doesn't understand
- Replaced both `npm version` calls with direct `node -e` package.json writes (version set + retry on E409)

## Test plan
- [ ] Merge and verify `publish-cli` job succeeds
- [ ] Verify `@pachca/cli` appears on npm with version `2026.3.x`