### PR TITLE
fix: print npm publish error on cli failure

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -162,6 +162,7 @@ jobs:
               node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='${BASE}.$((PATCH+1))';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
               npm publish --access public --provenance
             else
+              echo "$OUTPUT"
               exit $CODE
             fi
           }

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -143,7 +143,7 @@ jobs:
             console.log(base + '.' + patch);
           ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          cd packages/cli && npm version $VERSION --no-git-tag-version
+          cd packages/cli && node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='$VERSION';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
       - name: Generate changelog
         run: npx tsx scripts/diff-endpoints.ts
         working-directory: packages/cli
@@ -159,7 +159,7 @@ jobs:
               CURRENT=$(node -e "console.log(require('./package.json').version)")
               PATCH=$(echo $CURRENT | cut -d. -f3)
               BASE=$(echo $CURRENT | cut -d. -f1-2)
-              npm version ${BASE}.$((PATCH + 1)) --no-git-tag-version
+              node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='${BASE}.$((PATCH+1))';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
               npm publish --access public --provenance
             else
               exit $CODE


### PR DESCRIPTION
## Summary
- Add `echo "$OUTPUT"` before `exit $CODE` in publish-cli so we can see the actual npm error when publish fails
- Previous run failed silently — error was swallowed by `2>&1` redirect into variable

## Test plan
- [ ] Merge, re-run SDK workflow, read error message if it fails again