### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,11 @@
     "typescript": "^5.7.3",
     "vitest": "^3.1.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pachca/openapi",
+    "directory": "packages/cli"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary
- `npm publish --provenance` fails with E422: `repository.url` is empty, expected `https://github.com/pachca/openapi`
- Added `repository` field to `packages/cli/package.json`

## Test plan
- [ ] Merge and verify `publish-cli` succeeds