### PR TITLE
fix: 10 CLI user-facing bugs

### DIFF
--- a/apps/docs/content/guides/cli.mdx
+++ b/apps/docs/content/guides/cli.mdx
@@ -40,7 +40,7 @@ pachca auth login --token $ACCESS_TOKEN`}
 
 # ID    Имя              Email               Роль
 # 1234  Иван Иванов      ivan@company.ru     admin
-# 5678  Мария Петрова    maria@company.ru    regular`}
+# 5678  Мария Петрова    maria@company.ru    user`}
 </CodeBlock>
 
     Добавьте `-o json` для JSON-вывода.
@@ -275,6 +275,48 @@ pachca guide "активные чаты"
 | `--no-header` | | Скрыть заголовок таблицы |
 | `--no-truncate` | | Не обрезать длинные значения |
 | `--no-retry` | | Отключить авто-retry при 429/503 |
+
+### Имена флагов
+
+Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это [стандартная конвенция](https://clig.dev/#arguments-and-flags) всех современных CLI (AWS, gcloud, GitHub CLI, Stripe CLI, kubectl и др.):
+
+<CodeBlock language="text" title="API → CLI">
+{`API-документация          CLI-флаг
+─────────────────         ────────────────
+first_name            →   --first-name
+phone_number          →   --phone-number
+entity_id             →   --entity-id
+skip_email_notify     →   --skip-email-notify
+list_tags             →   --list-tags
+custom_properties     →   --custom-properties
+parent_message_id     →   --parent-message-id`}
+</CodeBlock>
+
+При отправке запроса CLI автоматически конвертирует имена обратно в snake_case для API. Проверить можно через `--dry-run`:
+
+<CodeBlock language="bash" title="Проверка">
+{`pachca users update 123 --first-name "Иван" --phone-number "+7900" --dry-run
+
+# {"user": {"first_name": "Иван", "phone_number": "+7900"}}`}
+</CodeBlock>
+
+### Boolean-флаги
+
+Для boolean-параметров API используйте флаг для установки `true` и `--no-` префикс для `false`:
+
+<CodeBlock language="bash" title="Boolean-флаги">
+{`# Деактивировать сотрудника (suspended: true)
+pachca users update 123 --suspended
+
+# Активировать обратно (suspended: false)
+pachca users update 123 --no-suspended
+
+# Создать публичный канал (channel: true, public: true)
+pachca chats create --name "Новости" --channel --public
+
+# Сделать канал приватным (public: false)
+pachca chats update 123 --no-public`}
+</CodeBlock>
 
 ### Предпросмотр запроса
 

--- a/apps/docs/content/guides/cli.mdx
+++ b/apps/docs/content/guides/cli.mdx
@@ -278,7 +278,7 @@ pachca guide "активные чаты"
 
 ### Имена флагов
 
-Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это [стандартная конвенция](https://clig.dev/#arguments-and-flags) всех современных CLI (AWS, gcloud, GitHub CLI, Stripe CLI, kubectl и др.):
+Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это [стандартная конвенция](https://clig.dev/#arguments-and-flags) для CLI-инструментов:
 
 <CodeBlock language="text" title="API → CLI">
 {`API-документация          CLI-флаг

--- a/apps/docs/public/guides/cli.md
+++ b/apps/docs/public/guides/cli.md
@@ -46,7 +46,7 @@ pachca users list
 
 # ID    Имя              Email               Роль
 # 1234  Иван Иванов      ivan@company.ru     admin
-# 5678  Мария Петрова    maria@company.ru    regular
+# 5678  Мария Петрова    maria@company.ru    user
 ```
 
 
@@ -283,7 +283,7 @@ pachca users list --no-truncate
 
 ```bash
 # Передать в jq
-pachca users list -o json | jq '.[].name'
+pachca users list | jq '.[].name'
 
 # Текст сообщения из файла
 pachca messages create --entity-id 123 < message.txt
@@ -318,7 +318,7 @@ pachca users list --all
 
 ## Сценарии
 
-CLI включает готовые пошаговые сценарии для типичных задач — это те же сценарии, что используют [AI-агенты](/guides/ai-agents#agent-skills-skillmd). Не знаете какую команду использовать — поищите по задаче:
+CLI включает готовые пошаговые сценарии для типичных задач — это те же сценарии, что используют [AI-агенты](/guides/ai-agents#agent-skills-skillmd). Не знаете, какую команду использовать — поищите по задаче:
 
 **Поиск сценариев**
 
@@ -385,6 +385,57 @@ pachca guide "активные чаты"
 | `--no-header` | | Скрыть заголовок таблицы |
 | `--no-truncate` | | Не обрезать длинные значения |
 | `--no-retry` | | Отключить авто-retry при 429/503 |
+
+### Имена флагов
+
+Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это [стандартная конвенция](https://clig.dev/#arguments-and-flags) всех современных CLI (AWS, gcloud, GitHub CLI, Stripe CLI, kubectl и др.):
+
+**API → CLI**
+
+```text
+API-документация          CLI-флаг
+─────────────────         ────────────────
+first_name            →   --first-name
+phone_number          →   --phone-number
+entity_id             →   --entity-id
+skip_email_notify     →   --skip-email-notify
+list_tags             →   --list-tags
+custom_properties     →   --custom-properties
+parent_message_id     →   --parent-message-id
+```
+
+
+При отправке запроса CLI автоматически конвертирует имена обратно в snake_case для API. Проверить можно через `--dry-run`:
+
+**Проверка**
+
+```bash
+pachca users update 123 --first-name "Иван" --phone-number "+7900" --dry-run
+
+# {"user": {"first_name": "Иван", "phone_number": "+7900"}}
+```
+
+
+### Boolean-флаги
+
+Для boolean-параметров API используйте флаг для установки `true` и `--no-` префикс для `false`:
+
+**Boolean-флаги**
+
+```bash
+# Деактивировать сотрудника (suspended: true)
+pachca users update 123 --suspended
+
+# Активировать обратно (suspended: false)
+pachca users update 123 --no-suspended
+
+# Создать публичный канал (channel: true, public: true)
+pachca chats create --name "Новости" --channel --public
+
+# Сделать канал приватным (public: false)
+pachca chats update 123 --no-public
+```
+
 
 ### Предпросмотр запроса
 
@@ -474,7 +525,7 @@ PACHCA_TOKEN=$TOKEN pachca messages create \\
 pachca api GET /messages --query chat_id=123
 
 # POST с типизированными полями (-F конвертирует числа и boolean)
-pachca api POST /messages -F message[chat_id]=12345 -f message[content]="Привет"
+pachca api POST /messages -F message[entity_id]=12345 -f message[content]="Привет"
 
 # PUT со строковым полем (-f гарантирует string)
 pachca api PUT /tasks/42 -f task[due_at]="2026-04-01T10:00:00Z"
@@ -553,7 +604,7 @@ CLI автоматически проверяет наличие новой ве
 # Обновить до последней версии
 npm install -g @pachca/cli
 
-# Посмотреть что нового
+# Посмотреть, что нового
 pachca changelog
 ```
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -859,7 +859,7 @@ pachca users list
 
 # ID    Имя              Email               Роль
 # 1234  Иван Иванов      ivan@company.ru     admin
-# 5678  Мария Петрова    maria@company.ru    regular
+# 5678  Мария Петрова    maria@company.ru    user
 ```
 
 
@@ -1096,7 +1096,7 @@ pachca users list --no-truncate
 
 ```bash
 # Передать в jq
-pachca users list -o json | jq '.[].name'
+pachca users list | jq '.[].name'
 
 # Текст сообщения из файла
 pachca messages create --entity-id 123 < message.txt
@@ -1131,7 +1131,7 @@ pachca users list --all
 
 ## Сценарии
 
-CLI включает готовые пошаговые сценарии для типичных задач — это те же сценарии, что используют [AI-агенты](/guides/ai-agents#agent-skills-skillmd). Не знаете какую команду использовать — поищите по задаче:
+CLI включает готовые пошаговые сценарии для типичных задач — это те же сценарии, что используют [AI-агенты](/guides/ai-agents#agent-skills-skillmd). Не знаете, какую команду использовать — поищите по задаче:
 
 **Поиск сценариев**
 
@@ -1198,6 +1198,57 @@ pachca guide "активные чаты"
 | `--no-header` | | Скрыть заголовок таблицы |
 | `--no-truncate` | | Не обрезать длинные значения |
 | `--no-retry` | | Отключить авто-retry при 429/503 |
+
+### Имена флагов
+
+Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это [стандартная конвенция](https://clig.dev/#arguments-and-flags) всех современных CLI (AWS, gcloud, GitHub CLI, Stripe CLI, kubectl и др.):
+
+**API → CLI**
+
+```text
+API-документация          CLI-флаг
+─────────────────         ────────────────
+first_name            →   --first-name
+phone_number          →   --phone-number
+entity_id             →   --entity-id
+skip_email_notify     →   --skip-email-notify
+list_tags             →   --list-tags
+custom_properties     →   --custom-properties
+parent_message_id     →   --parent-message-id
+```
+
+
+При отправке запроса CLI автоматически конвертирует имена обратно в snake_case для API. Проверить можно через `--dry-run`:
+
+**Проверка**
+
+```bash
+pachca users update 123 --first-name "Иван" --phone-number "+7900" --dry-run
+
+# {"user": {"first_name": "Иван", "phone_number": "+7900"}}
+```
+
+
+### Boolean-флаги
+
+Для boolean-параметров API используйте флаг для установки `true` и `--no-` префикс для `false`:
+
+**Boolean-флаги**
+
+```bash
+# Деактивировать сотрудника (suspended: true)
+pachca users update 123 --suspended
+
+# Активировать обратно (suspended: false)
+pachca users update 123 --no-suspended
+
+# Создать публичный канал (channel: true, public: true)
+pachca chats create --name "Новости" --channel --public
+
+# Сделать канал приватным (public: false)
+pachca chats update 123 --no-public
+```
+
 
 ### Предпросмотр запроса
 
@@ -1287,7 +1338,7 @@ PACHCA_TOKEN=$TOKEN pachca messages create \\
 pachca api GET /messages --query chat_id=123
 
 # POST с типизированными полями (-F конвертирует числа и boolean)
-pachca api POST /messages -F message[chat_id]=12345 -f message[content]="Привет"
+pachca api POST /messages -F message[entity_id]=12345 -f message[content]="Привет"
 
 # PUT со строковым полем (-f гарантирует string)
 pachca api PUT /tasks/42 -f task[due_at]="2026-04-01T10:00:00Z"
@@ -1366,7 +1417,7 @@ CLI автоматически проверяет наличие новой ве
 # Обновить до последней версии
 npm install -g @pachca/cli
 
-# Посмотреть что нового
+# Посмотреть, что нового
 pachca changelog
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -246,6 +246,22 @@ pachca users list --cursor eyJpZCI6NTB9
 pachca users list --all
 ```
 
+## Имена флагов
+
+Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это стандартная конвенция всех современных CLI:
+
+```
+API-документация          CLI-флаг
+first_name            →   --first-name
+phone_number          →   --phone-number
+entity_id             →   --entity-id
+skip_email_notify     →   --skip-email-notify
+list_tags             →   --list-tags
+custom_properties     →   --custom-properties
+```
+
+При отправке запроса CLI автоматически конвертирует имена обратно в snake_case для API.
+
 ## Вывод и скрипты
 
 ```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -285,6 +285,11 @@ PACHCA_TOKEN=xxx pachca messages create --entity-id 123 --content "Деплой 
 
 # DELETE без подтверждения (в TTY)
 pachca users delete 1234 --force
+
+# Boolean-флаги: --flag (true), --no-flag (false)
+pachca users update 123 --suspended
+pachca users update 123 --no-suspended
+pachca chats update 123 --no-public
 ```
 
 ## Прямые API-запросы

--- a/packages/cli/README.template.md
+++ b/packages/cli/README.template.md
@@ -84,6 +84,22 @@ pachca users list --cursor eyJpZCI6NTB9
 pachca users list --all
 ```
 
+## Имена флагов
+
+Флаги CLI используют **kebab-case** (через дефис), а не snake_case как в API-документации — это стандартная конвенция всех современных CLI:
+
+```
+API-документация          CLI-флаг
+first_name            →   --first-name
+phone_number          →   --phone-number
+entity_id             →   --entity-id
+skip_email_notify     →   --skip-email-notify
+list_tags             →   --list-tags
+custom_properties     →   --custom-properties
+```
+
+При отправке запроса CLI автоматически конвертирует имена обратно в snake_case для API.
+
 ## Вывод и скрипты
 
 ```
@@ -123,6 +139,11 @@ PACHCA_TOKEN=xxx pachca messages create --entity-id 123 --content "Деплой 
 
 # DELETE без подтверждения (в TTY)
 pachca users delete 1234 --force
+
+# Boolean-флаги: --flag (true), --no-flag (false)
+pachca users update 123 --suspended
+pachca users update 123 --no-suspended
+pachca chats update 123 --no-public
 ```
 
 ## Прямые API-запросы

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1736,6 +1736,9 @@
       "aliases": [],
       "args": {},
       "description": "История событий",
+      "examples": [
+        "Обработка событий через историю (polling):\n  $ pachca bots list-events"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -1839,18 +1842,24 @@
           "type": "boolean"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из meta.paginate.next_page)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -1864,6 +1873,12 @@
       "scope": "webhooks:events:read",
       "apiMethod": "GET",
       "apiPath": "/webhooks/events",
+      "defaultColumns": [
+        "id",
+        "created_at",
+        "event_type",
+        "payload"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -1882,6 +1897,9 @@
         }
       },
       "description": "Удаление события",
+      "examples": [
+        "Обработка событий через историю (polling):\n  $ pachca bots remove-event"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2020,6 +2038,9 @@
         }
       },
       "description": "Редактирование бота",
+      "examples": [
+        "Обновить Webhook URL бота:\n  $ pachca bots update"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2125,7 +2146,6 @@
         "webhook": {
           "description": "Объект параметров вебхука",
           "name": "webhook",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2142,6 +2162,9 @@
       "scope": "bots:write",
       "apiMethod": "PUT",
       "apiPath": "/bots/{id}",
+      "defaultColumns": [
+        "id"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2160,6 +2183,10 @@
         }
       },
       "description": "Архивация чата",
+      "examples": [
+        "Архивация и управление чатом:\n  $ pachca chats archive",
+        "Найти и заархивировать неактивные чаты:\n  $ pachca chats archive"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2286,6 +2313,11 @@
       "aliases": [],
       "args": {},
       "description": "Новый чат",
+      "examples": [
+        "Найти чат по имени и отправить сообщение:\n  $ pachca chats list",
+        "Создать канал и пригласить участников:\n  $ pachca chats create",
+        "Создать проектную беседу из шаблона:\n  $ pachca chats create"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2391,7 +2423,6 @@
         "name": {
           "description": "Название",
           "name": "name",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2413,13 +2444,13 @@
         "channel": {
           "description": "Является каналом",
           "name": "channel",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         },
         "public": {
           "description": "Открытый доступ",
           "name": "public",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         }
       },
@@ -2434,6 +2465,13 @@
       "scope": "chats:create",
       "apiMethod": "POST",
       "apiPath": "/chats",
+      "defaultColumns": [
+        "id",
+        "name",
+        "created_at",
+        "owner_id",
+        "channel"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2452,6 +2490,9 @@
         }
       },
       "description": "Информация о чате",
+      "examples": [
+        "Переименовать или обновить чат:\n  $ pachca chats update"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2566,6 +2607,13 @@
       "scope": "chats:read",
       "apiMethod": "GET",
       "apiPath": "/chats/{id}",
+      "defaultColumns": [
+        "id",
+        "name",
+        "created_at",
+        "owner_id",
+        "channel"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2578,6 +2626,11 @@
       "aliases": [],
       "args": {},
       "description": "Список чатов",
+      "examples": [
+        "Найти чат по имени и отправить сообщение:\n  $ pachca chats list",
+        "Создать канал и пригласить участников:\n  $ pachca chats create",
+        "Создать проектную беседу из шаблона:\n  $ pachca chats create"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2687,9 +2740,9 @@
           "multiple": false,
           "type": "option"
         },
-        "sort-last_message_at": {
+        "sort-last-message-at": {
           "description": "Дата и время создания последнего сообщения",
-          "name": "sort-last_message_at",
+          "name": "sort-last-message-at",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -2718,22 +2771,28 @@
         "personal": {
           "description": "Фильтрация по личным и групповым чатам. Если параметр не указан, возвращаются любые чаты.",
           "name": "personal",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из meta.paginate.next_page)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -2747,6 +2806,13 @@
       "scope": "chats:read",
       "apiMethod": "GET",
       "apiPath": "/chats",
+      "defaultColumns": [
+        "id",
+        "name",
+        "created_at",
+        "owner_id",
+        "channel"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -2765,6 +2831,9 @@
         }
       },
       "description": "Разархивация чата",
+      "examples": [
+        "Архивация и управление чатом:\n  $ pachca chats unarchive"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -2897,6 +2966,9 @@
         }
       },
       "description": "Обновление чата",
+      "examples": [
+        "Переименовать или обновить чат:\n  $ pachca chats update"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -3009,7 +3081,7 @@
         "public": {
           "description": "Открытый доступ",
           "name": "public",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         }
       },
@@ -3024,12 +3096,797 @@
       "scope": "chats:update",
       "apiMethod": "PUT",
       "apiPath": "/chats/{id}",
+      "defaultColumns": [
+        "id",
+        "name",
+        "created_at",
+        "owner_id",
+        "channel"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
         "commands",
         "chats",
         "update.js"
+      ]
+    },
+    "common:custom-properties": {
+      "aliases": [],
+      "args": {},
+      "description": "Список дополнительных полей",
+      "examples": [
+        "Создать напоминание:\n  $ pachca common custom-properties",
+        "Получить кастомные поля профиля:\n  $ pachca common custom-properties"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "entity-type": {
+          "description": "Тип сущности",
+          "name": "entity-type",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "User",
+            "Task"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "common:custom-properties",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "custom_properties:read",
+      "apiMethod": "GET",
+      "apiPath": "/custom_properties",
+      "defaultColumns": [
+        "id",
+        "name",
+        "data_type"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "common",
+        "custom-properties.js"
+      ]
+    },
+    "common:direct-url": {
+      "aliases": [],
+      "args": {},
+      "description": "Загрузка файла",
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "content-disposition": {
+          "description": "Параметр Content-Disposition, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "content-disposition",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "acl": {
+          "description": "Параметр acl, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "acl",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "policy": {
+          "description": "Параметр policy, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "policy",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "x-amz-credential": {
+          "description": "Параметр x-amz-credential, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "x-amz-credential",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "x-amz-algorithm": {
+          "description": "Параметр x-amz-algorithm, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "x-amz-algorithm",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "x-amz-date": {
+          "description": "Параметр x-amz-date, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "x-amz-date",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "x-amz-signature": {
+          "description": "Параметр x-amz-signature, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "x-amz-signature",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "key": {
+          "description": "Параметр key, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
+          "name": "key",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "file": {
+          "description": "Файл для загрузки",
+          "name": "file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "common:direct-url",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "apiMethod": "POST",
+      "apiPath": "/direct_url",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "common",
+        "direct-url.js"
+      ]
+    },
+    "common:get-exports": {
+      "aliases": [],
+      "args": {
+        "id": {
+          "description": "Идентификатор экспорта",
+          "name": "id",
+          "required": true
+        }
+      },
+      "description": "Скачать архив экспорта",
+      "examples": [
+        "Экспорт истории чата:\n  $ pachca common get-exports"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "save": {
+          "description": "Путь для сохранения файла",
+          "name": "save",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "common:get-exports",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "chat_exports:read",
+      "plan": "corporation",
+      "apiMethod": "GET",
+      "apiPath": "/chats/exports/{id}",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "common",
+        "get-exports.js"
+      ]
+    },
+    "common:request-export": {
+      "aliases": [],
+      "args": {},
+      "description": "Экспорт сообщений",
+      "examples": [
+        "Экспорт истории чата:\n  $ pachca common request-export"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "start-at": {
+          "description": "Дата начала для экспорта (ISO-8601, UTC+0) в формате YYYY-MM-DD",
+          "name": "start-at",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "end-at": {
+          "description": "Дата окончания для экспорта (ISO-8601, UTC+0) в формате YYYY-MM-DD",
+          "name": "end-at",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "webhook-url": {
+          "description": "Адрес, на который будет отправлен вебхук по завершению экспорта",
+          "name": "webhook-url",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "chat-ids": {
+          "description": "Массив идентификаторов чатов. Указывается, если нужно получить сообщения только некоторых чатов.",
+          "name": "chat-ids",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "skip-chats-file": {
+          "description": "Пропуск формирования файла со списком чатов (chats.json)",
+          "name": "skip-chats-file",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "common:request-export",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "chat_exports:write",
+      "plan": "corporation",
+      "apiMethod": "POST",
+      "apiPath": "/chats/exports",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "common",
+        "request-export.js"
+      ]
+    },
+    "common:uploads": {
+      "aliases": [],
+      "args": {},
+      "description": "Получение подписи, ключа и других параметров",
+      "examples": [
+        "Отправить сообщение с файлами:\n  $ pachca common uploads",
+        "Изменить вложения сообщения:\n  $ pachca common uploads"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "common:uploads",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "uploads:write",
+      "apiMethod": "POST",
+      "apiPath": "/uploads",
+      "defaultColumns": [
+        "Content-Disposition",
+        "acl",
+        "policy",
+        "x-amz-credential",
+        "x-amz-algorithm"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "common",
+        "uploads.js"
       ]
     },
     "config:get": {
@@ -3429,775 +4286,14 @@
         "set.js"
       ]
     },
-    "common:custom-properties": {
-      "aliases": [],
-      "args": {},
-      "description": "Список дополнительных полей",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "entity-type": {
-          "description": "Тип сущности",
-          "name": "entity-type",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "User",
-            "Task"
-          ],
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "common:custom-properties",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "custom_properties:read",
-      "apiMethod": "GET",
-      "apiPath": "/custom_properties",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "common",
-        "custom-properties.js"
-      ]
-    },
-    "common:direct-url": {
-      "aliases": [],
-      "args": {},
-      "description": "Загрузка файла",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "contentDisposition": {
-          "description": "Параметр Content-Disposition, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "contentDisposition",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "acl": {
-          "description": "Параметр acl, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "acl",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "policy": {
-          "description": "Параметр policy, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "policy",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "xAmzCredential": {
-          "description": "Параметр x-amz-credential, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "xAmzCredential",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "xAmzAlgorithm": {
-          "description": "Параметр x-amz-algorithm, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "xAmzAlgorithm",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "xAmzDate": {
-          "description": "Параметр x-amz-date, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "xAmzDate",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "xAmzSignature": {
-          "description": "Параметр x-amz-signature, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "xAmzSignature",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "key": {
-          "description": "Параметр key, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
-          "name": "key",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "file": {
-          "description": "Файл для загрузки",
-          "name": "file",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "common:direct-url",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "apiMethod": "POST",
-      "apiPath": "/direct_url",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "common",
-        "direct-url.js"
-      ]
-    },
-    "common:get-exports": {
-      "aliases": [],
-      "args": {
-        "id": {
-          "description": "Идентификатор экспорта",
-          "name": "id",
-          "required": true
-        }
-      },
-      "description": "Скачать архив экспорта",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "save": {
-          "description": "Путь для сохранения файла",
-          "name": "save",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "common:get-exports",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "chat_exports:read",
-      "plan": "corporation",
-      "apiMethod": "GET",
-      "apiPath": "/chats/exports/{id}",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "common",
-        "get-exports.js"
-      ]
-    },
-    "common:request-export": {
-      "aliases": [],
-      "args": {},
-      "description": "Экспорт сообщений",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "start-at": {
-          "description": "Дата начала для экспорта (ISO-8601, UTC+0) в формате YYYY-MM-DD",
-          "name": "start-at",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "end-at": {
-          "description": "Дата окончания для экспорта (ISO-8601, UTC+0) в формате YYYY-MM-DD",
-          "name": "end-at",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "webhook-url": {
-          "description": "Адрес, на который будет отправлен вебхук по завершению экспорта",
-          "name": "webhook-url",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "chat-ids": {
-          "description": "Массив идентификаторов чатов. Указывается, если нужно получить сообщения только некоторых чатов.",
-          "name": "chat-ids",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "skip-chats-file": {
-          "description": "Пропуск формирования файла со списком чатов (chats.json)",
-          "name": "skip-chats-file",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "common:request-export",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "chat_exports:write",
-      "plan": "corporation",
-      "apiMethod": "POST",
-      "apiPath": "/chats/exports",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "common",
-        "request-export.js"
-      ]
-    },
-    "common:uploads": {
-      "aliases": [],
-      "args": {},
-      "description": "Получение подписи, ключа и других параметров",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "common:uploads",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "uploads:write",
-      "apiMethod": "POST",
-      "apiPath": "/uploads",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "common",
-        "uploads.js"
-      ]
-    },
     "group-tags:create": {
       "aliases": [],
       "args": {},
       "description": "Новый тег",
+      "examples": [
+        "Массовое создание сотрудников с тегами:\n  $ pachca group-tags create",
+        "Получить всех сотрудников тега/департамента:\n  $ pachca group-tags list"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -4303,7 +4399,6 @@
         "name": {
           "description": "Название тега",
           "name": "name",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -4320,6 +4415,11 @@
       "scope": "group_tags:write",
       "apiMethod": "POST",
       "apiPath": "/group_tags",
+      "defaultColumns": [
+        "id",
+        "name",
+        "users_count"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4590,6 +4690,11 @@
       "scope": "group_tags:read",
       "apiMethod": "GET",
       "apiPath": "/group_tags/{id}",
+      "defaultColumns": [
+        "id",
+        "name",
+        "users_count"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4608,6 +4713,9 @@
         }
       },
       "description": "Список сотрудников тега",
+      "examples": [
+        "Получить всех сотрудников тега/департамента:\n  $ pachca group-tags list-users"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -4711,18 +4819,24 @@
           "type": "boolean"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -4736,6 +4850,13 @@
       "scope": "group_tags:read",
       "apiMethod": "GET",
       "apiPath": "/group_tags/{id}/users",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -4748,6 +4869,10 @@
       "aliases": [],
       "args": {},
       "description": "Список тегов сотрудников",
+      "examples": [
+        "Массовое создание сотрудников с тегами:\n  $ pachca group-tags create",
+        "Получить всех сотрудников тега/департамента:\n  $ pachca group-tags list"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -4851,25 +4976,31 @@
           "type": "boolean"
         },
         "names": {
-          "description": "Массив названий тегов, по которым вы хотите отфильтровать список",
+          "description": "Массив названий тегов, по которым вы хотите отфильтровать список (через запятую)",
           "name": "names",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -4883,6 +5014,11 @@
       "scope": "group_tags:read",
       "apiMethod": "GET",
       "apiPath": "/group_tags",
+      "defaultColumns": [
+        "id",
+        "name",
+        "users_count"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -5006,7 +5142,6 @@
         "name": {
           "description": "Название тега",
           "name": "name",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -5023,6 +5158,11 @@
       "scope": "group_tags:write",
       "apiMethod": "PUT",
       "apiPath": "/group_tags/{id}",
+      "defaultColumns": [
+        "id",
+        "name",
+        "users_count"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -5041,6 +5181,9 @@
         }
       },
       "description": "Unfurl (разворачивание ссылок)",
+      "examples": [
+        "Разворачивание ссылок (unfurling):\n  $ pachca link-previews add"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -5146,7 +5289,6 @@
         "link-previews": {
           "description": "`JSON` карта предпросмотров ссылок, где каждый ключ — `URL`, который был получен в исходящем вебхуке о новом сообщении.",
           "name": "link-previews",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -5171,10 +5313,729 @@
         "add.js"
       ]
     },
+    "profile:delete-status": {
+      "aliases": [],
+      "args": {},
+      "description": "Удаление статуса",
+      "examples": [
+        "Установить статус:\n  $ pachca profile update-status",
+        "Сбросить статус:\n  $ pachca profile delete-status"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "Пропустить подтверждение",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profile:delete-status",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "profile_status:write",
+      "apiMethod": "DELETE",
+      "apiPath": "/profile/status",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "profile",
+        "delete-status.js"
+      ]
+    },
+    "profile:get-info": {
+      "aliases": [],
+      "args": {},
+      "description": "Информация о токене",
+      "examples": [
+        "Проверить свой токен:\n  $ pachca profile get-info"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profile:get-info",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "apiMethod": "GET",
+      "apiPath": "/oauth/token/info",
+      "defaultColumns": [
+        "id",
+        "name",
+        "created_at",
+        "token",
+        "user_id"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "profile",
+        "get-info.js"
+      ]
+    },
+    "profile:get-status": {
+      "aliases": [],
+      "args": {},
+      "description": "Текущий статус",
+      "examples": [
+        "Установить статус:\n  $ pachca profile update-status",
+        "Сбросить статус:\n  $ pachca profile delete-status"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profile:get-status",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "profile_status:read",
+      "apiMethod": "GET",
+      "apiPath": "/profile/status",
+      "defaultColumns": [
+        "title",
+        "emoji",
+        "expires_at",
+        "is_away"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "profile",
+        "get-status.js"
+      ]
+    },
+    "profile:get": {
+      "aliases": [],
+      "args": {},
+      "description": "Информация о профиле",
+      "examples": [
+        "Получить свой профиль:\n  $ pachca profile get",
+        "Получить кастомные поля профиля:\n  $ pachca profile get"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profile:get",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "profile:read",
+      "apiMethod": "GET",
+      "apiPath": "/profile",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "profile",
+        "get.js"
+      ]
+    },
+    "profile:update-status": {
+      "aliases": [],
+      "args": {},
+      "description": "Новый статус",
+      "examples": [
+        "Установить статус:\n  $ pachca profile update-status",
+        "Сбросить статус:\n  $ pachca profile delete-status"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "emoji": {
+          "description": "Emoji символ статуса",
+          "name": "emoji",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "title": {
+          "description": "Текст статуса",
+          "name": "title",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "expires-at": {
+          "description": "Срок жизни статуса (ISO-8601, UTC+0) в формате YYYY-MM-DDThh:mm:ss.sssZ",
+          "name": "expires-at",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "is-away": {
+          "description": "Режим «Нет на месте»",
+          "name": "is-away",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "away-message": {
+          "description": "Текст сообщения при режиме «Нет на месте». Отображается в профиле и при личных сообщениях/упоминаниях. (макс. 1024 символов)",
+          "name": "away-message",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profile:update-status",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "profile_status:write",
+      "apiMethod": "PUT",
+      "apiPath": "/profile/status",
+      "defaultColumns": [
+        "title",
+        "emoji",
+        "expires_at",
+        "is_away"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "profile",
+        "update-status.js"
+      ]
+    },
     "messages:create": {
       "aliases": [],
       "args": {},
       "description": "Новое сообщение",
+      "examples": [
+        "Найти чат по имени и отправить сообщение:\n  $ pachca messages create",
+        "Отправить сообщение в канал или беседу (если chat_id известен):\n  $ pachca messages create",
+        "Отправить личное сообщение пользователю:\n  $ pachca messages create"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -5287,7 +6148,6 @@
         "entity-id": {
           "description": "Идентификатор сущности",
           "name": "entity-id",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -5295,7 +6155,6 @@
         "content": {
           "description": "Текст сообщения",
           "name": "content",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -5338,13 +6197,13 @@
         "skip-invite-mentions": {
           "description": "Пропуск добавления упоминаемых пользователей в тред. Работает только при отправке сообщения в тред.",
           "name": "skip-invite-mentions",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         },
         "link-preview": {
           "description": "Отображение предпросмотра первой найденной ссылки в тексте сообщения",
           "name": "link-preview",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         }
       },
@@ -5359,6 +6218,13 @@
       "scope": "messages:create",
       "apiMethod": "POST",
       "apiPath": "/messages",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "entity_type",
+        "entity_id"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -5377,6 +6243,11 @@
         }
       },
       "description": "Удаление сообщения",
+      "examples": [
+        "Получить вложения из сообщения:\n  $ pachca messages get",
+        "Отредактировать сообщение:\n  $ pachca messages update",
+        "Изменить вложения сообщения:\n  $ pachca messages get"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -5515,6 +6386,11 @@
         }
       },
       "description": "Информация о сообщении",
+      "examples": [
+        "Получить вложения из сообщения:\n  $ pachca messages get",
+        "Отредактировать сообщение:\n  $ pachca messages update",
+        "Изменить вложения сообщения:\n  $ pachca messages get"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -5629,6 +6505,13 @@
       "scope": "messages:read",
       "apiMethod": "GET",
       "apiPath": "/messages/{id}",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "entity_type",
+        "entity_id"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -5641,6 +6524,11 @@
       "aliases": [],
       "args": {},
       "description": "Список сообщений чата",
+      "examples": [
+        "Найти чат по имени и отправить сообщение:\n  $ pachca messages create",
+        "Отправить сообщение в канал или беседу (если chat_id известен):\n  $ pachca messages create",
+        "Отправить личное сообщение пользователю:\n  $ pachca messages create"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -5746,7 +6634,6 @@
         "chat-id": {
           "description": "Идентификатор чата (беседа, канал, диалог или чат треда)",
           "name": "chat-id",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -5759,18 +6646,24 @@
           "type": "option"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -5784,6 +6677,13 @@
       "scope": "messages:read",
       "apiMethod": "GET",
       "apiPath": "/messages",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "entity_type",
+        "entity_id"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -5802,6 +6702,10 @@
         }
       },
       "description": "Закрепление сообщения",
+      "examples": [
+        "Закрепить/открепить сообщение:\n  $ pachca messages pin",
+        "Закрепить/открепить сообщение:\n  $ pachca messages unpin"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -5934,6 +6838,10 @@
         }
       },
       "description": "Открепление сообщения",
+      "examples": [
+        "Закрепить/открепить сообщение:\n  $ pachca messages pin",
+        "Закрепить/открепить сообщение:\n  $ pachca messages unpin"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -6072,6 +6980,11 @@
         }
       },
       "description": "Редактирование сообщения",
+      "examples": [
+        "Получить вложения из сообщения:\n  $ pachca messages get",
+        "Отредактировать сообщение:\n  $ pachca messages update",
+        "Изменить вложения сообщения:\n  $ pachca messages get"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -6221,6 +7134,13 @@
       "scope": "messages:update",
       "apiMethod": "PUT",
       "apiPath": "/messages/{id}",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "entity_type",
+        "entity_id"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -6344,7 +7264,6 @@
         "group-tag-ids": {
           "description": "Массив идентификаторов тегов, которые станут участниками",
           "name": "group-tag-ids",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -6379,6 +7298,11 @@
         }
       },
       "description": "Добавление пользователей",
+      "examples": [
+        "Подписаться на тред сообщения:\n  $ pachca members add",
+        "Упомянуть пользователя по имени:\n  $ pachca members list",
+        "Создать канал и пригласить участников:\n  $ pachca members add"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -6484,7 +7408,6 @@
         "member-ids": {
           "description": "Массив идентификаторов пользователей, которые станут участниками",
           "name": "member-ids",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -6492,7 +7415,7 @@
         "silent": {
           "description": "Не создавать в чате системное сообщение о добавлении участника",
           "name": "silent",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         }
       },
@@ -6525,6 +7448,9 @@
         }
       },
       "description": "Выход из беседы или канала",
+      "examples": [
+        "Архивация и управление чатом:\n  $ pachca members leave"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -6663,6 +7589,11 @@
         }
       },
       "description": "Список участников чата",
+      "examples": [
+        "Подписаться на тред сообщения:\n  $ pachca members add",
+        "Упомянуть пользователя по имени:\n  $ pachca members list",
+        "Создать канал и пригласить участников:\n  $ pachca members add"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -6773,18 +7704,24 @@
           "type": "option"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из meta.paginate.next_page)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -6798,6 +7735,13 @@
       "scope": "chat_members:read",
       "apiMethod": "GET",
       "apiPath": "/chats/{id}/members",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -6964,6 +7908,10 @@
         }
       },
       "description": "Исключение пользователя",
+      "examples": [
+        "Архивация и управление чатом:\n  $ pachca members update",
+        "Архивация и управление чатом:\n  $ pachca members remove"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -7107,6 +8055,10 @@
         }
       },
       "description": "Редактирование роли",
+      "examples": [
+        "Архивация и управление чатом:\n  $ pachca members update",
+        "Архивация и управление чатом:\n  $ pachca members remove"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -7208,6 +8160,13 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
+        },
+        "role": {
+          "description": "Роль",
+          "name": "role",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -7229,677 +8188,6 @@
         "update.js"
       ]
     },
-    "profile:delete-status": {
-      "aliases": [],
-      "args": {},
-      "description": "Удаление статуса",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "Пропустить подтверждение",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "profile:delete-status",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "profile_status:write",
-      "apiMethod": "DELETE",
-      "apiPath": "/profile/status",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "profile",
-        "delete-status.js"
-      ]
-    },
-    "profile:get-info": {
-      "aliases": [],
-      "args": {},
-      "description": "Информация о токене",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "profile:get-info",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "apiMethod": "GET",
-      "apiPath": "/oauth/token/info",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "profile",
-        "get-info.js"
-      ]
-    },
-    "profile:get-status": {
-      "aliases": [],
-      "args": {},
-      "description": "Текущий статус",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "profile:get-status",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "profile_status:read",
-      "apiMethod": "GET",
-      "apiPath": "/profile/status",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "profile",
-        "get-status.js"
-      ]
-    },
-    "profile:get": {
-      "aliases": [],
-      "args": {},
-      "description": "Информация о профиле",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "profile:get",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "profile:read",
-      "apiMethod": "GET",
-      "apiPath": "/profile",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "profile",
-        "get.js"
-      ]
-    },
-    "profile:update-status": {
-      "aliases": [],
-      "args": {},
-      "description": "Новый статус",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "emoji": {
-          "description": "Emoji символ статуса",
-          "name": "emoji",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "title": {
-          "description": "Текст статуса",
-          "name": "title",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "expires-at": {
-          "description": "Срок жизни статуса (ISO-8601, UTC+0) в формате YYYY-MM-DDThh:mm:ss.sssZ",
-          "name": "expires-at",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "is-away": {
-          "description": "Режим «Нет на месте»",
-          "name": "is-away",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "away-message": {
-          "description": "Текст сообщения при режиме «Нет на месте». Отображается в профиле и при личных сообщениях/упоминаниях. (макс. 1024 символов)",
-          "name": "away-message",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "profile:update-status",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "profile_status:write",
-      "apiMethod": "PUT",
-      "apiPath": "/profile/status",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "profile",
-        "update-status.js"
-      ]
-    },
     "reactions:add": {
       "aliases": [],
       "args": {
@@ -7910,6 +8198,10 @@
         }
       },
       "description": "Добавление реакции",
+      "examples": [
+        "Добавить реакцию на сообщение:\n  $ pachca reactions add",
+        "Добавить реакцию на сообщение:\n  $ pachca reactions remove"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8015,7 +8307,6 @@
         "code": {
           "description": "Emoji символ реакции",
           "name": "code",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -8039,6 +8330,12 @@
       "scope": "reactions:write",
       "apiMethod": "POST",
       "apiPath": "/messages/{id}/reactions",
+      "defaultColumns": [
+        "name",
+        "created_at",
+        "user_id",
+        "code"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -8057,6 +8354,10 @@
         }
       },
       "description": "Список реакций",
+      "examples": [
+        "Добавить реакцию на сообщение:\n  $ pachca reactions add",
+        "Добавить реакцию на сообщение:\n  $ pachca reactions remove"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8160,18 +8461,24 @@
           "type": "boolean"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -8185,6 +8492,12 @@
       "scope": "reactions:read",
       "apiMethod": "GET",
       "apiPath": "/messages/{id}/reactions",
+      "defaultColumns": [
+        "name",
+        "created_at",
+        "user_id",
+        "code"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -8203,6 +8516,10 @@
         }
       },
       "description": "Удаление реакции",
+      "examples": [
+        "Добавить реакцию на сообщение:\n  $ pachca reactions add",
+        "Добавить реакцию на сообщение:\n  $ pachca reactions remove"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8308,7 +8625,6 @@
         "code": {
           "description": "Emoji символ реакции",
           "name": "code",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -8356,6 +8672,9 @@
         }
       },
       "description": "Список прочитавших сообщение",
+      "examples": [
+        "Проверить, кто прочитал сообщение:\n  $ pachca read-member list-readers"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8459,18 +8778,24 @@
           "type": "boolean"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -8496,6 +8821,9 @@
       "aliases": [],
       "args": {},
       "description": "Поиск чатов",
+      "examples": [
+        "Найти чат по названию:\n  $ pachca search list-chats"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8601,20 +8929,6 @@
         "query": {
           "description": "Текст поискового запроса",
           "name": "query",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "limit": {
-          "description": "Количество возвращаемых результатов за один запрос",
-          "name": "limit",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "cursor": {
-          "description": "Курсор для пагинации (из meta.paginate.next_page)",
-          "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -8647,7 +8961,7 @@
         "active": {
           "description": "Фильтр по активности чата",
           "name": "active",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         },
         "chat-subtype": {
@@ -8664,6 +8978,26 @@
         "personal": {
           "description": "Фильтр по личным чатам",
           "name": "personal",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "limit": {
+          "description": "Количество результатов на страницу",
+          "name": "limit",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cursor": {
+          "description": "Курсор для следующей страницы",
+          "name": "cursor",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
           "allowNo": false,
           "type": "boolean"
         }
@@ -8679,6 +9013,13 @@
       "scope": "search:chats",
       "apiMethod": "GET",
       "apiPath": "/search/chats",
+      "defaultColumns": [
+        "id",
+        "name",
+        "created_at",
+        "owner_id",
+        "channel"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -8691,6 +9032,9 @@
       "aliases": [],
       "args": {},
       "description": "Поиск сообщений",
+      "examples": [
+        "Найти сообщение по тексту:\n  $ pachca search list-messages"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8796,20 +9140,6 @@
         "query": {
           "description": "Текст поискового запроса",
           "name": "query",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "limit": {
-          "description": "Количество возвращаемых результатов за один запрос",
-          "name": "limit",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "cursor": {
-          "description": "Курсор для пагинации (из meta.paginate.next_page)",
-          "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -8840,14 +9170,14 @@
           "type": "option"
         },
         "chat-ids": {
-          "description": "Фильтр по ID чатов",
+          "description": "Фильтр по ID чатов (через запятую)",
           "name": "chat-ids",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "user-ids": {
-          "description": "Фильтр по ID авторов сообщений",
+          "description": "Фильтр по ID авторов сообщений (через запятую)",
           "name": "user-ids",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -8856,6 +9186,26 @@
         "active": {
           "description": "Фильтр по активности чата",
           "name": "active",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "limit": {
+          "description": "Количество результатов на страницу",
+          "name": "limit",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cursor": {
+          "description": "Курсор для следующей страницы",
+          "name": "cursor",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
           "allowNo": false,
           "type": "boolean"
         }
@@ -8871,6 +9221,13 @@
       "scope": "search:messages",
       "apiMethod": "GET",
       "apiPath": "/search/messages",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "entity_type",
+        "entity_id"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -8883,6 +9240,9 @@
       "aliases": [],
       "args": {},
       "description": "Поиск сотрудников",
+      "examples": [
+        "Найти сотрудника по имени:\n  $ pachca search list-users"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -8988,20 +9348,6 @@
         "query": {
           "description": "Текст поискового запроса",
           "name": "query",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "limit": {
-          "description": "Количество возвращаемых результатов за один запрос",
-          "name": "limit",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "cursor": {
-          "description": "Курсор для пагинации (из meta.paginate.next_page)",
-          "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -9043,11 +9389,31 @@
           "type": "option"
         },
         "company-roles": {
-          "description": "Фильтр по ролям сотрудников",
+          "description": "Фильтр по ролям сотрудников (через запятую)",
           "name": "company-roles",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "limit": {
+          "description": "Количество результатов на страницу",
+          "name": "limit",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cursor": {
+          "description": "Курсор для следующей страницы",
+          "name": "cursor",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -9061,6 +9427,13 @@
       "scope": "search:users",
       "apiMethod": "GET",
       "apiPath": "/search/users",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -9073,6 +9446,11 @@
       "aliases": [],
       "args": {},
       "description": "Журнал аудита событий",
+      "examples": [
+        "Получить журнал аудита событий:\n  $ pachca security list",
+        "Мониторинг подозрительных входов:\n  $ pachca security list",
+        "Экспорт логов за период:\n  $ pachca security list"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -9178,7 +9556,6 @@
         "start-time": {
           "description": "Начальная метка времени (включительно)",
           "name": "start-time",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -9186,7 +9563,6 @@
         "end-time": {
           "description": "Конечная метка времени (исключительно)",
           "name": "end-time",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -9264,18 +9640,24 @@
           "type": "option"
         },
         "limit": {
-          "description": "Количество записей для возврата",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации из meta.paginate.next_page",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -9290,6 +9672,13 @@
       "plan": "corporation",
       "apiMethod": "GET",
       "apiPath": "/audit_events",
+      "defaultColumns": [
+        "id",
+        "created_at",
+        "event_key",
+        "entity_id",
+        "entity_type"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -9308,6 +9697,10 @@
         }
       },
       "description": "Новый тред",
+      "examples": [
+        "Ответить в тред (комментарий к сообщению):\n  $ pachca thread add",
+        "Подписаться на тред сообщения:\n  $ pachca thread add"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -9422,6 +9815,13 @@
       "scope": "threads:create",
       "apiMethod": "POST",
       "apiPath": "/messages/{id}/thread",
+      "defaultColumns": [
+        "id",
+        "chat_id",
+        "message_id",
+        "message_chat_id",
+        "updated_at"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -9554,6 +9954,13 @@
       "scope": "threads:read",
       "apiMethod": "GET",
       "apiPath": "/threads/{id}",
+      "defaultColumns": [
+        "id",
+        "chat_id",
+        "message_id",
+        "message_chat_id",
+        "updated_at"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -9566,6 +9973,11 @@
       "aliases": [],
       "args": {},
       "description": "Новое напоминание",
+      "examples": [
+        "Создать напоминание:\n  $ pachca tasks create",
+        "Получить список предстоящих задач:\n  $ pachca tasks list",
+        "Создать серию напоминаний:\n  $ pachca tasks create"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -9671,7 +10083,6 @@
         "kind": {
           "description": "Тип",
           "name": "kind",
-          "required": true,
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
@@ -9714,7 +10125,7 @@
         "all-day": {
           "description": "Напоминание на весь день (без указания времени)",
           "name": "all-day",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         },
         "custom-properties": {
@@ -9736,6 +10147,13 @@
       "scope": "tasks:create",
       "apiMethod": "POST",
       "apiPath": "/tasks",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "kind",
+        "due_at"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -9754,6 +10172,11 @@
         }
       },
       "description": "Удаление напоминания",
+      "examples": [
+        "Получить задачу по ID:\n  $ pachca tasks get",
+        "Отметить задачу выполненной:\n  $ pachca tasks update",
+        "Обновить задачу (перенести срок, сменить ответственных):\n  $ pachca tasks update"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -9892,6 +10315,11 @@
         }
       },
       "description": "Информация о напоминании",
+      "examples": [
+        "Получить задачу по ID:\n  $ pachca tasks get",
+        "Отметить задачу выполненной:\n  $ pachca tasks update",
+        "Обновить задачу (перенести срок, сменить ответственных):\n  $ pachca tasks update"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -10006,6 +10434,13 @@
       "scope": "tasks:read",
       "apiMethod": "GET",
       "apiPath": "/tasks/{id}",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "kind",
+        "due_at"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -10018,6 +10453,11 @@
       "aliases": [],
       "args": {},
       "description": "Список напоминаний",
+      "examples": [
+        "Создать напоминание:\n  $ pachca tasks create",
+        "Получить список предстоящих задач:\n  $ pachca tasks list",
+        "Создать серию напоминаний:\n  $ pachca tasks create"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -10121,18 +10561,24 @@
           "type": "boolean"
         },
         "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
+          "description": "Количество результатов на страницу",
           "name": "limit",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
         },
         "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
+          "description": "Курсор для следующей страницы",
           "name": "cursor",
           "hasDynamicHelp": false,
           "multiple": false,
           "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
@@ -10146,6 +10592,13 @@
       "scope": "tasks:read",
       "apiMethod": "GET",
       "apiPath": "/tasks",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "kind",
+        "due_at"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -10164,6 +10617,11 @@
         }
       },
       "description": "Редактирование напоминания",
+      "examples": [
+        "Получить задачу по ID:\n  $ pachca tasks get",
+        "Отметить задачу выполненной:\n  $ pachca tasks update",
+        "Обновить задачу (перенести срок, сменить ответственных):\n  $ pachca tasks update"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -10311,7 +10769,7 @@
         "all-day": {
           "description": "Напоминание на весь день (без указания времени)",
           "name": "all-day",
-          "allowNo": false,
+          "allowNo": true,
           "type": "boolean"
         },
         "done-at": {
@@ -10340,6 +10798,13 @@
       "scope": "tasks:update",
       "apiMethod": "PUT",
       "apiPath": "/tasks/{id}",
+      "defaultColumns": [
+        "id",
+        "content",
+        "created_at",
+        "kind",
+        "due_at"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
@@ -10348,1178 +10813,15 @@
         "update.js"
       ]
     },
-    "views:open": {
-      "aliases": [],
-      "args": {},
-      "description": "Открытие представления",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "type": {
-          "description": "Способ открытия представления",
-          "name": "type",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "modal"
-          ],
-          "type": "option"
-        },
-        "trigger-id": {
-          "description": "Уникальный идентификатор события (полученный, например, в исходящем вебхуке о нажатии кнопки)",
-          "name": "trigger-id",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "private-metadata": {
-          "description": "Необязательная строка, которая будет отправлена в ваше приложение при отправке пользователем заполненной формы. Используйте это поле, например, для передачи в формате `JSON` какой то дополнительной информации вместе с заполненной пользователем формой. (макс. 3000 символов)",
-          "name": "private-metadata",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "callback-id": {
-          "description": "Необязательный идентификатор для распознавания этого представления, который будет отправлен в ваше приложение при отправке пользователем заполненной формы. Используйте это поле, например, для понимания, какую форму должен был заполнить пользователь. (макс. 255 символов)",
-          "name": "callback-id",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "view": {
-          "description": "Собранный объект представления",
-          "name": "view",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "views:open",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "views:write",
-      "apiMethod": "POST",
-      "apiPath": "/views/open",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "views",
-        "open.js"
-      ]
-    },
     "users:create": {
       "aliases": [],
       "args": {},
       "description": "Создать сотрудника",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "user": {
-          "description": "user",
-          "name": "user",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "skip-email-notify": {
-          "description": "Пропуск этапа отправки приглашения сотруднику. Сотруднику не будет отправлено письмо на электронную почту с приглашением создать аккаунт. Полезно при предварительном создании аккаунтов перед входом через SSO.",
-          "name": "skip-email-notify",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:create",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "users:create",
-      "apiMethod": "POST",
-      "apiPath": "/users",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "create.js"
-      ]
-    },
-    "users:delete": {
-      "aliases": [],
-      "args": {
-        "id": {
-          "description": "Идентификатор пользователя",
-          "name": "id",
-          "required": true
-        }
-      },
-      "description": "Удаление сотрудника",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "Пропустить подтверждение",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:delete",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "users:delete",
-      "apiMethod": "DELETE",
-      "apiPath": "/users/{id}",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "delete.js"
-      ]
-    },
-    "users:get-status": {
-      "aliases": [],
-      "args": {
-        "user_id": {
-          "description": "Идентификатор пользователя",
-          "name": "user_id",
-          "required": true
-        }
-      },
-      "description": "Статус сотрудника",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:get-status",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "user_status:read",
-      "apiMethod": "GET",
-      "apiPath": "/users/{user_id}/status",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "get-status.js"
-      ]
-    },
-    "users:get": {
-      "aliases": [],
-      "args": {
-        "id": {
-          "description": "Идентификатор пользователя",
-          "name": "id",
-          "required": true
-        }
-      },
-      "description": "Информация о сотруднике",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:get",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "users:read",
-      "apiMethod": "GET",
-      "apiPath": "/users/{id}",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "get.js"
-      ]
-    },
-    "users:list": {
-      "aliases": [],
-      "args": {},
-      "description": "Список сотрудников",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "query": {
-          "description": "Поисковая фраза для фильтрации результатов. Поиск работает по полям: `first_name` (имя), `last_name` (фамилия), `email` (электронная почта), `phone_number` (телефон) и `nickname` (никнейм).",
-          "name": "query",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "limit": {
-          "description": "Количество возвращаемых сущностей за один запрос",
-          "name": "limit",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "cursor": {
-          "description": "Курсор для пагинации (из `meta.paginate.next_page`)",
-          "name": "cursor",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:list",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "users:read",
-      "apiMethod": "GET",
-      "apiPath": "/users",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "list.js"
-      ]
-    },
-    "users:remove-status": {
-      "aliases": [],
-      "args": {
-        "user_id": {
-          "description": "Идентификатор пользователя",
-          "name": "user_id",
-          "required": true
-        }
-      },
-      "description": "Удаление статуса сотрудника",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "force": {
-          "description": "Пропустить подтверждение",
-          "name": "force",
-          "allowNo": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:remove-status",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "user_status:write",
-      "apiMethod": "DELETE",
-      "apiPath": "/users/{user_id}/status",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "remove-status.js"
-      ]
-    },
-    "users:update-status": {
-      "aliases": [],
-      "args": {
-        "user_id": {
-          "description": "Идентификатор пользователя",
-          "name": "user_id",
-          "required": true
-        }
-      },
-      "description": "Новый статус сотрудника",
-      "flags": {
-        "output": {
-          "char": "o",
-          "description": "Output format: table, json, yaml, csv",
-          "name": "output",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "options": [
-            "table",
-            "json",
-            "yaml",
-            "csv"
-          ],
-          "type": "option"
-        },
-        "columns": {
-          "char": "c",
-          "description": "Columns to display (comma-separated)",
-          "name": "columns",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-header": {
-          "description": "Hide table header",
-          "name": "no-header",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-truncate": {
-          "description": "Do not truncate values in table",
-          "name": "no-truncate",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "profile": {
-          "char": "p",
-          "description": "Profile to use for this command",
-          "name": "profile",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "token": {
-          "description": "Bearer token for this call (not saved)",
-          "name": "token",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "quiet": {
-          "char": "q",
-          "description": "Suppress output except errors",
-          "name": "quiet",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "description": "Disable color output",
-          "name": "no-color",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "char": "v",
-          "description": "Show HTTP request/response details",
-          "name": "verbose",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "no-input": {
-          "description": "Disable interactive prompts",
-          "name": "no-input",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "dry-run": {
-          "description": "Show HTTP request without sending",
-          "name": "dry-run",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Request timeout in seconds",
-          "name": "timeout",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "no-retry": {
-          "description": "Disable auto-retry on 429/503",
-          "name": "no-retry",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "json": {
-          "description": "Output as JSON (alias for --output json)",
-          "hidden": true,
-          "name": "json",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "emoji": {
-          "description": "Emoji символ статуса",
-          "name": "emoji",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "title": {
-          "description": "Текст статуса",
-          "name": "title",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "expires-at": {
-          "description": "Срок жизни статуса (ISO-8601, UTC+0) в формате YYYY-MM-DDThh:mm:ss.sssZ",
-          "name": "expires-at",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "is-away": {
-          "description": "Режим «Нет на месте»",
-          "name": "is-away",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "away-message": {
-          "description": "Текст сообщения при режиме «Нет на месте». Отображается в профиле и при личных сообщениях/упоминаниях. (макс. 1024 символов)",
-          "name": "away-message",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "users:update-status",
-      "pluginAlias": "@pachca/cli",
-      "pluginName": "@pachca/cli",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "scope": "user_status:write",
-      "apiMethod": "PUT",
-      "apiPath": "/users/{user_id}/status",
-      "isESM": true,
-      "relativePath": [
-        "dist",
-        "commands",
-        "users",
-        "update-status.js"
-      ]
-    },
-    "users:update": {
-      "aliases": [],
-      "args": {
-        "id": {
-          "description": "Идентификатор пользователя",
-          "name": "id",
-          "required": true
-        }
-      },
-      "description": "Редактирование сотрудника",
+      "examples": [
+        "Отправить личное сообщение пользователю:\n  $ pachca users list",
+        "Упомянуть пользователя по имени:\n  $ pachca users list",
+        "Проверить, кто прочитал сообщение:\n  $ pachca users list"
+      ],
       "flags": {
         "output": {
           "char": "o",
@@ -11681,7 +10983,1148 @@
         "suspended": {
           "description": "Деактивация пользователя",
           "name": "suspended",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "list-tags": {
+          "description": "Массив тегов, привязываемых к сотруднику",
+          "name": "list-tags",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "custom-properties": {
+          "description": "Задаваемые дополнительные поля",
+          "name": "custom-properties",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "skip-email-notify": {
+          "description": "Пропуск этапа отправки приглашения сотруднику. Сотруднику не будет отправлено письмо на электронную почту с приглашением создать аккаунт. Полезно при предварительном создании аккаунтов перед входом через SSO.",
+          "name": "skip-email-notify",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:create",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "users:create",
+      "apiMethod": "POST",
+      "apiPath": "/users",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "create.js"
+      ]
+    },
+    "users:delete": {
+      "aliases": [],
+      "args": {
+        "id": {
+          "description": "Идентификатор пользователя",
+          "name": "id",
+          "required": true
+        }
+      },
+      "description": "Удаление сотрудника",
+      "examples": [
+        "Получить сотрудника по ID:\n  $ pachca users get",
+        "Массовое создание сотрудников с тегами:\n  $ pachca users update",
+        "Offboarding сотрудника:\n  $ pachca users update"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
           "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "Пропустить подтверждение",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:delete",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "users:delete",
+      "apiMethod": "DELETE",
+      "apiPath": "/users/{id}",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "delete.js"
+      ]
+    },
+    "users:get-status": {
+      "aliases": [],
+      "args": {
+        "user_id": {
+          "description": "Идентификатор пользователя",
+          "name": "user_id",
+          "required": true
+        }
+      },
+      "description": "Статус сотрудника",
+      "examples": [
+        "Управление статусом сотрудника:\n  $ pachca users get-status",
+        "Управление статусом сотрудника:\n  $ pachca users update-status",
+        "Управление статусом сотрудника:\n  $ pachca users remove-status"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:get-status",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "user_status:read",
+      "apiMethod": "GET",
+      "apiPath": "/users/{user_id}/status",
+      "defaultColumns": [
+        "title",
+        "emoji",
+        "expires_at",
+        "is_away"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "get-status.js"
+      ]
+    },
+    "users:get": {
+      "aliases": [],
+      "args": {
+        "id": {
+          "description": "Идентификатор пользователя",
+          "name": "id",
+          "required": true
+        }
+      },
+      "description": "Информация о сотруднике",
+      "examples": [
+        "Получить сотрудника по ID:\n  $ pachca users get",
+        "Массовое создание сотрудников с тегами:\n  $ pachca users update",
+        "Offboarding сотрудника:\n  $ pachca users update"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:get",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "users:read",
+      "apiMethod": "GET",
+      "apiPath": "/users/{id}",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "get.js"
+      ]
+    },
+    "users:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Список сотрудников",
+      "examples": [
+        "Отправить личное сообщение пользователю:\n  $ pachca users list",
+        "Упомянуть пользователя по имени:\n  $ pachca users list",
+        "Проверить, кто прочитал сообщение:\n  $ pachca users list"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "query": {
+          "description": "Поисковая фраза для фильтрации результатов. Поиск работает по полям: `first_name` (имя), `last_name` (фамилия), `email` (электронная почта), `phone_number` (телефон) и `nickname` (никнейм).",
+          "name": "query",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "limit": {
+          "description": "Количество результатов на страницу",
+          "name": "limit",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cursor": {
+          "description": "Курсор для следующей страницы",
+          "name": "cursor",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "all": {
+          "description": "Загрузить все страницы автоматически",
+          "name": "all",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:list",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "users:read",
+      "apiMethod": "GET",
+      "apiPath": "/users",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "list.js"
+      ]
+    },
+    "users:remove-status": {
+      "aliases": [],
+      "args": {
+        "user_id": {
+          "description": "Идентификатор пользователя",
+          "name": "user_id",
+          "required": true
+        }
+      },
+      "description": "Удаление статуса сотрудника",
+      "examples": [
+        "Управление статусом сотрудника:\n  $ pachca users get-status",
+        "Управление статусом сотрудника:\n  $ pachca users update-status",
+        "Управление статусом сотрудника:\n  $ pachca users remove-status"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "description": "Пропустить подтверждение",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:remove-status",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "user_status:write",
+      "apiMethod": "DELETE",
+      "apiPath": "/users/{user_id}/status",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "remove-status.js"
+      ]
+    },
+    "users:update-status": {
+      "aliases": [],
+      "args": {
+        "user_id": {
+          "description": "Идентификатор пользователя",
+          "name": "user_id",
+          "required": true
+        }
+      },
+      "description": "Новый статус сотрудника",
+      "examples": [
+        "Управление статусом сотрудника:\n  $ pachca users get-status",
+        "Управление статусом сотрудника:\n  $ pachca users update-status",
+        "Управление статусом сотрудника:\n  $ pachca users remove-status"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "emoji": {
+          "description": "Emoji символ статуса",
+          "name": "emoji",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "title": {
+          "description": "Текст статуса",
+          "name": "title",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "expires-at": {
+          "description": "Срок жизни статуса (ISO-8601, UTC+0) в формате YYYY-MM-DDThh:mm:ss.sssZ",
+          "name": "expires-at",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "is-away": {
+          "description": "Режим «Нет на месте»",
+          "name": "is-away",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "away-message": {
+          "description": "Текст сообщения при режиме «Нет на месте». Отображается в профиле и при личных сообщениях/упоминаниях. (макс. 1024 символов)",
+          "name": "away-message",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "users:update-status",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "user_status:write",
+      "apiMethod": "PUT",
+      "apiPath": "/users/{user_id}/status",
+      "defaultColumns": [
+        "title",
+        "emoji",
+        "expires_at",
+        "is_away"
+      ],
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "users",
+        "update-status.js"
+      ]
+    },
+    "users:update": {
+      "aliases": [],
+      "args": {
+        "id": {
+          "description": "Идентификатор пользователя",
+          "name": "id",
+          "required": true
+        }
+      },
+      "description": "Редактирование сотрудника",
+      "examples": [
+        "Получить сотрудника по ID:\n  $ pachca users get",
+        "Массовое создание сотрудников с тегами:\n  $ pachca users update",
+        "Offboarding сотрудника:\n  $ pachca users update"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "first-name": {
+          "description": "Имя",
+          "name": "first-name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "last-name": {
+          "description": "Фамилия",
+          "name": "last-name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "email": {
+          "description": "Электронная почта",
+          "name": "email",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "phone-number": {
+          "description": "Телефон",
+          "name": "phone-number",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nickname": {
+          "description": "Имя пользователя",
+          "name": "nickname",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "department": {
+          "description": "Департамент",
+          "name": "department",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "title": {
+          "description": "Должность",
+          "name": "title",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "role": {
+          "description": "Уровень доступа",
+          "name": "role",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "suspended": {
+          "description": "Деактивация пользователя",
+          "name": "suspended",
+          "allowNo": true,
           "type": "boolean"
         },
         "list-tags": {
@@ -11710,12 +12153,208 @@
       "scope": "users:update",
       "apiMethod": "PUT",
       "apiPath": "/users/{id}",
+      "defaultColumns": [
+        "id",
+        "title",
+        "first_name",
+        "last_name",
+        "email"
+      ],
       "isESM": true,
       "relativePath": [
         "dist",
         "commands",
         "users",
         "update.js"
+      ]
+    },
+    "views:open": {
+      "aliases": [],
+      "args": {},
+      "description": "Открытие представления",
+      "examples": [
+        "Показать интерактивную форму пользователю:\n  $ pachca views open",
+        "Опрос сотрудников через форму:\n  $ pachca views open"
+      ],
+      "flags": {
+        "output": {
+          "char": "o",
+          "description": "Output format: table, json, yaml, csv",
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "table",
+            "json",
+            "yaml",
+            "csv"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Columns to display (comma-separated)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "Hide table header",
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "Do not truncate values in table",
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "char": "p",
+          "description": "Profile to use for this command",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "description": "Bearer token for this call (not saved)",
+          "name": "token",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "quiet": {
+          "char": "q",
+          "description": "Suppress output except errors",
+          "name": "quiet",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-color": {
+          "description": "Disable color output",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show HTTP request/response details",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-input": {
+          "description": "Disable interactive prompts",
+          "name": "no-input",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "dry-run": {
+          "description": "Show HTTP request without sending",
+          "name": "dry-run",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Request timeout in seconds",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-retry": {
+          "description": "Disable auto-retry on 429/503",
+          "name": "no-retry",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output as JSON (alias for --output json)",
+          "hidden": true,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Заголовок представления (макс. 24 символов)",
+          "name": "title",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "close-text": {
+          "description": "Текст кнопки закрытия представления (макс. 24 символов)",
+          "name": "close-text",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "submit-text": {
+          "description": "Текст кнопки отправки формы (макс. 24 символов)",
+          "name": "submit-text",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "blocks": {
+          "description": "Массив блоков представления",
+          "name": "blocks",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "type": {
+          "description": "Способ открытия представления",
+          "name": "type",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "modal"
+          ],
+          "type": "option"
+        },
+        "trigger-id": {
+          "description": "Уникальный идентификатор события (полученный, например, в исходящем вебхуке о нажатии кнопки)",
+          "name": "trigger-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "private-metadata": {
+          "description": "Необязательная строка, которая будет отправлена в ваше приложение при отправке пользователем заполненной формы. Используйте это поле, например, для передачи в формате `JSON` какой то дополнительной информации вместе с заполненной пользователем формой. (макс. 3000 символов)",
+          "name": "private-metadata",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "callback-id": {
+          "description": "Необязательный идентификатор для распознавания этого представления, который будет отправлен в ваше приложение при отправке пользователем заполненной формы. Используйте это поле, например, для понимания, какую форму должен был заполнить пользователь. (макс. 255 символов)",
+          "name": "callback-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "views:open",
+      "pluginAlias": "@pachca/cli",
+      "pluginName": "@pachca/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "scope": "views:write",
+      "apiMethod": "POST",
+      "apiPath": "/views/open",
+      "isESM": true,
+      "relativePath": [
+        "dist",
+        "commands",
+        "views",
+        "open.js"
       ]
     }
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,8 +20,8 @@
     "build": "tsx scripts/generate-cli.ts && tsc && oclif manifest",
     "dev": "node --import tsx bin/dev.js",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
-    "generate": "tsx scripts/generate-cli.ts"
+    "test": "tsc && vitest run",
+    "generate-cli": "tsx scripts/generate-cli.ts"
   },
   "oclif": {
     "bin": "pachca",

--- a/packages/cli/scripts/generate-cli.ts
+++ b/packages/cli/scripts/generate-cli.ts
@@ -335,7 +335,17 @@ interface BodyField {
   maxLength?: number;
   maximum?: number;
   minimum?: number;
+  isSibling?: boolean;
 }
+
+/** Wire names for multipart/form-data fields that differ from schema property names */
+const MULTIPART_WIRE_NAMES: Record<string, string> = {
+  contentDisposition: 'Content-Disposition',
+  xAmzCredential: 'x-amz-credential',
+  xAmzAlgorithm: 'x-amz-algorithm',
+  xAmzDate: 'x-amz-date',
+  xAmzSignature: 'x-amz-signature',
+};
 
 function extractBodyFields(requestBody?: RequestBody): BodyField[] {
   if (!requestBody) return [];
@@ -353,14 +363,20 @@ function extractBodyFields(requestBody?: RequestBody): BodyField[] {
   const properties = resolved.properties || {};
   const requiredFields = new Set(resolved.required || []);
 
-  // Check if top-level is a wrapper (single property that's an object)
+  // Check if top-level has exactly one object property that can be unwrapped
   const topKeys = Object.keys(properties);
-  if (topKeys.length === 1) {
-    const wrapper = properties[topKeys[0]];
+  const objectKeys = topKeys.filter((k) => {
+    const inner = resolveAllOf(properties[k]);
+    return inner.properties && Object.keys(inner.properties).length > 0;
+  });
+
+  if (objectKeys.length === 1) {
+    const wrapperKey = objectKeys[0];
+    const wrapper = properties[wrapperKey];
     const innerResolved = resolveAllOf(wrapper);
     if (innerResolved.properties) {
       const innerRequired = new Set(innerResolved.required || []);
-      return Object.entries(innerResolved.properties)
+      const fields: BodyField[] = Object.entries(innerResolved.properties)
         .filter(([, v]) => !v.readOnly)
         .map(([name, propSchema]) => ({
           name,
@@ -373,6 +389,26 @@ function extractBodyFields(requestBody?: RequestBody): BodyField[] {
           maximum: propSchema.maximum,
           minimum: propSchema.minimum,
         }));
+
+      // Add sibling scalar fields (non-object top-level properties)
+      for (const key of topKeys) {
+        if (key === wrapperKey) continue;
+        const propSchema = resolveAllOf(properties[key]);
+        fields.push({
+          name: key,
+          type: getSchemaType(propSchema),
+          format: propSchema.format,
+          required: requiredFields.has(key),
+          description: propSchema.description,
+          enum: propSchema.enum,
+          maxLength: propSchema.maxLength,
+          maximum: propSchema.maximum,
+          minimum: propSchema.minimum,
+          isSibling: true,
+        });
+      }
+
+      return fields;
     }
   }
 
@@ -525,10 +561,6 @@ function generateCommandCode(p: CommandGenParams): string {
     imports.push(`import { downloadFile } from '../../client.js';`);
     imports.push(`import { formatSize } from '../../utils.js';`);
   }
-  if (p.stdinField) {
-    imports.push(`import { Readable } from 'node:stream';`);
-  }
-
   // Build args
   const argsCode = p.pathParams.map((param) => {
     const argName = param.name.replace(/[{}]/g, '');
@@ -559,6 +591,7 @@ function generateCommandCode(p: CommandGenParams): string {
     const flagType = getOclifFlagType(param.schema);
     const extras: string[] = [];
     if (param.schema.enum) extras.push(`      options: ${JSON.stringify(param.schema.enum)},`);
+    if (flagType === 'boolean') extras.push(`      allowNo: true,`);
     const extrasStr = extras.length > 0 ? '\n' + extras.join('\n') : '';
     queryFlagLines.push(`    '${flagName}': Flags.${flagType}({
       description: ${JSON.stringify(param.description || param.name)},${extrasStr}
@@ -594,6 +627,7 @@ function generateCommandCode(p: CommandGenParams): string {
     const maxLenComment = field.maxLength ? ` (макс. ${field.maxLength} символов)` : '';
     const bodyExtras: string[] = [];
     if (field.enum) bodyExtras.push(`      options: ${JSON.stringify(field.enum)},`);
+    if (flagType === 'boolean') bodyExtras.push(`      allowNo: true,`);
     const bodyExtrasStr = bodyExtras.length > 0 ? '\n' + bodyExtras.join('\n') : '';
     bodyFlagLines.push(`    '${flagName}': Flags.${flagType}({
       description: ${JSON.stringify((field.description || field.name) + maxLenComment)},${bodyExtrasStr}
@@ -737,22 +771,26 @@ function generateCommandCode(p: CommandGenParams): string {
   }
 
   // Build request body object
-  const bodyEntries: string[] = [];
+  const wrapperEntries: string[] = [];
+  const siblingEntries: string[] = [];
   const jsonContent = p.endpoint.requestBody?.content['application/json'];
   const wrapperKey = jsonContent ? getWrapperKey(jsonContent.schema) : null;
 
   for (const field of p.bodyFields) {
     if (field.format === 'binary') continue;
     const flagName = field.name.replace(/_/g, '-');
+    let entry: string;
     // Parse JSON array/object flags
     if (field.type === 'array' || field.type === 'object') {
-      bodyEntries.push(`      ${field.name}: flags['${flagName}'] ? this.parseJSON(flags['${flagName}'], '${flagName}') : undefined,`);
-    } else if (field.type === 'integer' || field.type === 'number') {
-      bodyEntries.push(`      ${field.name}: flags['${flagName}'],`);
-    } else if (field.type === 'boolean') {
-      bodyEntries.push(`      ${field.name}: flags['${flagName}'],`);
+      entry = `      ${field.name}: flags['${flagName}'] ? this.parseJSON(flags['${flagName}'], '${flagName}') : undefined,`;
     } else {
-      bodyEntries.push(`      ${field.name}: flags['${flagName}'],`);
+      entry = `      ${field.name}: flags['${flagName}'],`;
+    }
+
+    if (wrapperKey && field.isSibling) {
+      siblingEntries.push(entry);
+    } else {
+      wrapperEntries.push(entry);
     }
   }
 
@@ -827,7 +865,8 @@ function generateCommandCode(p: CommandGenParams): string {
     for (const field of p.bodyFields) {
       if (field.format === 'binary') continue;
       const flagName = field.name.replace(/_/g, '-');
-      runBodyLines.push(`      if (flags['${flagName}']) formData.append('${field.name}', String(flags['${flagName}']));`);
+      const wireName = MULTIPART_WIRE_NAMES[field.name] || field.name;
+      runBodyLines.push(`      if (flags['${flagName}']) formData.append('${wireName}', String(flags['${flagName}']));`);
     }
     runBodyLines.push(`    }`);
     runBodyLines.push('');
@@ -841,10 +880,17 @@ function generateCommandCode(p: CommandGenParams): string {
     }
     runBodyLines.push(`      formData,`);
     runBodyLines.push(`    });`);
-  } else if (bodyEntries.length > 0) {
-    const bodyObj = wrapperKey
-      ? `{ ${wrapperKey}: {\n${bodyEntries.join('\n')}\n    } }`
-      : `{\n${bodyEntries.join('\n')}\n    }`;
+  } else if (wrapperEntries.length > 0 || siblingEntries.length > 0) {
+    let bodyObj: string;
+    if (wrapperKey) {
+      if (siblingEntries.length > 0) {
+        bodyObj = `{\n      ${wrapperKey}: {\n${wrapperEntries.join('\n')}\n      },\n${siblingEntries.join('\n')}\n    }`;
+      } else {
+        bodyObj = `{ ${wrapperKey}: {\n${wrapperEntries.join('\n')}\n    } }`;
+      }
+    } else {
+      bodyObj = `{\n${wrapperEntries.join('\n')}\n    }`;
+    }
 
     // Clean undefined fields
     runBodyLines.push(`    const body: Record<string, unknown> = ${bodyObj};`);
@@ -852,9 +898,26 @@ function generateCommandCode(p: CommandGenParams): string {
     if (wrapperKey) {
       runBodyLines.push(`    const inner = body['${wrapperKey}'] as Record<string, unknown>;`);
       runBodyLines.push(`    for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }`);
+      if (siblingEntries.length > 0) {
+        runBodyLines.push(`    for (const [k, v] of Object.entries(body)) { if (k !== '${wrapperKey}' && v === undefined) delete body[k]; }`);
+      }
     } else {
       runBodyLines.push(`    for (const [k, v] of Object.entries(body)) { if (v === undefined) delete body[k]; }`);
     }
+
+    // Empty body warning for update commands
+    if (p.endpoint.method === 'PUT' || p.endpoint.method === 'PATCH') {
+      runBodyLines.push('');
+      if (wrapperKey) {
+        runBodyLines.push(`    if (Object.keys(inner).length === 0) {`);
+      } else {
+        runBodyLines.push(`    if (Object.keys(body).length === 0) {`);
+      }
+      runBodyLines.push(`      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\\n');`);
+      runBodyLines.push(`      return;`);
+      runBodyLines.push(`    }`);
+    }
+
     runBodyLines.push('');
     runBodyLines.push(`    const { data } = await this.apiRequest({`);
     runBodyLines.push(`      method: '${p.endpoint.method}',`);
@@ -950,10 +1013,11 @@ function getWrapperKey(schema: Schema): string | null {
   const resolved = resolveAllOf(schema);
   if (!resolved.properties) return null;
   const keys = Object.keys(resolved.properties);
-  if (keys.length === 1) {
-    const inner = resolveAllOf(resolved.properties[keys[0]]);
-    if (inner.properties) return keys[0];
-  }
+  const objectKeys = keys.filter((k) => {
+    const inner = resolveAllOf(resolved.properties![k]);
+    return inner.properties && Object.keys(inner.properties).length > 0;
+  });
+  if (objectKeys.length === 1) return objectKeys[0];
   return null;
 }
 

--- a/packages/cli/scripts/generate-cli.ts
+++ b/packages/cli/scripts/generate-cli.ts
@@ -15,7 +15,7 @@ import * as yaml from 'js-yaml';
 // We read the openapi.yaml directly instead of importing parser.ts to avoid
 // complex cross-package path resolution at build time.
 
-interface Schema {
+export interface Schema {
   type?: string | string[];
   format?: string;
   description?: string;
@@ -42,7 +42,7 @@ interface Schema {
   additionalProperties?: boolean | Schema;
 }
 
-interface Parameter {
+export interface Parameter {
   name: string;
   in: 'query' | 'path' | 'header' | 'cookie';
   description?: string;
@@ -51,19 +51,19 @@ interface Parameter {
   'x-param-names'?: { name: string; description?: string }[];
 }
 
-interface RequestBody {
+export interface RequestBody {
   description?: string;
   required?: boolean;
   content: Record<string, { schema: Schema }>;
 }
 
-interface Response {
+export interface Response {
   description: string;
   content?: Record<string, { schema: Schema }>;
   headers?: Record<string, { description?: string; schema?: Schema }>;
 }
 
-interface Endpoint {
+export interface Endpoint {
   id: string;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   path: string;
@@ -90,7 +90,7 @@ import { generateUrlFromOperation } from '../../../apps/docs/lib/openapi/mapper.
 
 // ----- OpenAPI Parsing -----
 
-function parseOpenAPI(): Endpoint[] {
+export function parseOpenAPI(): Endpoint[] {
   const raw = fs.readFileSync(SPEC_PATH, 'utf-8');
   const spec = yaml.load(raw) as Record<string, unknown>;
   const paths = (spec.paths || {}) as Record<string, Record<string, unknown>>;
@@ -325,7 +325,7 @@ function generateCommand(endpoint: Endpoint, examples?: string[]): GeneratedComm
   return { section, action, filename, code, summary };
 }
 
-interface BodyField {
+export interface BodyField {
   name: string;
   type: string;
   format?: string;
@@ -339,7 +339,7 @@ interface BodyField {
 }
 
 /** Wire names for multipart/form-data fields that differ from schema property names */
-const MULTIPART_WIRE_NAMES: Record<string, string> = {
+export const MULTIPART_WIRE_NAMES: Record<string, string> = {
   contentDisposition: 'Content-Disposition',
   xAmzCredential: 'x-amz-credential',
   xAmzAlgorithm: 'x-amz-algorithm',
@@ -347,7 +347,15 @@ const MULTIPART_WIRE_NAMES: Record<string, string> = {
   xAmzSignature: 'x-amz-signature',
 };
 
-function extractBodyFields(requestBody?: RequestBody): BodyField[] {
+/** Convert camelCase/snake_case to kebab-case for flag names */
+export function toKebabCase(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/_/g, '-')
+    .toLowerCase();
+}
+
+export function extractBodyFields(requestBody?: RequestBody): BodyField[] {
   if (!requestBody) return [];
 
   const jsonContent = requestBody.content['application/json'];
@@ -428,7 +436,7 @@ function extractBodyFields(requestBody?: RequestBody): BodyField[] {
     }));
 }
 
-function resolveAllOf(schema: Schema): Schema {
+export function resolveAllOf(schema: Schema): Schema {
   if (!schema.allOf || schema.allOf.length === 0) return schema;
   let merged: Schema = {};
   for (const sub of schema.allOf) {
@@ -443,7 +451,7 @@ function resolveAllOf(schema: Schema): Schema {
   return merged;
 }
 
-function getSchemaType(schema: Schema): string {
+export function getSchemaType(schema: Schema): string {
   if (schema.type) {
     if (Array.isArray(schema.type)) return schema.type[0];
     return schema.type;
@@ -525,7 +533,7 @@ function generateCommandCode(p: CommandGenParams): string {
     if (param['x-param-names']) continue;
     if (param.required) {
       requiredQueryFlags.push({
-        flagName: param.name.replace(/_/g, '-'),
+        flagName: toKebabCase(param.name),
         description: param.description || param.name,
         type: getOclifFlagType(param.schema),
       });
@@ -536,7 +544,7 @@ function generateCommandCode(p: CommandGenParams): string {
     if (p.hasBinaryField && field.format === 'binary') continue;
     if (field.required) {
       requiredBodyFlags.push({
-        flagName: field.name.replace(/_/g, '-'),
+        flagName: toKebabCase(field.name),
         description: field.description || field.name,
         type: getOclifFlagType({ type: field.type, enum: field.enum } as Schema),
       });
@@ -579,7 +587,7 @@ function generateCommandCode(p: CommandGenParams): string {
     // Handle x-param-names (composite params like sort[{field}])
     if (param['x-param-names']) {
       for (const sub of param['x-param-names']) {
-        const flagName = sub.name.replace(/[\[\]]/g, '-').replace(/-+/g, '-').replace(/-$/, '');
+        const flagName = toKebabCase(sub.name.replace(/[\[\]]/g, '-').replace(/-+/g, '-').replace(/-$/, ''));
         queryFlagLines.push(`    '${flagName}': Flags.string({
       description: ${JSON.stringify(sub.description || sub.name)},
     }),`);
@@ -587,14 +595,15 @@ function generateCommandCode(p: CommandGenParams): string {
       continue;
     }
 
-    const flagName = param.name.replace(/_/g, '-');
+    const flagName = toKebabCase(param.name);
     const flagType = getOclifFlagType(param.schema);
     const extras: string[] = [];
     if (param.schema.enum) extras.push(`      options: ${JSON.stringify(param.schema.enum)},`);
     if (flagType === 'boolean') extras.push(`      allowNo: true,`);
     const extrasStr = extras.length > 0 ? '\n' + extras.join('\n') : '';
+    const arrayHint = param.schema.type === 'array' ? ' (через запятую)' : '';
     queryFlagLines.push(`    '${flagName}': Flags.${flagType}({
-      description: ${JSON.stringify(param.description || param.name)},${extrasStr}
+      description: ${JSON.stringify(param.description || param.name)}${arrayHint ? ` + ${JSON.stringify(arrayHint)}` : ''},${extrasStr}
     }),`);
   }
 
@@ -622,7 +631,7 @@ function generateCommandCode(p: CommandGenParams): string {
       continue;
     }
 
-    const flagName = field.name.replace(/_/g, '-');
+    const flagName = toKebabCase(field.name);
     const flagType = getOclifFlagType({ type: field.type, enum: field.enum } as Schema);
     const maxLenComment = field.maxLength ? ` (макс. ${field.maxLength} символов)` : '';
     const bodyExtras: string[] = [];
@@ -658,7 +667,7 @@ function generateCommandCode(p: CommandGenParams): string {
 
   // Stdin support for text fields
   if (p.stdinField) {
-    const flagName = p.stdinField.name.replace(/_/g, '-');
+    const flagName = toKebabCase(p.stdinField.name);
     runBodyLines.push('');
     runBodyLines.push(`    // Read from stdin if --${flagName} not provided and stdin is not TTY`);
     runBodyLines.push(`    if (!flags['${flagName}'] && !process.stdin.isTTY) {`);
@@ -700,7 +709,7 @@ function generateCommandCode(p: CommandGenParams): string {
   // Validation
   const validations: string[] = [];
   for (const field of p.bodyFields) {
-    const flagName = field.name.replace(/_/g, '-');
+    const flagName = toKebabCase(field.name);
     if (field.maxLength) {
       validations.push(`    if (flags['${flagName}'] && String(flags['${flagName}']).length > ${field.maxLength}) {
       process.stderr.write(\`✗ --${flagName}: максимум ${field.maxLength} символов (передано: \${String(flags['${flagName}']).length})\\n\`);
@@ -753,12 +762,12 @@ function generateCommandCode(p: CommandGenParams): string {
     if (p.hasPagination && (param.name === 'cursor' || param.name === 'limit')) continue;
     if (param['x-param-names']) {
       for (const sub of param['x-param-names']) {
-        const flagName = sub.name.replace(/[\[\]]/g, '-').replace(/-+/g, '-').replace(/-$/, '');
+        const flagName = toKebabCase(sub.name.replace(/[\[\]]/g, '-').replace(/-+/g, '-').replace(/-$/, ''));
         queryEntries.push(`      '${sub.name}': flags['${flagName}'],`);
       }
       continue;
     }
-    const flagName = param.name.replace(/_/g, '-');
+    const flagName = toKebabCase(param.name);
     if (flagName !== param.name) {
       queryEntries.push(`      '${param.name}': flags['${flagName}'],`);
     } else {
@@ -778,7 +787,7 @@ function generateCommandCode(p: CommandGenParams): string {
 
   for (const field of p.bodyFields) {
     if (field.format === 'binary') continue;
-    const flagName = field.name.replace(/_/g, '-');
+    const flagName = toKebabCase(field.name);
     let entry: string;
     // Parse JSON array/object flags
     if (field.type === 'array' || field.type === 'object') {
@@ -864,7 +873,7 @@ function generateCommandCode(p: CommandGenParams): string {
     // Add other fields to FormData
     for (const field of p.bodyFields) {
       if (field.format === 'binary') continue;
-      const flagName = field.name.replace(/_/g, '-');
+      const flagName = toKebabCase(field.name);
       const wireName = MULTIPART_WIRE_NAMES[field.name] || field.name;
       runBodyLines.push(`      if (flags['${flagName}']) formData.append('${wireName}', String(flags['${flagName}']));`);
     }
@@ -977,7 +986,6 @@ function generateCommandCode(p: CommandGenParams): string {
   if (p.plan) staticMeta.push(`  static plan = ${JSON.stringify(p.plan)};`);
   staticMeta.push(`  static apiMethod = ${JSON.stringify(p.endpoint.method)};`);
   staticMeta.push(`  static apiPath = ${JSON.stringify(p.endpoint.path)};`);
-  if (!p.requiresAuth) staticMeta.push(`  static requiresAuth = false;`);
   if (p.defaultColumns.length > 0) staticMeta.push(`  static defaultColumns = ${JSON.stringify(p.defaultColumns)};`);
 
   // Build examples from workflows
@@ -1009,7 +1017,7 @@ ${runBodyLines.join('\n')}
 `;
 }
 
-function getWrapperKey(schema: Schema): string | null {
+export function getWrapperKey(schema: Schema): string | null {
   const resolved = resolveAllOf(schema);
   if (!resolved.properties) return null;
   const keys = Object.keys(resolved.properties);

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -108,6 +108,9 @@ export abstract class BaseCommand extends Command {
     };
   }
 
+  /**
+   * Safely parse JSON string from a flag value.
+   */
   protected parseJSON(value: string, flagName: string): unknown {
     try {
       return JSON.parse(value);

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -226,6 +226,10 @@ export abstract class BaseCommand extends Command {
    * Output a success message to stderr.
    */
   protected success(message: string): void {
+    const format = this.getOutputFormat();
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify({ ok: true }) + '\n');
+    }
     outputSuccess(message, this.parsedFlags.quiet);
   }
 

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -228,8 +228,8 @@ export async function request(
       lastError = error as Error;
       // Only retry network errors for idempotent methods (not POST/DELETE)
       const safeMethod = ['GET', 'HEAD', 'OPTIONS', 'PUT'].includes(opts.method);
-      if (attempt < MAX_RETRIES && !noRetry && safeMethod) {
-        continue;
+      if (!safeMethod || noRetry || attempt >= MAX_RETRIES) {
+        break;
       }
     }
   }

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,5 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { spinner } from '@clack/prompts';
 import ansis from 'ansis';
 import { isInteractive } from './utils.js';
@@ -167,7 +169,8 @@ export async function request(
       // Handle rate limiting (429)
       if (response.status === 429 && !noRetry && attempt < MAX_RETRIES) {
         const retryAfter = response.headers.get('retry-after');
-        const waitMs = retryAfter ? Number.parseInt(retryAfter, 10) * 1000 : 1000;
+        const parsed = retryAfter ? Number.parseInt(retryAfter, 10) : NaN;
+        const waitMs = Number.isNaN(parsed) ? 1000 : parsed * 1000;
         if (clientFlags?.verbose) {
           process.stderr.write(`${ansis.dim(`⏳ Rate limited, retrying in ${waitMs}ms...`)}\n`);
         }
@@ -223,7 +226,9 @@ export async function request(
       }
 
       lastError = error as Error;
-      if (attempt < MAX_RETRIES && !noRetry) {
+      // Only retry network errors for idempotent methods (not POST/DELETE)
+      const safeMethod = ['GET', 'HEAD', 'OPTIONS', 'PUT'].includes(opts.method);
+      if (attempt < MAX_RETRIES && !noRetry && safeMethod) {
         continue;
       }
     }
@@ -294,36 +299,48 @@ export class ApiError extends Error {
 }
 
 export async function downloadFile(url: string, savePath: string): Promise<{ size: number }> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Download failed: HTTP ${response.status}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5 * 60 * 1000); // 5 min timeout
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Download failed: HTTP ${response.status}`);
+    }
+
+    // If savePath is a directory, derive filename
+    let finalPath = savePath;
+    if (savePath.endsWith('/') || (fs.existsSync(savePath) && fs.statSync(savePath).isDirectory())) {
+      const disposition = response.headers.get('content-disposition');
+      let filename = '';
+      if (disposition) {
+        const match = disposition.match(/filename="?([^";\n]+)"?/);
+        if (match) filename = match[1];
+      }
+      if (!filename) {
+        const urlPath = new URL(url).pathname;
+        filename = path.basename(urlPath.split('?')[0]);
+      }
+      if (!filename) filename = 'download';
+
+      if (!fs.existsSync(savePath)) {
+        throw new Error(`Directory does not exist: ${savePath}`);
+      }
+      finalPath = path.join(savePath, filename);
+    }
+
+    if (!response.body) {
+      throw new Error('Response body is empty');
+    }
+
+    const nodeStream = Readable.fromWeb(response.body as import('node:stream/web').ReadableStream);
+    await pipeline(nodeStream, fs.createWriteStream(finalPath));
+
+    const stat = fs.statSync(finalPath);
+    return { size: stat.size };
+  } finally {
+    clearTimeout(timer);
   }
-
-  const buffer = Buffer.from(await response.arrayBuffer());
-
-  // If savePath is a directory, derive filename
-  let finalPath = savePath;
-  if (savePath.endsWith('/') || (fs.existsSync(savePath) && fs.statSync(savePath).isDirectory())) {
-    const disposition = response.headers.get('content-disposition');
-    let filename = '';
-    if (disposition) {
-      const match = disposition.match(/filename="?([^";\n]+)"?/);
-      if (match) filename = match[1];
-    }
-    if (!filename) {
-      const urlPath = new URL(url).pathname;
-      filename = path.basename(urlPath.split('?')[0]);
-    }
-    if (!filename) filename = 'download';
-
-    if (!fs.existsSync(savePath)) {
-      throw new Error(`Directory does not exist: ${savePath}`);
-    }
-    finalPath = path.join(savePath, filename);
-  }
-
-  fs.writeFileSync(finalPath, buffer);
-  return { size: buffer.length };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/commands/bots/update.ts
+++ b/packages/cli/src/commands/bots/update.ts
@@ -63,6 +63,11 @@ export default class BotsUpdate extends BaseCommand {
     const inner = body['bot'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
 
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
+
     const { data } = await this.apiRequest({
       method: 'PUT',
       path: `/bots/${args.id}`,

--- a/packages/cli/src/commands/chats/create.ts
+++ b/packages/cli/src/commands/chats/create.ts
@@ -34,9 +34,11 @@ export default class ChatsCreate extends BaseCommand {
     }),
     'channel': Flags.boolean({
       description: "Является каналом",
+      allowNo: true,
     }),
     'public': Flags.boolean({
       description: "Открытый доступ",
+      allowNo: true,
     }),
   };
 

--- a/packages/cli/src/commands/chats/list.ts
+++ b/packages/cli/src/commands/chats/list.ts
@@ -39,6 +39,7 @@ export default class ChatsList extends BaseCommand {
     }),
     'personal': Flags.boolean({
       description: "Фильтрация по личным и групповым чатам. Если параметр не указан, возвращаются любые чаты.",
+      allowNo: true,
     }),
     limit: Flags.integer({
       description: 'Количество результатов на страницу',

--- a/packages/cli/src/commands/chats/list.ts
+++ b/packages/cli/src/commands/chats/list.ts
@@ -25,7 +25,7 @@ export default class ChatsList extends BaseCommand {
     'sort-id': Flags.string({
       description: "Идентификатор чата",
     }),
-    'sort-last_message_at': Flags.string({
+    'sort-last-message-at': Flags.string({
       description: "Дата и время создания последнего сообщения",
     }),
     'availability': Flags.string({
@@ -69,7 +69,7 @@ export default class ChatsList extends BaseCommand {
       while (pages < 500) {
         const query: Record<string, string | number | boolean | undefined> = {
         'sort[id]': flags['sort-id'],
-        'sort[last_message_at]': flags['sort-last_message_at'],
+        'sort[last_message_at]': flags['sort-last-message-at'],
         availability: flags['availability'],
         'last_message_at_after': flags['last-message-at-after'],
         'last_message_at_before': flags['last-message-at-before'],
@@ -113,7 +113,7 @@ export default class ChatsList extends BaseCommand {
       path: '/chats',
       query: {
       'sort[id]': flags['sort-id'],
-      'sort[last_message_at]': flags['sort-last_message_at'],
+      'sort[last_message_at]': flags['sort-last-message-at'],
       availability: flags['availability'],
       'last_message_at_after': flags['last-message-at-after'],
       'last_message_at_before': flags['last-message-at-before'],

--- a/packages/cli/src/commands/chats/update.ts
+++ b/packages/cli/src/commands/chats/update.ts
@@ -28,6 +28,7 @@ export default class ChatsUpdate extends BaseCommand {
     }),
     'public': Flags.boolean({
       description: "Открытый доступ",
+      allowNo: true,
     }),
   };
 
@@ -44,6 +45,11 @@ export default class ChatsUpdate extends BaseCommand {
     // Clean undefined fields
     const inner = body['chat'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',

--- a/packages/cli/src/commands/common/direct-url.ts
+++ b/packages/cli/src/commands/common/direct-url.ts
@@ -91,13 +91,13 @@ export default class CommonDirectUrl extends BaseCommand {
         const blob = new Blob([fs.readFileSync(flags.file)]);
         formData.append('file', blob, path.basename(flags.file));
       }
-      if (flags['contentDisposition']) formData.append('contentDisposition', String(flags['contentDisposition']));
+      if (flags['contentDisposition']) formData.append('Content-Disposition', String(flags['contentDisposition']));
       if (flags['acl']) formData.append('acl', String(flags['acl']));
       if (flags['policy']) formData.append('policy', String(flags['policy']));
-      if (flags['xAmzCredential']) formData.append('xAmzCredential', String(flags['xAmzCredential']));
-      if (flags['xAmzAlgorithm']) formData.append('xAmzAlgorithm', String(flags['xAmzAlgorithm']));
-      if (flags['xAmzDate']) formData.append('xAmzDate', String(flags['xAmzDate']));
-      if (flags['xAmzSignature']) formData.append('xAmzSignature', String(flags['xAmzSignature']));
+      if (flags['xAmzCredential']) formData.append('x-amz-credential', String(flags['xAmzCredential']));
+      if (flags['xAmzAlgorithm']) formData.append('x-amz-algorithm', String(flags['xAmzAlgorithm']));
+      if (flags['xAmzDate']) formData.append('x-amz-date', String(flags['xAmzDate']));
+      if (flags['xAmzSignature']) formData.append('x-amz-signature', String(flags['xAmzSignature']));
       if (flags['key']) formData.append('key', String(flags['key']));
     }
 

--- a/packages/cli/src/commands/common/direct-url.ts
+++ b/packages/cli/src/commands/common/direct-url.ts
@@ -10,7 +10,6 @@ export default class CommonDirectUrl extends BaseCommand {
 
   static apiMethod = "POST";
   static apiPath = "/direct_url";
-  static requiresAuth = false;
 
   static override args = {
 
@@ -18,7 +17,7 @@ export default class CommonDirectUrl extends BaseCommand {
 
   static override flags = {
     ...BaseCommand.baseFlags,
-    'contentDisposition': Flags.string({
+    'content-disposition': Flags.string({
       description: "Параметр Content-Disposition, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
     }),
     'acl': Flags.string({
@@ -27,16 +26,16 @@ export default class CommonDirectUrl extends BaseCommand {
     'policy': Flags.string({
       description: "Параметр policy, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
     }),
-    'xAmzCredential': Flags.string({
+    'x-amz-credential': Flags.string({
       description: "Параметр x-amz-credential, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
     }),
-    'xAmzAlgorithm': Flags.string({
+    'x-amz-algorithm': Flags.string({
       description: "Параметр x-amz-algorithm, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
     }),
-    'xAmzDate': Flags.string({
+    'x-amz-date': Flags.string({
       description: "Параметр x-amz-date, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
     }),
-    'xAmzSignature': Flags.string({
+    'x-amz-signature': Flags.string({
       description: "Параметр x-amz-signature, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)",
     }),
     'key': Flags.string({
@@ -52,13 +51,13 @@ export default class CommonDirectUrl extends BaseCommand {
     this.parsedFlags = flags;
 
     const missingRequired: { flag: string; label: string; type: string }[] = [
-      { flag: 'contentDisposition', label: "Параметр Content-Disposition, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
+      { flag: 'content-disposition', label: "Параметр Content-Disposition, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
       { flag: 'acl', label: "Параметр acl, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
       { flag: 'policy', label: "Параметр policy, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
-      { flag: 'xAmzCredential', label: "Параметр x-amz-credential, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
-      { flag: 'xAmzAlgorithm', label: "Параметр x-amz-algorithm, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
-      { flag: 'xAmzDate', label: "Параметр x-amz-date, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
-      { flag: 'xAmzSignature', label: "Параметр x-amz-signature, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
+      { flag: 'x-amz-credential', label: "Параметр x-amz-credential, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
+      { flag: 'x-amz-algorithm', label: "Параметр x-amz-algorithm, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
+      { flag: 'x-amz-date', label: "Параметр x-amz-date, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
+      { flag: 'x-amz-signature', label: "Параметр x-amz-signature, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
       { flag: 'key', label: "Параметр key, полученный в ответе на запрос [Получение подписи, ключа и других параметров](POST /uploads)", type: 'string' },
     ].filter((f) => (flags as Record<string, unknown>)[f.flag] === undefined || (flags as Record<string, unknown>)[f.flag] === null);
 
@@ -91,13 +90,13 @@ export default class CommonDirectUrl extends BaseCommand {
         const blob = new Blob([fs.readFileSync(flags.file)]);
         formData.append('file', blob, path.basename(flags.file));
       }
-      if (flags['contentDisposition']) formData.append('Content-Disposition', String(flags['contentDisposition']));
+      if (flags['content-disposition']) formData.append('Content-Disposition', String(flags['content-disposition']));
       if (flags['acl']) formData.append('acl', String(flags['acl']));
       if (flags['policy']) formData.append('policy', String(flags['policy']));
-      if (flags['xAmzCredential']) formData.append('x-amz-credential', String(flags['xAmzCredential']));
-      if (flags['xAmzAlgorithm']) formData.append('x-amz-algorithm', String(flags['xAmzAlgorithm']));
-      if (flags['xAmzDate']) formData.append('x-amz-date', String(flags['xAmzDate']));
-      if (flags['xAmzSignature']) formData.append('x-amz-signature', String(flags['xAmzSignature']));
+      if (flags['x-amz-credential']) formData.append('x-amz-credential', String(flags['x-amz-credential']));
+      if (flags['x-amz-algorithm']) formData.append('x-amz-algorithm', String(flags['x-amz-algorithm']));
+      if (flags['x-amz-date']) formData.append('x-amz-date', String(flags['x-amz-date']));
+      if (flags['x-amz-signature']) formData.append('x-amz-signature', String(flags['x-amz-signature']));
       if (flags['key']) formData.append('key', String(flags['key']));
     }
 

--- a/packages/cli/src/commands/common/request-export.ts
+++ b/packages/cli/src/commands/common/request-export.ts
@@ -35,6 +35,7 @@ export default class CommonRequestExport extends BaseCommand {
     }),
     'skip-chats-file': Flags.boolean({
       description: "Пропуск формирования файла со списком чатов (chats.json)",
+      allowNo: true,
     }),
   };
 

--- a/packages/cli/src/commands/group-tags/list.ts
+++ b/packages/cli/src/commands/group-tags/list.ts
@@ -22,7 +22,7 @@ export default class GroupTagsList extends BaseCommand {
   static override flags = {
     ...BaseCommand.baseFlags,
     'names': Flags.string({
-      description: "Массив названий тегов, по которым вы хотите отфильтровать список",
+      description: "Массив названий тегов, по которым вы хотите отфильтровать список" + " (через запятую)",
     }),
     limit: Flags.integer({
       description: 'Количество результатов на страницу',

--- a/packages/cli/src/commands/group-tags/update.ts
+++ b/packages/cli/src/commands/group-tags/update.ts
@@ -59,6 +59,11 @@ export default class GroupTagsUpdate extends BaseCommand {
     const inner = body['group_tag'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
 
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
+
     const { data } = await this.apiRequest({
       method: 'PUT',
       path: `/group_tags/${args.id}`,

--- a/packages/cli/src/commands/members/add.ts
+++ b/packages/cli/src/commands/members/add.ts
@@ -30,6 +30,7 @@ export default class MembersAdd extends BaseCommand {
     }),
     'silent': Flags.boolean({
       description: "Не создавать в чате системное сообщение о добавлении участника",
+      allowNo: true,
     }),
   };
 

--- a/packages/cli/src/commands/members/update.ts
+++ b/packages/cli/src/commands/members/update.ts
@@ -1,6 +1,7 @@
 // Auto-generated from openapi.yaml — DO NOT EDIT
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
+import * as clack from '@clack/prompts';
 
 export default class MembersUpdate extends BaseCommand {
   static override description = "Редактирование роли";
@@ -27,18 +28,53 @@ export default class MembersUpdate extends BaseCommand {
 
   static override flags = {
     ...BaseCommand.baseFlags,
-
+    'role': Flags.string({
+      description: "Роль",
+    }),
   };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(MembersUpdate);
     this.parsedFlags = flags;
 
+    const missingRequired: { flag: string; label: string; type: string }[] = [
+      { flag: 'role', label: "Роль", type: 'string' },
+    ].filter((f) => (flags as Record<string, unknown>)[f.flag] === undefined || (flags as Record<string, unknown>)[f.flag] === null);
+
+    if (missingRequired.length > 0) {
+      if (this.isInteractive()) {
+        for (const field of missingRequired) {
+          const value = await clack.text({ message: field.label, validate: (v) => v.length === 0 ? 'Обязательное поле' : undefined });
+          if (clack.isCancel(value)) { process.stderr.write('Отменено.\n'); this.exit(0); }
+          if (field.type === 'integer') { (flags as Record<string, unknown>)[field.flag] = Number.parseInt(value, 10); }
+          else if (field.type === 'boolean') { (flags as Record<string, unknown>)[field.flag] = value === 'true'; }
+          else { (flags as Record<string, unknown>)[field.flag] = value; }
+        }
+      } else {
+        for (const field of missingRequired) {
+          process.stderr.write(`✗ Обязательный флаг --${field.flag} не передан\n`);
+        }
+        this.exit(2);
+      }
+    }
+
     this.checkScope("chat_members:write");
+
+    const body: Record<string, unknown> = {
+      role: flags['role'],
+    };
+    // Clean undefined fields
+    for (const [k, v] of Object.entries(body)) { if (v === undefined) delete body[k]; }
+
+    if (Object.keys(body).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',
       path: `/chats/${args.id}/members/${args.user_id}`,
+      body,
     });
 
     const responseBody = data as Record<string, unknown>;

--- a/packages/cli/src/commands/messages/create.ts
+++ b/packages/cli/src/commands/messages/create.ts
@@ -2,7 +2,6 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import * as clack from '@clack/prompts';
-import { Readable } from 'node:stream';
 
 export default class MessagesCreate extends BaseCommand {
   static override description = "Новое сообщение";
@@ -50,9 +49,11 @@ export default class MessagesCreate extends BaseCommand {
     }),
     'skip-invite-mentions': Flags.boolean({
       description: "Пропуск добавления упоминаемых пользователей в тред. Работает только при отправке сообщения в тред.",
+      allowNo: true,
     }),
     'link-preview': Flags.boolean({
       description: "Отображение предпросмотра первой найденной ссылки в тексте сообщения",
+      allowNo: true,
     }),
   };
 

--- a/packages/cli/src/commands/messages/update.ts
+++ b/packages/cli/src/commands/messages/update.ts
@@ -1,7 +1,6 @@
 // Auto-generated from openapi.yaml — DO NOT EDIT
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { Readable } from 'node:stream';
 
 export default class MessagesUpdate extends BaseCommand {
   static override description = "Редактирование сообщения";
@@ -68,6 +67,11 @@ export default class MessagesUpdate extends BaseCommand {
     // Clean undefined fields
     const inner = body['message'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',

--- a/packages/cli/src/commands/profile/update-status.ts
+++ b/packages/cli/src/commands/profile/update-status.ts
@@ -33,6 +33,7 @@ export default class ProfileUpdateStatus extends BaseCommand {
     }),
     'is-away': Flags.boolean({
       description: "Режим «Нет на месте»",
+      allowNo: true,
     }),
     'away-message': Flags.string({
       description: "Текст сообщения при режиме «Нет на месте». Отображается в профиле и при личных сообщениях/упоминаниях. (макс. 1024 символов)",
@@ -82,6 +83,11 @@ export default class ProfileUpdateStatus extends BaseCommand {
     // Clean undefined fields
     const inner = body['status'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',

--- a/packages/cli/src/commands/search/list-chats.ts
+++ b/packages/cli/src/commands/search/list-chats.ts
@@ -35,6 +35,7 @@ export default class SearchListChats extends BaseCommand {
     }),
     'active': Flags.boolean({
       description: "Фильтр по активности чата",
+      allowNo: true,
     }),
     'chat-subtype': Flags.string({
       description: "Фильтр по типу чата",
@@ -42,6 +43,7 @@ export default class SearchListChats extends BaseCommand {
     }),
     'personal': Flags.boolean({
       description: "Фильтр по личным чатам",
+      allowNo: true,
     }),
     limit: Flags.integer({
       description: 'Количество результатов на страницу',

--- a/packages/cli/src/commands/search/list-messages.ts
+++ b/packages/cli/src/commands/search/list-messages.ts
@@ -41,6 +41,7 @@ export default class SearchListMessages extends BaseCommand {
     }),
     'active': Flags.boolean({
       description: "Фильтр по активности чата",
+      allowNo: true,
     }),
     limit: Flags.integer({
       description: 'Количество результатов на страницу',

--- a/packages/cli/src/commands/search/list-messages.ts
+++ b/packages/cli/src/commands/search/list-messages.ts
@@ -34,10 +34,10 @@ export default class SearchListMessages extends BaseCommand {
       description: "Фильтр по дате создания (до)",
     }),
     'chat-ids': Flags.string({
-      description: "Фильтр по ID чатов",
+      description: "Фильтр по ID чатов" + " (через запятую)",
     }),
     'user-ids': Flags.string({
-      description: "Фильтр по ID авторов сообщений",
+      description: "Фильтр по ID авторов сообщений" + " (через запятую)",
     }),
     'active': Flags.boolean({
       description: "Фильтр по активности чата",

--- a/packages/cli/src/commands/search/list-users.ts
+++ b/packages/cli/src/commands/search/list-users.ts
@@ -38,7 +38,7 @@ export default class SearchListUsers extends BaseCommand {
       description: "Фильтр по дате создания (до)",
     }),
     'company-roles': Flags.string({
-      description: "Фильтр по ролям сотрудников",
+      description: "Фильтр по ролям сотрудников" + " (через запятую)",
     }),
     limit: Flags.integer({
       description: 'Количество результатов на страницу',

--- a/packages/cli/src/commands/tasks/create.ts
+++ b/packages/cli/src/commands/tasks/create.ts
@@ -2,7 +2,6 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import * as clack from '@clack/prompts';
-import { Readable } from 'node:stream';
 
 export default class TasksCreate extends BaseCommand {
   static override description = "Новое напоминание";
@@ -44,6 +43,7 @@ export default class TasksCreate extends BaseCommand {
     }),
     'all-day': Flags.boolean({
       description: "Напоминание на весь день (без указания времени)",
+      allowNo: true,
     }),
     'custom-properties': Flags.string({
       description: "Задаваемые дополнительные поля",

--- a/packages/cli/src/commands/tasks/update.ts
+++ b/packages/cli/src/commands/tasks/update.ts
@@ -1,7 +1,6 @@
 // Auto-generated from openapi.yaml — DO NOT EDIT
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
-import { Readable } from 'node:stream';
 
 export default class TasksUpdate extends BaseCommand {
   static override description = "Редактирование напоминания";
@@ -46,6 +45,7 @@ export default class TasksUpdate extends BaseCommand {
     }),
     'all-day': Flags.boolean({
       description: "Напоминание на весь день (без указания времени)",
+      allowNo: true,
     }),
     'done-at': Flags.string({
       description: "Дата и время выполнения напоминания (ISO-8601, UTC+0) в формате YYYY-MM-DDThh:mm:ss.sssZ",
@@ -84,6 +84,11 @@ export default class TasksUpdate extends BaseCommand {
     // Clean undefined fields
     const inner = body['task'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',

--- a/packages/cli/src/commands/users/create.ts
+++ b/packages/cli/src/commands/users/create.ts
@@ -23,11 +23,43 @@ export default class UsersCreate extends BaseCommand {
 
   static override flags = {
     ...BaseCommand.baseFlags,
-    'user': Flags.string({
-      description: "user",
+    'first-name': Flags.string({
+      description: "Имя",
+    }),
+    'last-name': Flags.string({
+      description: "Фамилия",
+    }),
+    'email': Flags.string({
+      description: "Электронная почта",
+    }),
+    'phone-number': Flags.string({
+      description: "Телефон",
+    }),
+    'nickname': Flags.string({
+      description: "Имя пользователя",
+    }),
+    'department': Flags.string({
+      description: "Департамент",
+    }),
+    'title': Flags.string({
+      description: "Должность",
+    }),
+    'role': Flags.string({
+      description: "Уровень доступа",
+    }),
+    'suspended': Flags.boolean({
+      description: "Деактивация пользователя",
+      allowNo: true,
+    }),
+    'list-tags': Flags.string({
+      description: "Массив тегов, привязываемых к сотруднику",
+    }),
+    'custom-properties': Flags.string({
+      description: "Задаваемые дополнительные поля",
     }),
     'skip-email-notify': Flags.boolean({
       description: "Пропуск этапа отправки приглашения сотруднику. Сотруднику не будет отправлено письмо на электронную почту с приглашением создать аккаунт. Полезно при предварительном создании аккаунтов перед входом через SSO.",
+      allowNo: true,
     }),
   };
 
@@ -36,7 +68,7 @@ export default class UsersCreate extends BaseCommand {
     this.parsedFlags = flags;
 
     const missingRequired: { flag: string; label: string; type: string }[] = [
-      { flag: 'user', label: "user", type: 'string' },
+      { flag: 'email', label: "Электронная почта", type: 'string' },
     ].filter((f) => (flags as Record<string, unknown>)[f.flag] === undefined || (flags as Record<string, unknown>)[f.flag] === null);
 
     if (missingRequired.length > 0) {
@@ -59,11 +91,25 @@ export default class UsersCreate extends BaseCommand {
     this.checkScope("users:create");
 
     const body: Record<string, unknown> = {
-      user: flags['user'] ? this.parseJSON(flags['user'], 'user') : undefined,
+      user: {
+      first_name: flags['first-name'],
+      last_name: flags['last-name'],
+      email: flags['email'],
+      phone_number: flags['phone-number'],
+      nickname: flags['nickname'],
+      department: flags['department'],
+      title: flags['title'],
+      role: flags['role'],
+      suspended: flags['suspended'],
+      list_tags: flags['list-tags'] ? this.parseJSON(flags['list-tags'], 'list-tags') : undefined,
+      custom_properties: flags['custom-properties'] ? this.parseJSON(flags['custom-properties'], 'custom-properties') : undefined,
+      },
       skip_email_notify: flags['skip-email-notify'],
     };
     // Clean undefined fields
-    for (const [k, v] of Object.entries(body)) { if (v === undefined) delete body[k]; }
+    const inner = body['user'] as Record<string, unknown>;
+    for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+    for (const [k, v] of Object.entries(body)) { if (k !== 'user' && v === undefined) delete body[k]; }
 
     const { data } = await this.apiRequest({
       method: 'POST',

--- a/packages/cli/src/commands/users/update-status.ts
+++ b/packages/cli/src/commands/users/update-status.ts
@@ -37,6 +37,7 @@ export default class UsersUpdateStatus extends BaseCommand {
     }),
     'is-away': Flags.boolean({
       description: "Режим «Нет на месте»",
+      allowNo: true,
     }),
     'away-message': Flags.string({
       description: "Текст сообщения при режиме «Нет на месте». Отображается в профиле и при личных сообщениях/упоминаниях. (макс. 1024 символов)",
@@ -86,6 +87,11 @@ export default class UsersUpdateStatus extends BaseCommand {
     // Clean undefined fields
     const inner = body['status'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',

--- a/packages/cli/src/commands/users/update.ts
+++ b/packages/cli/src/commands/users/update.ts
@@ -51,6 +51,7 @@ export default class UsersUpdate extends BaseCommand {
     }),
     'suspended': Flags.boolean({
       description: "Деактивация пользователя",
+      allowNo: true,
     }),
     'list-tags': Flags.string({
       description: "Массив тегов, привязываемых к сотруднику",
@@ -82,6 +83,11 @@ export default class UsersUpdate extends BaseCommand {
     // Clean undefined fields
     const inner = body['user'] as Record<string, unknown>;
     for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+
+    if (Object.keys(inner).length === 0) {
+      process.stderr.write('⚠ Не указаны поля для обновления. Используйте --help для списка флагов.\n');
+      return;
+    }
 
     const { data } = await this.apiRequest({
       method: 'PUT',

--- a/packages/cli/src/commands/views/open.ts
+++ b/packages/cli/src/commands/views/open.ts
@@ -21,6 +21,18 @@ export default class ViewsOpen extends BaseCommand {
 
   static override flags = {
     ...BaseCommand.baseFlags,
+    'title': Flags.string({
+      description: "Заголовок представления (макс. 24 символов)",
+    }),
+    'close-text': Flags.string({
+      description: "Текст кнопки закрытия представления (макс. 24 символов)",
+    }),
+    'submit-text': Flags.string({
+      description: "Текст кнопки отправки формы (макс. 24 символов)",
+    }),
+    'blocks': Flags.string({
+      description: "Массив блоков представления",
+    }),
     'type': Flags.string({
       description: "Способ открытия представления",
       options: ["modal"],
@@ -34,9 +46,6 @@ export default class ViewsOpen extends BaseCommand {
     'callback-id': Flags.string({
       description: "Необязательный идентификатор для распознавания этого представления, который будет отправлен в ваше приложение при отправке пользователем заполненной формы. Используйте это поле, например, для понимания, какую форму должен был заполнить пользователь. (макс. 255 символов)",
     }),
-    'view': Flags.string({
-      description: "Собранный объект представления",
-    }),
   };
 
   async run(): Promise<void> {
@@ -44,9 +53,10 @@ export default class ViewsOpen extends BaseCommand {
     this.parsedFlags = flags;
 
     const missingRequired: { flag: string; label: string; type: string }[] = [
+      { flag: 'title', label: "Заголовок представления", type: 'string' },
+      { flag: 'blocks', label: "Массив блоков представления", type: 'string' },
       { flag: 'type', label: "Способ открытия представления", type: 'string' },
       { flag: 'trigger-id', label: "Уникальный идентификатор события (полученный, например, в исходящем вебхуке о нажатии кнопки)", type: 'string' },
-      { flag: 'view', label: "Собранный объект представления", type: 'string' },
     ].filter((f) => (flags as Record<string, unknown>)[f.flag] === undefined || (flags as Record<string, unknown>)[f.flag] === null);
 
     if (missingRequired.length > 0) {
@@ -66,6 +76,18 @@ export default class ViewsOpen extends BaseCommand {
       }
     }
 
+    if (flags['title'] && String(flags['title']).length > 24) {
+      process.stderr.write(`✗ --title: максимум 24 символов (передано: ${String(flags['title']).length})\n`);
+      this.exit(2);
+    }
+    if (flags['close-text'] && String(flags['close-text']).length > 24) {
+      process.stderr.write(`✗ --close-text: максимум 24 символов (передано: ${String(flags['close-text']).length})\n`);
+      this.exit(2);
+    }
+    if (flags['submit-text'] && String(flags['submit-text']).length > 24) {
+      process.stderr.write(`✗ --submit-text: максимум 24 символов (передано: ${String(flags['submit-text']).length})\n`);
+      this.exit(2);
+    }
     if (flags['type'] && !["modal"].includes(flags['type'])) {
       process.stderr.write(`✗ --type: допустимые значения — "modal"\n`);
       this.exit(2);
@@ -82,14 +104,21 @@ export default class ViewsOpen extends BaseCommand {
     this.checkScope("views:write");
 
     const body: Record<string, unknown> = {
+      view: {
+      title: flags['title'],
+      close_text: flags['close-text'],
+      submit_text: flags['submit-text'],
+      blocks: flags['blocks'] ? this.parseJSON(flags['blocks'], 'blocks') : undefined,
+      },
       type: flags['type'],
       trigger_id: flags['trigger-id'],
       private_metadata: flags['private-metadata'],
       callback_id: flags['callback-id'],
-      view: flags['view'] ? this.parseJSON(flags['view'], 'view') : undefined,
     };
     // Clean undefined fields
-    for (const [k, v] of Object.entries(body)) { if (v === undefined) delete body[k]; }
+    const inner = body['view'] as Record<string, unknown>;
+    for (const [k, v] of Object.entries(inner)) { if (v === undefined) delete inner[k]; }
+    for (const [k, v] of Object.entries(body)) { if (k !== 'view' && v === undefined) delete body[k]; }
 
     const { data } = await this.apiRequest({
       method: 'POST',

--- a/packages/cli/src/data/changelog.json
+++ b/packages/cli/src/data/changelog.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "version": "2026.3.1",
+    "date": "4 марта 2026",
+    "changes": [
+      { "type": "+", "command": "all", "description": "Все флаги в kebab-case (--first-name, --entity-id, --phone-number)" },
+      { "type": "+", "command": "all", "description": "Boolean-флаги с --no- префиксом (--suspended / --no-suspended)" },
+      { "type": "+", "command": "all", "description": "Хинт «через запятую» для массивных параметров (--chat-ids, --user-ids)" },
+      { "type": "+", "command": "all", "description": "DELETE --json выводит {\"ok\":true} в stdout" },
+      { "type": "+", "command": "all", "description": "POST/DELETE не ретраятся при сетевых ошибках" },
+      { "type": "+", "command": "common direct-url", "description": "Флаги в kebab-case (--content-disposition, --x-amz-credential)" },
+      { "type": "+", "command": "common direct-url", "description": "FormData wire names (Content-Disposition, x-amz-credential)" },
+      { "type": "+", "command": "chats list", "description": "Флаг --sort-last-message-at (был --sort-last_message_at)" },
+      { "type": "+", "command": "guide", "description": "Поиск по сценариям использования API" },
+      { "type": "+", "command": "doctor", "description": "Диагностика окружения (Node.js, сеть, токен, версия)" },
+      { "type": "+", "command": "introspect", "description": "Метаинформация о командах и флагах для агентов" },
+      { "type": "+", "command": "api", "description": "Прямые HTTP-запросы с -f/-F, --input, --query" }
+    ]
+  }
+]

--- a/packages/cli/src/hooks/postrun.ts
+++ b/packages/cli/src/hooks/postrun.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { Hook } from '@oclif/core';
 import semver from 'semver';
@@ -54,7 +55,7 @@ const hook: Hook<'postrun'> = async function (opts) {
       }
 
       // Spawn detached background process to fetch latest version
-      const scriptPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'get-version.js');
+      const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'get-version.js');
       if (fs.existsSync(scriptPath)) {
         const child = spawn(process.execPath, [scriptPath, versionFile], {
           detached: true,

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -190,5 +190,7 @@ export function outputSuccess(message: string, quiet?: boolean): void {
   if (quiet) return;
   if (process.stderr.isTTY) {
     process.stderr.write(`✔ ${message}\n`);
+  } else {
+    process.stderr.write(`${message}\n`);
   }
 }

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -141,7 +141,13 @@ export function getConfigValue(key: string): unknown {
   return current;
 }
 
+const ALLOWED_CONFIG_KEYS = new Set(['defaults.output', 'defaults.timeout']);
+
 export function setConfigValue(key: string, value: string): void {
+  if (!ALLOWED_CONFIG_KEYS.has(key)) {
+    throw new Error(`Unknown config key: ${key}. Allowed keys: ${[...ALLOWED_CONFIG_KEYS].join(', ')}`);
+  }
+
   const config = readConfig();
   const parts = key.split('.');
 

--- a/packages/cli/tests/client.test.ts
+++ b/packages/cli/tests/client.test.ts
@@ -505,6 +505,189 @@ describe('client', () => {
     });
   });
 
+  it('should not produce NaN timeout when PACHCA_TIMEOUT is unset', async () => {
+    delete process.env.PACHCA_TIMEOUT;
+    let capturedSignal: AbortSignal | undefined;
+
+    globalThis.fetch = vi.fn().mockImplementation((_url, opts) => {
+      capturedSignal = opts?.signal;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ data: {} }),
+      });
+    });
+
+    await request({ method: 'GET', path: '/test', token: 'test' }, { quiet: true });
+    expect(capturedSignal).toBeDefined();
+    // Signal must NOT be immediately aborted (NaN timeout would cause instant abort)
+    expect(capturedSignal!.aborted).toBe(false);
+  });
+
+  it('should not produce NaN timeout when PACHCA_TIMEOUT is empty string', async () => {
+    process.env.PACHCA_TIMEOUT = '';
+    let capturedSignal: AbortSignal | undefined;
+
+    globalThis.fetch = vi.fn().mockImplementation((_url, opts) => {
+      capturedSignal = opts?.signal;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ data: {} }),
+      });
+    });
+
+    await request({ method: 'GET', path: '/test', token: 'test' }, { quiet: true });
+    expect(capturedSignal!.aborted).toBe(false);
+  });
+
+  it('should handle retry-after with non-numeric value', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: new Headers({ 'retry-after': 'invalid' }),
+          json: () => Promise.resolve({}),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ data: 'ok' }),
+      });
+    });
+
+    const result = await request(
+      { method: 'GET', path: '/test', token: 'test' },
+      { quiet: true },
+    );
+    expect(result.data).toEqual({ data: 'ok' });
+    expect(callCount).toBe(2);
+  });
+
+  it('should not retry POST on network error', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.reject(new TypeError('fetch failed'));
+    });
+
+    await expect(
+      request({ method: 'POST', path: '/messages', token: 'test' }, { quiet: true }),
+    ).rejects.toThrow();
+    expect(callCount).toBe(1);
+  });
+
+  it('should not retry DELETE on network error', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.reject(new TypeError('fetch failed'));
+    });
+
+    await expect(
+      request({ method: 'DELETE', path: '/messages/1', token: 'test' }, { quiet: true }),
+    ).rejects.toThrow();
+    expect(callCount).toBe(1);
+  });
+
+  it('should retry GET on network error', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.reject(new TypeError('fetch failed'));
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ data: 'ok' }),
+      });
+    });
+
+    const result = await request(
+      { method: 'GET', path: '/test', token: 'test' },
+      { quiet: true },
+    );
+    expect(result.data).toEqual({ data: 'ok' });
+    expect(callCount).toBe(3);
+  });
+
+  it('should retry PUT on network error', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.reject(new TypeError('fetch failed'));
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: () => Promise.resolve({ data: 'ok' }),
+      });
+    });
+
+    const result = await request(
+      { method: 'PUT', path: '/users/1', token: 'test' },
+      { quiet: true },
+    );
+    expect(result.data).toEqual({ data: 'ok' });
+    expect(callCount).toBe(3);
+  });
+
+  it('should not retry PATCH on network error', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.reject(new TypeError('fetch failed'));
+    });
+
+    await expect(
+      request({ method: 'PATCH', path: '/test', token: 'test' }, { quiet: true }),
+    ).rejects.toThrow();
+    expect(callCount).toBe(1);
+  });
+
+  it('should handle non-JSON error response (HTML)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: new Headers({ 'content-type': 'text/html' }),
+      text: () => Promise.resolve('<html>Bad Gateway</html>'),
+    });
+
+    try {
+      await request({ method: 'GET', path: '/test', token: 'test', noRetry: true }, { quiet: true });
+      expect.unreachable('Should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).details.code).toBe(502);
+    }
+  });
+
+  it('should return null data when content-length is 0', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-length': '0' }),
+    });
+
+    const result = await request(
+      { method: 'POST', path: '/test', token: 'test' },
+      { quiet: true },
+    );
+    expect(result.data).toBeNull();
+  });
+
   describe('downloadFile', () => {
     let tmpDir: string;
 
@@ -577,6 +760,33 @@ describe('client', () => {
       });
 
       await expect(downloadFile('https://example.com/missing.zip', path.join(tmpDir, 'out.zip'))).rejects.toThrow('Download failed');
+    });
+
+    it('should throw when response body is null', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: null,
+      });
+
+      await expect(
+        downloadFile('https://example.com/file.zip', path.join(tmpDir, 'out.zip')),
+      ).rejects.toThrow();
+    });
+
+    it('should throw when target directory does not exist', async () => {
+      const content = Buffer.from('data');
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: mockStream(content),
+      });
+
+      await expect(
+        downloadFile('https://example.com/file.zip', '/nonexistent-dir-xyz/'),
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/cli/tests/client.test.ts
+++ b/packages/cli/tests/client.test.ts
@@ -516,13 +516,22 @@ describe('client', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    function mockStream(content: Buffer) {
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(content));
+          controller.close();
+        },
+      });
+    }
+
     it('should download file to specified path', async () => {
       const content = Buffer.from('file content here');
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
         headers: new Headers(),
-        arrayBuffer: () => Promise.resolve(content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength)),
+        body: mockStream(content),
       });
 
       const filePath = path.join(tmpDir, 'output.zip');
@@ -539,7 +548,7 @@ describe('client', () => {
         ok: true,
         status: 200,
         headers: new Headers(),
-        arrayBuffer: () => Promise.resolve(content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength)),
+        body: mockStream(content),
       });
 
       const result = await downloadFile('https://example.com/archive-123.zip', tmpDir + '/');
@@ -554,7 +563,7 @@ describe('client', () => {
         ok: true,
         status: 200,
         headers: new Headers({ 'content-disposition': 'attachment; filename="export.csv"' }),
-        arrayBuffer: () => Promise.resolve(content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength)),
+        body: mockStream(content),
       });
 
       await downloadFile('https://example.com/download', tmpDir + '/');

--- a/packages/cli/tests/commands.test.ts
+++ b/packages/cli/tests/commands.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runCommand } from '@oclif/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const CLI_ROOT = path.join(__dirname, '..');
+
+let tmpDir: string;
+const originalFetch = globalThis.fetch;
+const savedEnv: Record<string, string | undefined> = {};
+
+function setEnv(key: string, value: string | undefined) {
+  if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function mockFetch(response: { status?: number; data?: unknown; headers?: Record<string, string> }) {
+  const status = response.status ?? 200;
+  const headers = new Headers({ 'content-type': 'application/json', ...response.headers });
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 400,
+    status,
+    statusText: status === 200 ? 'OK' : status === 302 ? 'Found' : 'Error',
+    headers,
+    json: () => Promise.resolve(response.data ?? {}),
+    text: () => Promise.resolve(JSON.stringify(response.data ?? {})),
+  });
+}
+
+function mockPaginatedFetch(pages: { data: unknown[]; next?: string }[]) {
+  let callIndex = 0;
+  globalThis.fetch = vi.fn().mockImplementation(() => {
+    const page = pages[callIndex++] || pages[pages.length - 1];
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({
+        data: page.data,
+        meta: { paginate: { next_page: page.next || null } },
+      }),
+      text: () => Promise.resolve(JSON.stringify({
+        data: page.data,
+        meta: { paginate: { next_page: page.next || null } },
+      })),
+    });
+  });
+}
+
+// All scopes needed for tests
+const ALL_SCOPES = [
+  'users:read', 'users:create', 'users:update', 'users:delete',
+  'chats:read', 'messages:create', 'search:messages',
+  'uploads:write',
+];
+
+function setupProfile(scopes = ALL_SCOPES) {
+  const configDir = path.join(tmpDir, 'pachca');
+  fs.mkdirSync(configDir, { recursive: true });
+  const scopesStr = scopes.map((s) => `"${s}"`).join(', ');
+  fs.writeFileSync(
+    path.join(configDir, 'config.toml'),
+    `active_profile = "test"\n\n[profiles.test]\ntype = "user"\ntoken = "test-token"\nuser = "Test User"\nscopes = [${scopesStr}]\n`,
+  );
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pachca-cmd-test-'));
+  setEnv('XDG_CONFIG_HOME', tmpDir);
+  setEnv('PACHCA_TOKEN', undefined);
+  setEnv('PACHCA_PROFILE', undefined);
+  Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
+  Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true, configurable: true });
+  Object.defineProperty(process.stderr, 'isTTY', { value: false, writable: true, configurable: true });
+  setupProfile();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  for (const key of Object.keys(savedEnv)) delete savedEnv[key];
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Get fetch mock calls */
+function fetchCalls() {
+  return (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+}
+
+describe('generated commands — functional tests', () => {
+  // ----- GET list (users list) -----
+
+  describe('users list', () => {
+    it('GET /users → JSON array', async () => {
+      mockFetch({ data: { data: [{ id: 1, first_name: 'Ivan' }] } });
+      const { stdout } = await runCommand(['users', 'list'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual([{ id: 1, first_name: 'Ivan' }]);
+      expect(fetchCalls()[0][0]).toContain('/users');
+      expect(fetchCalls()[0][1].method).toBe('GET');
+    });
+
+    it('--limit 5 → query limit=5', async () => {
+      mockFetch({ data: { data: [{ id: 1 }] } });
+      await runCommand(['users', 'list', '--limit', '5'], { root: CLI_ROOT });
+      expect(fetchCalls()[0][0]).toContain('limit=5');
+    });
+
+    it('--cursor abc → query cursor=abc', async () => {
+      mockFetch({ data: { data: [{ id: 1 }] } });
+      await runCommand(['users', 'list', '--cursor', 'abc'], { root: CLI_ROOT });
+      expect(fetchCalls()[0][0]).toContain('cursor=abc');
+    });
+
+    it('--all → auto-paginate (2 pages)', async () => {
+      mockPaginatedFetch([
+        { data: [{ id: 1 }], next: 'cursor2' },
+        { data: [{ id: 2 }] },
+      ]);
+      const { stdout } = await runCommand(['users', 'list', '--all'], { root: CLI_ROOT });
+      expect(JSON.parse(stdout)).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(fetchCalls().length).toBe(2);
+    });
+
+    it('--all stops on cursor cycle', async () => {
+      mockPaginatedFetch([
+        { data: [{ id: 1 }], next: 'same' },
+        { data: [{ id: 2 }], next: 'same' },
+      ]);
+      const { stdout } = await runCommand(['users', 'list', '--all'], { root: CLI_ROOT });
+      expect(JSON.parse(stdout)).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(fetchCalls().length).toBe(2);
+    });
+
+    it('--quiet → empty stdout', async () => {
+      mockFetch({ data: { data: [{ id: 1 }] } });
+      const { stdout } = await runCommand(['users', 'list', '--quiet'], { root: CLI_ROOT });
+      expect(stdout.trim()).toBe('');
+    });
+  });
+
+  // ----- GET list output formats -----
+
+  describe('users list output formats', () => {
+    it('--output table → table with header', async () => {
+      mockFetch({ data: { data: [{ id: 1, first_name: 'Ivan', last_name: 'Petrov' }] } });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      const { stdout } = await runCommand(['users', 'list', '--output', 'table'], { root: CLI_ROOT });
+      // Table output has uppercased column headers
+      expect(stdout).toContain('ID');
+      expect(stdout).toContain('Ivan');
+    });
+
+    it('--output csv → CSV with header row', async () => {
+      mockFetch({ data: { data: [{ id: 1, first_name: 'Ivan', email: 'ivan@test.com' }] } });
+      const { stdout } = await runCommand(['users', 'list', '--output', 'csv'], { root: CLI_ROOT });
+      const lines = stdout.trim().split('\n');
+      // First line is CSV header
+      expect(lines[0]).toContain('id');
+      // Data row
+      expect(lines[1]).toContain('1');
+      expect(lines[1]).toContain('Ivan');
+    });
+  });
+
+  // ----- GET single (users get) -----
+
+  describe('users get', () => {
+    it('users get 123 → GET /users/123', async () => {
+      mockFetch({ data: { data: { id: 123, first_name: 'Ivan' } } });
+      const { stdout } = await runCommand(['users', 'get', '123'], { root: CLI_ROOT });
+      expect(JSON.parse(stdout)).toEqual({ id: 123, first_name: 'Ivan' });
+      expect(fetchCalls()[0][0]).toContain('/users/123');
+    });
+  });
+
+  // ----- POST create (messages create) -----
+
+  describe('messages create', () => {
+    it('--entity-id 456 --content hello → POST /messages with wrapper', async () => {
+      mockFetch({ data: { data: { id: 1, content: 'hello' } } });
+      await runCommand(['messages', 'create', '--entity-id', '456', '--content', 'hello'], { root: CLI_ROOT });
+      expect(fetchCalls().length).toBeGreaterThan(0);
+      const [url, opts] = fetchCalls()[0];
+      expect(url).toContain('/messages');
+      expect(opts.method).toBe('POST');
+      const body = JSON.parse(opts.body);
+      expect(body.message.entity_id).toBe(456);
+      expect(body.message.content).toBe('hello');
+    });
+
+    it('--files JSON array → body contains parsed array', async () => {
+      mockFetch({ data: { data: { id: 1 } } });
+      const filesJson = '[{"key":"file.png","name":"photo.png"}]';
+      await runCommand(['messages', 'create', '--entity-id', '456', '--content', 'hello', '--files', filesJson], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.message.files).toEqual([{ key: 'file.png', name: 'photo.png' }]);
+    });
+
+    it('missing required + --no-input → stderr error', async () => {
+      mockFetch({ data: {} });
+      // Pass --content to avoid stdin read hang, but omit required --entity-id
+      const { stderr, error } = await runCommand(['messages', 'create', '--content', 'hello', '--no-input'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('Обязательный флаг');
+    });
+  });
+
+  // ----- POST create with wrapper unwrap (users create) -----
+
+  describe('users create', () => {
+    it('--email test@test.com → body has user wrapper', async () => {
+      mockFetch({ data: { data: { id: 1 } } });
+      await runCommand(['users', 'create', '--email', 'test@test.com'], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.user).toBeDefined();
+      expect(body.user.email).toBe('test@test.com');
+    });
+
+    it('--skip-email-notify → sibling at top level', async () => {
+      mockFetch({ data: { data: { id: 1 } } });
+      await runCommand(['users', 'create', '--email', 'test@test.com', '--skip-email-notify'], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.user).toBeDefined();
+      expect(body.skip_email_notify).toBe(true);
+      expect(body.user.skip_email_notify).toBeUndefined();
+    });
+  });
+
+  // ----- PUT update (users update) -----
+
+  describe('users update', () => {
+    it('123 --first-name Ivan → PUT /users/123', async () => {
+      mockFetch({ data: { data: { id: 123 } } });
+      await runCommand(['users', 'update', '123', '--first-name', 'Ivan'], { root: CLI_ROOT });
+      const [url, opts] = fetchCalls()[0];
+      expect(url).toContain('/users/123');
+      expect(opts.method).toBe('PUT');
+      const body = JSON.parse(opts.body);
+      expect(body.user.first_name).toBe('Ivan');
+    });
+
+    it('no fields → stderr warning, no fetch', async () => {
+      mockFetch({ data: {} });
+      const { stderr } = await runCommand(['users', 'update', '123'], { root: CLI_ROOT });
+      expect(stderr).toContain('Не указаны поля для обновления');
+      expect(fetchCalls().length).toBe(0);
+    });
+
+    it('undefined fields stripped from body', async () => {
+      mockFetch({ data: { data: { id: 123 } } });
+      await runCommand(['users', 'update', '123', '--first-name', 'Ivan'], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.user.first_name).toBe('Ivan');
+      expect(body.user.last_name).toBeUndefined();
+      expect(body.user.email).toBeUndefined();
+    });
+  });
+
+  // ----- DELETE -----
+
+  describe('users delete', () => {
+    it('123 --force → DELETE /users/123', async () => {
+      mockFetch({ status: 204, data: null });
+      await runCommand(['users', 'delete', '123', '--force'], { root: CLI_ROOT });
+      expect(fetchCalls()[0][0]).toContain('/users/123');
+      expect(fetchCalls()[0][1].method).toBe('DELETE');
+    });
+
+    it('no --force + --no-input → error', async () => {
+      const { stderr, error } = await runCommand(['users', 'delete', '123', '--no-input'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('--force');
+    });
+
+    it('--force + --json → stdout {ok:true}', async () => {
+      mockFetch({ status: 204, data: null });
+      const { stdout } = await runCommand(['users', 'delete', '123', '--force', '--json'], { root: CLI_ROOT });
+      expect(stdout).toContain('"ok"');
+    });
+  });
+
+  // ----- Multipart (common direct-url) -----
+
+  describe('common direct-url', () => {
+    it('--file → FormData with wire name Content-Disposition', async () => {
+      mockFetch({ data: { data: { url: 'https://cdn.example.com/file.png' } } });
+      // Create a temp file to upload
+      const tmpFile = path.join(tmpDir, 'test.png');
+      fs.writeFileSync(tmpFile, 'fake-png-data');
+
+      await runCommand([
+        'common', 'direct-url',
+        '--content-disposition', 'inline',
+        '--acl', 'public-read',
+        '--policy', 'abc',
+        '--x-amz-credential', 'cred',
+        '--x-amz-algorithm', 'AWS4-HMAC-SHA256',
+        '--x-amz-date', '20240101T000000Z',
+        '--x-amz-signature', 'sig',
+        '--key', 'uploads/file.png',
+        '--file', tmpFile,
+      ], { root: CLI_ROOT });
+
+      expect(fetchCalls().length).toBeGreaterThan(0);
+      const [, opts] = fetchCalls()[0];
+      expect(opts.method).toBe('POST');
+      // Body should be FormData (not JSON)
+      expect(opts.body).toBeInstanceOf(FormData);
+      const fd = opts.body as FormData;
+      // Wire name: 'Content-Disposition' (not 'contentDisposition')
+      expect(fd.get('Content-Disposition')).toBe('inline');
+      expect(fd.get('key')).toBe('uploads/file.png');
+      expect(fd.get('file')).toBeTruthy();
+    });
+  });
+
+  // ----- Dry-run -----
+
+  describe('dry-run', () => {
+    it('--dry-run → stdout method + URL, no fetch', async () => {
+      const { stdout } = await runCommand(['users', 'list', '--dry-run'], { root: CLI_ROOT });
+      expect(stdout).toContain('GET');
+      expect(stdout).toContain('/users');
+    });
+
+    it('--dry-run --json → JSON with dry_run: true', async () => {
+      const { stdout } = await runCommand(['users', 'list', '--dry-run', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.dry_run).toBe(true);
+      expect(parsed.method).toBe('GET');
+    });
+  });
+
+  // ----- API errors -----
+
+  describe('API errors', () => {
+    it('401 → PACHCA_AUTH_ERROR', async () => {
+      mockFetch({
+        status: 401,
+        data: { error: 'invalid_token', error_description: 'Token is invalid' },
+      });
+      const { stderr, error } = await runCommand(['users', 'list'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('PACHCA_AUTH_ERROR');
+    });
+
+    it('404 → PACHCA_API_ERROR', async () => {
+      mockFetch({
+        status: 404,
+        data: { errors: [{ message: 'Not found' }] },
+      });
+      const { stderr, error } = await runCommand(['users', 'get', '999'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('PACHCA_API_ERROR');
+    });
+
+    it('429 → retry (2 fetch calls)', async () => {
+      let callCount = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false, status: 429, statusText: 'Too Many Requests',
+            headers: new Headers({ 'content-type': 'application/json', 'retry-after': '0' }),
+            json: () => Promise.resolve({ error: 'rate_limit' }),
+            text: () => Promise.resolve('{"error":"rate_limit"}'),
+          });
+        }
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({ data: [{ id: 1 }] }),
+          text: () => Promise.resolve('{"data":[{"id":1}]}'),
+        });
+      });
+      const { stdout } = await runCommand(['users', 'list'], { root: CLI_ROOT });
+      expect(callCount).toBe(2);
+      expect(JSON.parse(stdout)).toEqual([{ id: 1 }]);
+    });
+  });
+
+  // ----- Redirect (common uploads) -----
+
+  describe('common uploads', () => {
+    it('POST /uploads → response data', async () => {
+      mockFetch({ data: { data: { key: 'abc', url: 'https://cdn.example.com' } } });
+      const { stdout } = await runCommand(['common', 'uploads'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.key).toBe('abc');
+    });
+  });
+
+  // ----- Scope check -----
+
+  describe('scope check', () => {
+    it('missing scope → PACHCA_SCOPE_ERROR', async () => {
+      setupProfile(['users:read']);
+      mockFetch({ data: {} });
+      const { stderr, error } = await runCommand(['users', 'create', '--email', 'test@test.com'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('PACHCA_SCOPE_ERROR');
+    });
+  });
+
+  // ----- Composite query params (chats list) -----
+
+  describe('chats list', () => {
+    it('--sort-last-message-at desc → query sort[last_message_at]=desc', async () => {
+      mockFetch({ data: { data: [{ id: 1 }] } });
+      const { stdout, stderr, error } = await runCommand(['chats', 'list', '--sort-last-message-at', 'desc'], { root: CLI_ROOT });
+      // The mock might have been replaced if the init hook ran and modified fetch
+      // Check that the command ran successfully
+      expect(error).toBeUndefined();
+      expect(fetchCalls().length).toBeGreaterThan(0);
+      const url = fetchCalls()[0][0] as string;
+      expect(url).toContain('sort%5Blast_message_at%5D=desc');
+    });
+  });
+
+  // ----- Array query (search list-messages) -----
+
+  describe('search list-messages', () => {
+    it('--chat-ids 1,2,3 → query chat_ids', async () => {
+      mockFetch({ data: { data: [] } });
+      await runCommand(['search', 'list-messages', '--chat-ids', '1,2,3'], { root: CLI_ROOT });
+      expect(fetchCalls().length).toBeGreaterThan(0);
+      const url = fetchCalls()[0][0] as string;
+      expect(url).toContain('chat_ids=');
+    });
+  });
+});

--- a/packages/cli/tests/contract.test.ts
+++ b/packages/cli/tests/contract.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+
+const COMMANDS_DIR = path.join(__dirname, '..', 'src', 'commands');
+const SPEC_PATH = path.join(__dirname, '..', '..', 'spec', 'openapi.yaml');
+
+// ----- Minimal OpenAPI parser (same logic as generate-cli.ts) -----
+
+interface Schema {
+  type?: string | string[];
+  properties?: Record<string, Schema>;
+  items?: Schema;
+  required?: string[];
+  enum?: unknown[];
+  $ref?: string;
+  allOf?: Schema[];
+  oneOf?: Schema[];
+  anyOf?: Schema[];
+  readOnly?: boolean;
+  format?: string;
+}
+
+interface Parameter {
+  name: string;
+  in: 'query' | 'path';
+  schema: Schema;
+  'x-param-names'?: { name: string }[];
+}
+
+interface Endpoint {
+  method: string;
+  path: string;
+  parameters: Parameter[];
+  requestBody?: { content: Record<string, { schema: Schema }> };
+  requirements?: { scope?: string };
+}
+
+function parseSpec(): Endpoint[] {
+  const raw = fs.readFileSync(SPEC_PATH, 'utf-8');
+  const spec = yaml.load(raw) as Record<string, unknown>;
+  const paths = (spec.paths || {}) as Record<string, Record<string, unknown>>;
+  const endpoints: Endpoint[] = [];
+
+  function resolveRef(obj: unknown): unknown {
+    if (!obj || typeof obj !== 'object') return obj;
+    const rec = obj as Record<string, unknown>;
+    if (rec.$ref && typeof rec.$ref === 'string') {
+      const refPath = rec.$ref.replace('#/', '').split('/');
+      let current: unknown = spec;
+      for (const part of refPath) {
+        if (current && typeof current === 'object') current = (current as Record<string, unknown>)[part];
+      }
+      return resolveRef(current);
+    }
+    return obj;
+  }
+
+  function resolveSchema(s: unknown, depth = 0): Schema {
+    if (depth > 10) return s as Schema;
+    const resolved = resolveRef(s) as Record<string, unknown>;
+    if (!resolved || typeof resolved !== 'object') return {} as Schema;
+    const result: Schema = { ...resolved } as Schema;
+    if (result.properties) {
+      const props: Record<string, Schema> = {};
+      for (const [k, v] of Object.entries(result.properties)) props[k] = resolveSchema(v, depth + 1);
+      result.properties = props;
+    }
+    if (result.items) result.items = resolveSchema(result.items, depth + 1);
+    if (result.allOf) result.allOf = result.allOf.map((s) => resolveSchema(s, depth + 1));
+    if (result.oneOf) result.oneOf = result.oneOf.map((s) => resolveSchema(s, depth + 1));
+    if (result.anyOf) result.anyOf = result.anyOf.map((s) => resolveSchema(s, depth + 1));
+    return result;
+  }
+
+  for (const [pathStr, methods] of Object.entries(paths)) {
+    if (!methods || typeof methods !== 'object') continue;
+    for (const [method, opRaw] of Object.entries(methods as Record<string, unknown>)) {
+      if (!['get', 'post', 'put', 'delete', 'patch'].includes(method)) continue;
+      const op = opRaw as Record<string, unknown>;
+
+      const params: Parameter[] = [];
+      for (const p of (op.parameters || []) as Record<string, unknown>[]) {
+        const resolved = resolveRef(p) as Record<string, unknown>;
+        if (!resolved) continue;
+        params.push({
+          name: resolved.name as string,
+          in: resolved.in as 'query' | 'path',
+          schema: resolveSchema(resolved.schema),
+          'x-param-names': resolved['x-param-names'] as Parameter['x-param-names'],
+        });
+      }
+
+      let requestBody: Endpoint['requestBody'] | undefined;
+      if (op.requestBody) {
+        const rb = resolveRef(op.requestBody) as Record<string, unknown>;
+        const content: Record<string, { schema: Schema }> = {};
+        if (rb.content && typeof rb.content === 'object') {
+          for (const [ct, mediaRaw] of Object.entries(rb.content as Record<string, unknown>)) {
+            const media = resolveRef(mediaRaw) as Record<string, unknown>;
+            content[ct] = { schema: resolveSchema(media.schema) };
+          }
+        }
+        requestBody = { content };
+      }
+
+      let requirements: Endpoint['requirements'] | undefined;
+      if (op['x-requirements'] && typeof op['x-requirements'] === 'object') {
+        const req = op['x-requirements'] as Record<string, unknown>;
+        requirements = { scope: req.scope as string | undefined };
+      }
+
+      endpoints.push({ method: method.toUpperCase(), path: pathStr, parameters: params, requestBody, requirements });
+    }
+  }
+  return endpoints;
+}
+
+function resolveAllOf(schema: Schema): Schema {
+  if (!schema.allOf || schema.allOf.length === 0) return schema;
+  let merged: Schema = {};
+  for (const sub of schema.allOf) {
+    const resolved = resolveAllOf(sub);
+    merged = { ...merged, ...resolved, properties: { ...merged.properties, ...resolved.properties }, required: [...(merged.required || []), ...(resolved.required || [])] };
+  }
+  return merged;
+}
+
+function getSchemaType(schema: Schema): string {
+  if (schema.type) { return Array.isArray(schema.type) ? schema.type[0] : schema.type; }
+  if (schema.enum) return 'string';
+  if (schema.properties) return 'object';
+  return 'string';
+}
+
+function toKebabCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').replace(/_/g, '-').toLowerCase();
+}
+
+/** Same logic as generator for composite param flag name */
+function compositeParamFlagName(subName: string): string {
+  return toKebabCase(subName.replace(/[\[\]]/g, '-').replace(/-+/g, '-').replace(/-$/, ''));
+}
+
+function getWrapperKey(schema: Schema): string | null {
+  const resolved = resolveAllOf(schema);
+  if (!resolved.properties) return null;
+  const keys = Object.keys(resolved.properties);
+  const objectKeys = keys.filter((k) => {
+    const inner = resolveAllOf(resolved.properties![k]);
+    return inner.properties && Object.keys(inner.properties).length > 0;
+  });
+  if (objectKeys.length === 1) return objectKeys[0];
+  return null;
+}
+
+function extractBodyFields(requestBody?: Endpoint['requestBody']) {
+  if (!requestBody) return [];
+  const content = requestBody.content['application/json'] || requestBody.content['multipart/form-data'];
+  if (!content?.schema) return [];
+
+  const resolved = resolveAllOf(content.schema);
+  const properties = resolved.properties || {};
+
+  const topKeys = Object.keys(properties);
+  const objectKeys = topKeys.filter((k) => {
+    const inner = resolveAllOf(properties[k]);
+    return inner.properties && Object.keys(inner.properties).length > 0;
+  });
+
+  if (objectKeys.length === 1) {
+    const wrapperKey = objectKeys[0];
+    const innerResolved = resolveAllOf(properties[wrapperKey]);
+    if (innerResolved.properties) {
+      const fields = Object.entries(innerResolved.properties)
+        .filter(([, v]) => !v.readOnly)
+        .map(([name, p]) => ({ name, type: getSchemaType(p), enum: p.enum, isSibling: false }));
+
+      for (const key of topKeys) {
+        if (key === wrapperKey) continue;
+        const p = resolveAllOf(properties[key]);
+        fields.push({ name: key, type: getSchemaType(p), enum: p.enum, isSibling: true });
+      }
+      return fields;
+    }
+  }
+
+  return Object.entries(properties).filter(([, v]) => !v.readOnly)
+    .map(([name, p]) => ({ name, type: getSchemaType(p), enum: p.enum, isSibling: false }));
+}
+
+const MULTIPART_WIRE_NAMES: Record<string, string> = {
+  contentDisposition: 'Content-Disposition',
+  xAmzCredential: 'x-amz-credential',
+  xAmzAlgorithm: 'x-amz-algorithm',
+  xAmzDate: 'x-amz-date',
+  xAmzSignature: 'x-amz-signature',
+};
+
+// ----- Tests -----
+
+describe('contract tests', () => {
+  const endpoints = parseSpec();
+
+  it('should have at least 50 endpoints', () => {
+    expect(endpoints.length).toBeGreaterThanOrEqual(50);
+  });
+
+  // Build map of generated command files
+  const generatedFiles = new Map<string, string>();
+  const commandSections = fs.readdirSync(COMMANDS_DIR).filter((f) =>
+    fs.statSync(path.join(COMMANDS_DIR, f)).isDirectory()
+  );
+  for (const section of commandSections) {
+    const sectionDir = path.join(COMMANDS_DIR, section);
+    for (const file of fs.readdirSync(sectionDir).filter((f) => f.endsWith('.ts'))) {
+      const content = fs.readFileSync(path.join(sectionDir, file), 'utf-8');
+      if (content.includes('Auto-generated from openapi.yaml')) {
+        generatedFiles.set(`${section}/${file.replace('.ts', '')}`, content);
+      }
+    }
+  }
+
+  function findCommand(ep: Endpoint): { key: string; content: string } | null {
+    for (const [key, content] of generatedFiles) {
+      const m = content.match(/static apiMethod = "(\w+)"/);
+      const p = content.match(/static apiPath = "([^"]+)"/);
+      if (m?.[1] === ep.method && p?.[1] === ep.path) return { key, content };
+    }
+    return null;
+  }
+
+  /** Check if flag name exists in the command source (handles both 'name': and name: forms) */
+  function hasFlag(content: string, flagName: string): boolean {
+    return content.includes(`'${flagName}'`) || new RegExp(`\\b${flagName}:\\s*Flags\\.`).test(content);
+  }
+
+  for (const endpoint of endpoints) {
+    const cmd = findCommand(endpoint);
+    if (!cmd) continue;
+
+    const hasPagination = endpoint.parameters.some((p) => p.in === 'query' && p.name === 'limit');
+
+    describe(`${endpoint.method} ${endpoint.path} → ${cmd.key}`, () => {
+      it('method matches', () => {
+        expect(cmd.content).toMatch(new RegExp(`static apiMethod = "${endpoint.method}"`));
+      });
+
+      it('path matches', () => {
+        expect(cmd.content).toContain(`static apiPath = "${endpoint.path}"`);
+      });
+
+      // Path parameters → Args
+      const pathParams = [...endpoint.path.matchAll(/\{(\w+)\}/g)].map((m) => m[1]);
+      for (const param of pathParams) {
+        it(`path param {${param}} → arg`, () => {
+          expect(cmd.content).toContain(`${param}: Args.`);
+        });
+      }
+
+      // Query parameters → Flags
+      const queryParams = endpoint.parameters.filter((p) => p.in === 'query');
+      for (const param of queryParams) {
+        // Skip limit/cursor — generator replaces them with its own pagination flags
+        if (hasPagination && (param.name === 'limit' || param.name === 'cursor')) continue;
+
+        if (param['x-param-names']) {
+          for (const sub of param['x-param-names']) {
+            const flagName = compositeParamFlagName(sub.name);
+            it(`composite query ${sub.name} → --${flagName}`, () => {
+              expect(hasFlag(cmd.content, flagName)).toBe(true);
+            });
+          }
+        } else {
+          const kebabName = toKebabCase(param.name);
+          it(`query ${param.name} → --${kebabName}`, () => {
+            expect(hasFlag(cmd.content, kebabName)).toBe(true);
+          });
+        }
+      }
+
+      // Body fields → Flags
+      const bodyFields = extractBodyFields(endpoint.requestBody);
+      for (const field of bodyFields) {
+        const kebabName = toKebabCase(field.name);
+        it(`body ${field.name} → --${kebabName}`, () => {
+          expect(hasFlag(cmd.content, kebabName)).toBe(true);
+        });
+      }
+
+      // Enum constraints
+      for (const field of bodyFields) {
+        if (field.enum && field.enum.length > 0) {
+          it(`enum ${field.name} has options`, () => {
+            for (const val of field.enum!) expect(cmd.content).toContain(String(val));
+          });
+        }
+      }
+      for (const param of queryParams) {
+        if (hasPagination && (param.name === 'limit' || param.name === 'cursor')) continue;
+        if (param['x-param-names']) continue;
+        if (param.schema.enum && param.schema.enum.length > 0) {
+          it(`query enum ${param.name} has options`, () => {
+            for (const val of param.schema.enum!) expect(cmd.content).toContain(String(val));
+          });
+        }
+      }
+
+      // Scope
+      if (endpoint.requirements?.scope) {
+        it(`scope = "${endpoint.requirements.scope}"`, () => {
+          expect(cmd.content).toContain(`static scope = "${endpoint.requirements!.scope}"`);
+          expect(cmd.content).toContain(`this.checkScope("${endpoint.requirements!.scope}")`);
+        });
+      }
+
+      // Wrapper unwrap
+      if (endpoint.requestBody?.content['application/json']) {
+        const jsonSchema = endpoint.requestBody.content['application/json'].schema;
+        const wrapperKey = getWrapperKey(jsonSchema);
+        if (wrapperKey) {
+          it(`wrapper key "${wrapperKey}"`, () => {
+            expect(cmd.content).toContain(`${wrapperKey}: {`);
+          });
+
+          const resolved = resolveAllOf(jsonSchema);
+          const siblings = Object.keys(resolved.properties || {}).filter((k) => k !== wrapperKey);
+          for (const sibling of siblings) {
+            const sibResolved = resolveAllOf((resolved.properties || {})[sibling]);
+            if (!sibResolved.properties || Object.keys(sibResolved.properties).length === 0) {
+              it(`sibling "${sibling}" at top level`, () => {
+                expect(cmd.content).toMatch(new RegExp(`${sibling}:\\s*flags\\[`));
+              });
+            }
+          }
+        }
+      }
+
+      // Pagination
+      if (hasPagination) {
+        it('has pagination flags', () => {
+          expect(hasFlag(cmd.content, 'limit')).toBe(true);
+          expect(hasFlag(cmd.content, 'cursor')).toBe(true);
+          expect(hasFlag(cmd.content, 'all')).toBe(true);
+        });
+
+        it('has auto-pagination', () => {
+          expect(cmd.content).toContain('flags.all');
+          expect(cmd.content).toContain('nextCursor');
+          expect(cmd.content).toContain('seenCursors');
+        });
+      }
+
+      // DELETE → --force
+      if (endpoint.method === 'DELETE') {
+        it('has --force + confirmation', () => {
+          expect(hasFlag(cmd.content, 'force')).toBe(true);
+          expect(cmd.content).toContain('Вы уверены?');
+        });
+      }
+
+      // Boolean flags → allowNo
+      const boolFlags = [...cmd.content.matchAll(/'([^']+)':\s*Flags\.boolean\(\{([^}]*)\}/gs)];
+      for (const [, name, body] of boolFlags) {
+        if (name === 'force' || name === 'all') continue;
+        it(`--${name} has allowNo`, () => {
+          expect(body).toContain('allowNo: true');
+        });
+      }
+
+      // Array query params → hint
+      for (const param of queryParams) {
+        if (hasPagination && (param.name === 'limit' || param.name === 'cursor')) continue;
+        if (param['x-param-names']) continue;
+        if (param.schema.type === 'array' || param.schema.items) {
+          it(`array ${param.name} has comma hint`, () => {
+            expect(cmd.content).toContain('через запятую');
+          });
+        }
+      }
+
+      // Multipart wire names
+      if (endpoint.requestBody?.content['multipart/form-data']) {
+        it('uses FormData', () => {
+          expect(cmd.content).toContain('FormData');
+        });
+
+        const mpSchema = endpoint.requestBody.content['multipart/form-data'].schema;
+        const resolved = resolveAllOf(mpSchema);
+        if (resolved.properties) {
+          for (const propName of Object.keys(resolved.properties)) {
+            const wireName = MULTIPART_WIRE_NAMES[propName];
+            if (wireName) {
+              it(`multipart "${propName}" → wire "${wireName}"`, () => {
+                expect(cmd.content).toContain(`'${wireName}'`);
+              });
+            }
+          }
+        }
+      }
+
+      // All flags are kebab-case
+      const flagNames = [...cmd.content.matchAll(/'([^']+)':\s*Flags\.\w+\(/g)].map((m) => m[1]);
+      for (const name of flagNames) {
+        it(`flag "${name}" is kebab-case`, () => {
+          expect(name).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+        });
+      }
+    });
+  }
+});

--- a/packages/cli/tests/generate-cli.test.ts
+++ b/packages/cli/tests/generate-cli.test.ts
@@ -139,4 +139,91 @@ describe('generate-cli', () => {
       expect(content).toContain('static scope = ');
     });
   });
+
+  describe('toKebabCase via generated output', () => {
+    it('should convert camelCase flag names to kebab-case (direct-url)', () => {
+      const content = fs.readFileSync(
+        path.join(COMMANDS_DIR, 'common', 'direct-url.ts'),
+        'utf-8',
+      );
+      expect(content).toContain("'content-disposition'");
+      expect(content).toContain("'x-amz-credential'");
+      expect(content).toContain("'x-amz-algorithm'");
+      expect(content).toContain("'x-amz-date'");
+      expect(content).toContain("'x-amz-signature'");
+      // Must NOT contain camelCase flag names
+      expect(content).not.toMatch(/'contentDisposition':\s*Flags/);
+      expect(content).not.toMatch(/'xAmz\w+':\s*Flags/);
+    });
+
+    it('should convert composite param names with underscores (sort flags)', () => {
+      const content = fs.readFileSync(
+        path.join(COMMANDS_DIR, 'chats', 'list.ts'),
+        'utf-8',
+      );
+      // sort[last_message_at] → sort-last-message-at (not sort-last_message_at)
+      expect(content).toContain("'sort-last-message-at'");
+      // Flag declaration must be kebab-case (wire name in query object keeps underscores)
+      expect(content).not.toMatch(/'sort-last_message_at':\s*Flags/);
+    });
+  });
+
+  describe('wrapper unwrap with sibling fields', () => {
+    it('users/create should have individual flags, not a single user JSON flag', () => {
+      const content = fs.readFileSync(
+        path.join(COMMANDS_DIR, 'users', 'create.ts'),
+        'utf-8',
+      );
+      // Individual flags for user fields
+      expect(content).toContain("'first-name': Flags.string");
+      expect(content).toContain("'last-name': Flags.string");
+      expect(content).toContain("'email': Flags.string");
+      // Sibling field at top level of body (not inside user wrapper)
+      expect(content).toContain("skip_email_notify: flags['skip-email-notify']");
+      // Wrapper structure: user: { first_name, ... } at inner level
+      expect(content).toContain("user: {");
+      expect(content).toContain("first_name: flags['first-name']");
+    });
+
+    it('views/open should have sibling fields at top level', () => {
+      const content = fs.readFileSync(
+        path.join(COMMANDS_DIR, 'views', 'open.ts'),
+        'utf-8',
+      );
+      // Siblings: type, trigger_id, private_metadata, callback_id
+      expect(content).toMatch(/type: flags\['type'\],\s*\n\s*trigger_id:/);
+      // View wrapper inner fields
+      expect(content).toContain("view: {");
+    });
+  });
+
+  describe('multipart wire names', () => {
+    it('direct-url should use correct wire names in formData.append', () => {
+      const content = fs.readFileSync(
+        path.join(COMMANDS_DIR, 'common', 'direct-url.ts'),
+        'utf-8',
+      );
+      expect(content).toContain("formData.append('Content-Disposition'");
+      expect(content).toContain("formData.append('x-amz-credential'");
+      expect(content).toContain("formData.append('x-amz-algorithm'");
+      expect(content).toContain("formData.append('x-amz-date'");
+      expect(content).toContain("formData.append('x-amz-signature'");
+      // Flags use kebab-case
+      expect(content).toContain("flags['content-disposition']");
+      expect(content).toContain("flags['x-amz-credential']");
+    });
+  });
+
+  describe('array query params', () => {
+    it('search commands should hint comma-separated format', () => {
+      const content = fs.readFileSync(
+        path.join(COMMANDS_DIR, 'search', 'list-messages.ts'),
+        'utf-8',
+      );
+      // Hint is added as string concatenation: "description" + " (через запятую)"
+      expect(content).toContain('через запятую');
+      expect(content).toContain("'chat-ids'");
+      expect(content).toContain("'user-ids'");
+    });
+  });
 });

--- a/packages/cli/tests/manual-commands.test.ts
+++ b/packages/cli/tests/manual-commands.test.ts
@@ -1,0 +1,546 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runCommand } from '@oclif/test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const CLI_ROOT = path.join(__dirname, '..');
+
+let tmpDir: string;
+const originalFetch = globalThis.fetch;
+const savedEnv: Record<string, string | undefined> = {};
+
+function setEnv(key: string, value: string | undefined) {
+  if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function mockFetch(response: { status?: number; data?: unknown; headers?: Record<string, string> }) {
+  const status = response.status ?? 200;
+  const headers = new Headers({ 'content-type': 'application/json', ...response.headers });
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 400,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers,
+    json: () => Promise.resolve(response.data ?? {}),
+    text: () => Promise.resolve(JSON.stringify(response.data ?? {})),
+  });
+}
+
+function fetchCalls() {
+  return (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+}
+
+function setupProfile(name = 'test', opts: { scopes?: string[]; type?: string; user?: string; email?: string } = {}) {
+  const configDir = path.join(tmpDir, 'pachca');
+  fs.mkdirSync(configDir, { recursive: true });
+  const scopes = opts.scopes ?? ['users:read', 'messages:create'];
+  const type = opts.type ?? 'user';
+  const user = opts.user ?? 'Test User';
+  const email = opts.email ?? 'test@test.com';
+  const scopesStr = scopes.map((s) => `"${s}"`).join(', ');
+  fs.writeFileSync(
+    path.join(configDir, 'config.toml'),
+    `active_profile = "${name}"\n\n[profiles.${name}]\ntype = "${type}"\ntoken = "test-token"\nuser = "${user}"\nemail = "${email}"\nscopes = [${scopesStr}]\n`,
+  );
+}
+
+function setupMultiProfiles() {
+  const configDir = path.join(tmpDir, 'pachca');
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(configDir, 'config.toml'),
+    [
+      'active_profile = "default"',
+      '',
+      '[profiles.default]',
+      'type = "user"',
+      'token = "token-default"',
+      'user = "Default User"',
+      'email = "default@test.com"',
+      'scopes = ["users:read"]',
+      '',
+      '[profiles.bot]',
+      'type = "bot"',
+      'token = "token-bot"',
+      'user = "Bot User"',
+      'scopes = ["messages:create"]',
+    ].join('\n') + '\n',
+  );
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pachca-manual-test-'));
+  setEnv('XDG_CONFIG_HOME', tmpDir);
+  setEnv('PACHCA_TOKEN', undefined);
+  setEnv('PACHCA_PROFILE', undefined);
+  Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
+  Object.defineProperty(process.stdout, 'isTTY', { value: false, writable: true, configurable: true });
+  Object.defineProperty(process.stderr, 'isTTY', { value: false, writable: true, configurable: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  for (const key of Object.keys(savedEnv)) delete savedEnv[key];
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('manual commands — functional tests', () => {
+  // ===== Auth commands =====
+
+  describe('auth login', () => {
+    it('--token valid → profile saved', async () => {
+      // Mock token info + profile
+      let callNum = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callNum++;
+        if (callNum === 1) {
+          // GET /oauth/token/info
+          return Promise.resolve({
+            ok: true, status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({ user_id: 1, scopes: ['users:read', 'messages:create'] }),
+            text: () => Promise.resolve('{}'),
+          });
+        }
+        // GET /profile
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({ data: { first_name: 'Ivan', last_name: 'Petrov', email: 'ivan@test.com', bot: false } }),
+          text: () => Promise.resolve('{}'),
+        });
+      });
+
+      const { error } = await runCommand(['auth', 'login', '--token', 'my-token'], { root: CLI_ROOT });
+      expect(error).toBeUndefined();
+      // Profile should be saved
+      const configPath = path.join(tmpDir, 'pachca', 'config.toml');
+      expect(fs.existsSync(configPath)).toBe(true);
+      const content = fs.readFileSync(configPath, 'utf-8');
+      expect(content).toContain('my-token');
+      expect(content).toContain('Ivan Petrov');
+    });
+
+    it('--token invalid → 401 error', async () => {
+      mockFetch({ status: 401, data: { error: 'invalid_token', error_description: 'Token is invalid' } });
+      const { error } = await runCommand(['auth', 'login', '--token', 'bad-token'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+    });
+
+    it('--profile custom → saves under custom name', async () => {
+      let callNum = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callNum++;
+        if (callNum === 1) {
+          return Promise.resolve({
+            ok: true, status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({ user_id: 1, scopes: ['users:read'] }),
+            text: () => Promise.resolve('{}'),
+          });
+        }
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({ data: { first_name: 'Bot', last_name: '', email: null, bot: true } }),
+          text: () => Promise.resolve('{}'),
+        });
+      });
+
+      const { error } = await runCommand(['auth', 'login', '--token', 'bot-token', '--profile', 'my-bot'], { root: CLI_ROOT });
+      expect(error).toBeUndefined();
+      const content = fs.readFileSync(path.join(tmpDir, 'pachca', 'config.toml'), 'utf-8');
+      expect(content).toContain('my-bot');
+    });
+
+    it('no --token + --no-input → error', async () => {
+      const { stderr, error } = await runCommand(['auth', 'login', '--no-input'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('Token required');
+    });
+
+    it('bot token → type: bot', async () => {
+      let callNum = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callNum++;
+        if (callNum === 1) {
+          return Promise.resolve({
+            ok: true, status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({ user_id: 1, scopes: ['messages:create'] }),
+            text: () => Promise.resolve('{}'),
+          });
+        }
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({ data: { first_name: 'Bot', last_name: '', email: null, bot: true } }),
+          text: () => Promise.resolve('{}'),
+        });
+      });
+
+      const { stdout } = await runCommand(['auth', 'login', '--token', 'bot-token', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.type).toBe('bot');
+    });
+  });
+
+  describe('auth logout', () => {
+    it('logout profileName → deleted', async () => {
+      setupProfile();
+      const { error } = await runCommand(['auth', 'logout', 'test'], { root: CLI_ROOT });
+      expect(error).toBeUndefined();
+      const content = fs.readFileSync(path.join(tmpDir, 'pachca', 'config.toml'), 'utf-8');
+      expect(content).not.toContain('[profiles.test]');
+    });
+
+    it('logout nonexistent → error', async () => {
+      setupProfile();
+      const { stderr, error } = await runCommand(['auth', 'logout', 'nonexistent'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('not found');
+    });
+
+    it('logout single → active_profile cleared', async () => {
+      setupProfile();
+      await runCommand(['auth', 'logout', 'test'], { root: CLI_ROOT });
+      const content = fs.readFileSync(path.join(tmpDir, 'pachca', 'config.toml'), 'utf-8');
+      // active_profile should be empty or cleared
+      expect(content).not.toContain('active_profile = "test"');
+    });
+  });
+
+  describe('auth status', () => {
+    it('shows profile info', async () => {
+      setupProfile();
+      const { stdout } = await runCommand(['auth', 'status', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.profile).toBe('test');
+      expect(parsed.type).toBe('user');
+      expect(parsed.user).toBe('Test User');
+    });
+
+    it('no profile → error', async () => {
+      // Don't set up profile
+      const { stderr, error } = await runCommand(['auth', 'status'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('No active profile');
+    });
+  });
+
+  describe('auth list', () => {
+    it('shows all profiles with active marker', async () => {
+      setupMultiProfiles();
+      const { stdout } = await runCommand(['auth', 'list', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toHaveLength(2);
+      const defaultProfile = parsed.find((p: { name: string }) => p.name === 'default');
+      expect(defaultProfile.active).toBe(true);
+      const botProfile = parsed.find((p: { name: string }) => p.name === 'bot');
+      expect(botProfile.active).toBe(false);
+    });
+
+    it('empty → empty array in JSON', async () => {
+      // No profiles
+      const { stdout } = await runCommand(['auth', 'list', '--json'], { root: CLI_ROOT });
+      expect(JSON.parse(stdout)).toEqual([]);
+    });
+  });
+
+  describe('auth refresh', () => {
+    it('refreshes scopes', async () => {
+      setupProfile('test', { scopes: ['users:read'] });
+      mockFetch({ data: { scopes: ['users:read', 'users:create'] } });
+      const { stdout } = await runCommand(['auth', 'refresh', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.scopes_before).toEqual(['users:read']);
+      expect(parsed.scopes_after).toContain('users:create');
+      expect(parsed.added).toContain('users:create');
+    });
+
+    it('no profile → error', async () => {
+      const { stderr, error } = await runCommand(['auth', 'refresh'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe('auth switch', () => {
+    it('switch name → active_profile changed', async () => {
+      setupMultiProfiles();
+      const { stdout } = await runCommand(['auth', 'switch', 'bot', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.active_profile).toBe('bot');
+    });
+
+    it('nonexistent → error', async () => {
+      setupMultiProfiles();
+      const { stderr, error } = await runCommand(['auth', 'switch', 'nonexistent'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('not found');
+    });
+  });
+
+  // ===== Config commands =====
+
+  describe('config set', () => {
+    it('set defaults.output json → saved', async () => {
+      setupProfile();
+      const { stdout } = await runCommand(['config', 'set', 'defaults.output', 'json', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.key).toBe('defaults.output');
+      expect(parsed.value).toBe('json');
+    });
+
+    it('set unknown.key → error', async () => {
+      setupProfile();
+      const { error } = await runCommand(['config', 'set', 'unknown.key', 'value'], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+    });
+
+    it('set defaults.timeout 60 → number saved', async () => {
+      setupProfile();
+      await runCommand(['config', 'set', 'defaults.timeout', '60'], { root: CLI_ROOT });
+      const content = fs.readFileSync(path.join(tmpDir, 'pachca', 'config.toml'), 'utf-8');
+      expect(content).toContain('timeout = 60');
+    });
+  });
+
+  describe('config get', () => {
+    it('get existing key → outputs value', async () => {
+      setupProfile();
+      await runCommand(['config', 'set', 'defaults.output', 'yaml'], { root: CLI_ROOT });
+      const { stdout } = await runCommand(['config', 'get', 'defaults.output', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.value).toBe('yaml');
+    });
+
+    it('get missing key → null', async () => {
+      setupProfile();
+      const { stdout } = await runCommand(['config', 'get', 'defaults.output', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.value).toBeNull();
+    });
+  });
+
+  describe('config list', () => {
+    it('JSON mode → object without profiles', async () => {
+      setupProfile();
+      await runCommand(['config', 'set', 'defaults.output', 'json'], { root: CLI_ROOT });
+      const { stdout } = await runCommand(['config', 'list', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.defaults).toBeDefined();
+      expect(parsed.profiles).toBeUndefined();
+    });
+  });
+
+  // ===== Utility commands =====
+
+  describe('doctor', () => {
+    it('JSON mode → array of checks', async () => {
+      setupProfile();
+      // Mock network calls
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.includes('profile')) {
+          return Promise.resolve({
+            ok: true, status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({}),
+            text: () => Promise.resolve('{}'),
+          });
+        }
+        if (typeof url === 'string' && url.includes('token/info')) {
+          return Promise.resolve({
+            ok: true, status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({ scopes: ['users:read'] }),
+            text: () => Promise.resolve('{}'),
+          });
+        }
+        if (typeof url === 'string' && url.includes('npmjs')) {
+          return Promise.resolve({
+            ok: true, status: 200,
+            headers: new Headers({ 'content-type': 'application/json' }),
+            json: () => Promise.resolve({ 'dist-tags': { latest: '0.0.0' } }),
+            text: () => Promise.resolve('{}'),
+          });
+        }
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: new Headers({ 'content-type': 'application/json' }),
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('{}'),
+        });
+      });
+
+      const { stdout } = await runCommand(['doctor', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.checks).toBeDefined();
+      expect(Array.isArray(parsed.checks)).toBe(true);
+      // Node.js check should be ok
+      const nodeCheck = parsed.checks.find((c: { name: string }) => c.name === 'node');
+      expect(nodeCheck?.status).toBe('ok');
+    });
+
+    it('no network → error/warning for network check', async () => {
+      setupProfile();
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      const { stdout, error } = await runCommand(['doctor', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      const networkCheck = parsed.checks.find((c: { name: string }) => c.name === 'network');
+      expect(networkCheck?.status).toBe('error');
+    });
+
+    it('no profile → skipped for token check', async () => {
+      // Don't set up profile
+      mockFetch({ data: {} });
+      const { stdout } = await runCommand(['doctor', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      const tokenCheck = parsed.checks.find((c: { name: string }) => c.name === 'token');
+      // Token check should be skipped if no profile
+      expect(tokenCheck?.status).toBe('skipped');
+    });
+  });
+
+  describe('guide', () => {
+    it('no query → list all workflows', async () => {
+      const { stdout } = await runCommand(['guide', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(0);
+    });
+
+    it('query "сообщение" → found workflows', async () => {
+      const { stdout } = await runCommand(['guide', 'сообщение', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+    });
+
+    it('query "xyznonexistent" → empty array', async () => {
+      const { stdout } = await runCommand(['guide', 'xyznonexistent123', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toEqual([]);
+    });
+  });
+
+  describe('commands', () => {
+    it('lists all commands', async () => {
+      const { stdout } = await runCommand(['commands', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(10);
+    });
+
+    it('--available → filter by scopes', async () => {
+      setupProfile('test', { scopes: ['users:read'] });
+      const { stdout } = await runCommand(['commands', '--available', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      // Should have available flag
+      const usersRead = parsed.find((c: { scope: string }) => c.scope === 'users:read');
+      if (usersRead) expect(usersRead.available).toBe(true);
+      const messagesCreate = parsed.find((c: { scope: string }) => c.scope === 'messages:create');
+      if (messagesCreate) expect(messagesCreate.available).toBe(false);
+    });
+  });
+
+  describe('changelog', () => {
+    it('outputs changelog data', async () => {
+      const { stdout } = await runCommand(['changelog', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+    });
+  });
+
+  describe('version', () => {
+    it('outputs version string', async () => {
+      const { stdout } = await runCommand(['version'], { root: CLI_ROOT });
+      expect(stdout).toContain('version');
+    });
+
+    it('JSON → { version: "..." }', async () => {
+      const { stdout } = await runCommand(['version', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.version).toBeDefined();
+    });
+  });
+
+  describe('introspect', () => {
+    it('no args → list all commands with meta', async () => {
+      const { stdout } = await runCommand(['introspect', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeGreaterThan(10);
+      // Each entry should have command and summary
+      expect(parsed[0].command).toBeDefined();
+    });
+
+    it('introspect "messages create" → flags list', async () => {
+      const { stdout } = await runCommand(['introspect', 'messages', 'create', '--json'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.command).toContain('messages');
+      expect(parsed.flags).toBeDefined();
+      expect(Array.isArray(parsed.flags)).toBe(true);
+    });
+  });
+
+  describe('api', () => {
+    it('api GET /profile → fetch GET + JSON output', async () => {
+      setupProfile();
+      mockFetch({ data: { data: { id: 1, name: 'Ivan' } } });
+      const { stdout } = await runCommand(['api', 'GET', '/profile'], { root: CLI_ROOT });
+      const parsed = JSON.parse(stdout);
+      expect(parsed.data).toBeDefined();
+      expect(fetchCalls()[0][1].method).toBe('GET');
+    });
+
+    it('api POST /messages -f message[content]=hello → nested body', async () => {
+      setupProfile();
+      mockFetch({ data: { data: { id: 1 } } });
+      await runCommand(['api', 'POST', '/messages', '-f', 'message[content]=hello'], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.message.content).toBe('hello');
+    });
+
+    it('api POST -F message[chat_id]=123 → number (not string)', async () => {
+      setupProfile();
+      mockFetch({ data: { data: { id: 1 } } });
+      await runCommand(['api', 'POST', '/messages', '-F', 'message[chat_id]=123'], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.message.chat_id).toBe(123);
+    });
+
+    it('api GET /users --query limit=5 → query ?limit=5', async () => {
+      setupProfile();
+      mockFetch({ data: { data: [] } });
+      await runCommand(['api', 'GET', '/users', '--query', 'limit=5'], { root: CLI_ROOT });
+      const url = fetchCalls()[0][0] as string;
+      expect(url).toContain('limit=5');
+    });
+
+    it('api POST --input file → body from file', async () => {
+      setupProfile();
+      const inputFile = path.join(tmpDir, 'payload.json');
+      fs.writeFileSync(inputFile, JSON.stringify({ message: { content: 'from file' } }));
+      mockFetch({ data: { data: { id: 1 } } });
+      await runCommand(['api', 'POST', '/messages', '--input', inputFile], { root: CLI_ROOT });
+      const body = JSON.parse(fetchCalls()[0][1].body);
+      expect(body.message.content).toBe('from file');
+    });
+
+    it('-f and --input → mutually exclusive error', async () => {
+      setupProfile();
+      const inputFile = path.join(tmpDir, 'payload.json');
+      fs.writeFileSync(inputFile, '{}');
+      const { stderr, error } = await runCommand(['api', 'POST', '/messages', '-f', 'key=val', '--input', inputFile], { root: CLI_ROOT });
+      expect(error).toBeTruthy();
+      expect(stderr).toContain('mutually exclusive');
+    });
+  });
+});

--- a/packages/cli/tests/output.test.ts
+++ b/packages/cli/tests/output.test.ts
@@ -88,6 +88,13 @@ describe('output', () => {
       const calls = stdoutWrite.mock.calls.map((c: unknown[]) => c[0]);
       expect(calls[1]).toBe('1,\n');
     });
+
+    it('should escape CSV values with newlines', () => {
+      const data = [{ desc: 'Line 1\nLine 2' }];
+      outputData(data, { format: 'csv', quiet: false });
+      const calls = stdoutWrite.mock.calls.map((c: unknown[]) => c[0]);
+      expect(calls[1]).toBe('"Line 1\nLine 2"\n');
+    });
   });
 
   describe('table', () => {
@@ -230,6 +237,14 @@ describe('output', () => {
       const output = stderrWrite.mock.calls[0][0] as string;
       expect(() => JSON.parse(output)).not.toThrow();
     });
+
+    it('should not show "null" when error code is null in TTY', () => {
+      Object.defineProperty(process.stderr, 'isTTY', { value: true, writable: true, configurable: true });
+      outputError({ error: 'Network error', code: null, type: 'PACHCA_NETWORK_ERROR' }, 'table');
+      const combined = stderrWrite.mock.calls.map((c: unknown[]) => c[0]).join('');
+      expect(combined).not.toContain('null');
+      expect(combined).toContain('Network error');
+    });
   });
 
   describe('outputSuccess', () => {
@@ -246,10 +261,10 @@ describe('output', () => {
       expect(stderrWrite).not.toHaveBeenCalled();
     });
 
-    it('should suppress success message in non-TTY', () => {
+    it('should output plain success message in non-TTY', () => {
       Object.defineProperty(process.stderr, 'isTTY', { value: false, writable: true, configurable: true });
       outputSuccess('Done');
-      expect(stderrWrite).not.toHaveBeenCalled();
+      expect(stderrWrite).toHaveBeenCalledWith('Done\n');
     });
   });
 });

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -99,6 +99,53 @@ describe('smoke tests', () => {
             expect(content).toContain('limit');
           }
         });
+
+        it('flag names should be kebab-case', () => {
+          content = content || fs.readFileSync(cmd.filePath, 'utf-8');
+          // Extract all flag names from Flags declarations: 'flagName': Flags.type({
+          const flagNames = [...content.matchAll(/'([^']+)':\s*Flags\.\w+\(/g)].map((m) => m[1]);
+          for (const name of flagNames) {
+            expect(name, `Flag "${name}" should be kebab-case`).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+          }
+        });
+
+        it('boolean flags should have allowNo', () => {
+          content = content || fs.readFileSync(cmd.filePath, 'utf-8');
+          // Find Flags.boolean blocks, except --force and --all which are action flags
+          const booleanBlocks = [...content.matchAll(/'([^']+)':\s*Flags\.boolean\(\{([^}]*)\}/gs)];
+          for (const [, name, body] of booleanBlocks) {
+            if (name === 'force' || name === 'all') continue;
+            expect(body, `Boolean flag --${name} should have allowNo: true`).toContain('allowNo: true');
+          }
+        });
+
+        it('should not have dead requiresAuth', () => {
+          content = content || fs.readFileSync(cmd.filePath, 'utf-8');
+          expect(content).not.toContain('static requiresAuth');
+        });
+
+        it('should not import unused Readable', () => {
+          content = content || fs.readFileSync(cmd.filePath, 'utf-8');
+          if (content.includes("from 'node:stream'")) {
+            expect(content, 'Readable imported but not used').toContain('Readable.');
+          }
+        });
+
+        it('PUT/PATCH with wrapper body should warn on empty fields', () => {
+          content = content || fs.readFileSync(cmd.filePath, 'utf-8');
+          const methodMatch = content.match(/static apiMethod = "(\w+)"/);
+          const method = methodMatch?.[1];
+          if ((method === 'PUT' || method === 'PATCH') && content.includes('const inner =')) {
+            expect(content).toContain('Object.keys(inner).length === 0');
+          }
+        });
+
+        it('JSON array/object flags should use parseJSON', () => {
+          content = content || fs.readFileSync(cmd.filePath, 'utf-8');
+          // Find flags parsed as JSON in the body — pattern: this.parseJSON(flags['name'], 'name')
+          // Ensure no raw JSON.parse(flags[...]) calls
+          expect(content).not.toMatch(/JSON\.parse\(flags\[/);
+        });
       });
     }
   });

--- a/packages/cli/tests/utils.test.ts
+++ b/packages/cli/tests/utils.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isInteractive, useColor, defaultOutputFormat, formatSize, levenshtein } from '../src/utils.js';
+
+describe('utils', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function setEnv(key: string, value: string | undefined) {
+    if (!(key in savedEnv)) savedEnv[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    for (const key of Object.keys(savedEnv)) delete savedEnv[key];
+  });
+
+  describe('isInteractive()', () => {
+    it('should return true when TTY and no CI/PACHCA_PROMPT_DISABLED', () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      setEnv('CI', undefined);
+      setEnv('PACHCA_PROMPT_DISABLED', undefined);
+      expect(isInteractive()).toBe(true);
+    });
+
+    it('should return false when stdin is not TTY', () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: undefined, writable: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      expect(isInteractive()).toBe(false);
+    });
+
+    it('should return false when stdout is not TTY', () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: undefined, writable: true, configurable: true });
+      expect(isInteractive()).toBe(false);
+    });
+
+    it('should return false when CI=true', () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      setEnv('CI', 'true');
+      expect(isInteractive()).toBe(false);
+    });
+
+    it('should return false when PACHCA_PROMPT_DISABLED', () => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, writable: true, configurable: true });
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      setEnv('PACHCA_PROMPT_DISABLED', '1');
+      expect(isInteractive()).toBe(false);
+    });
+  });
+
+  describe('useColor()', () => {
+    it('should return true with TTY (default)', () => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      setEnv('FORCE_COLOR', undefined);
+      setEnv('NO_COLOR', undefined);
+      setEnv('TERM', undefined);
+      expect(useColor()).toBe(true);
+    });
+
+    it('should return true when FORCE_COLOR is set', () => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: undefined, writable: true, configurable: true });
+      setEnv('FORCE_COLOR', '1');
+      expect(useColor()).toBe(true);
+    });
+
+    it('should return false when NO_COLOR is set', () => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      setEnv('NO_COLOR', '1');
+      setEnv('FORCE_COLOR', undefined);
+      expect(useColor()).toBe(false);
+    });
+
+    it('should return false when TERM=dumb', () => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      setEnv('TERM', 'dumb');
+      setEnv('FORCE_COLOR', undefined);
+      setEnv('NO_COLOR', undefined);
+      expect(useColor()).toBe(false);
+    });
+  });
+
+  describe('defaultOutputFormat()', () => {
+    it('should return "table" when TTY', () => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: true, writable: true, configurable: true });
+      expect(defaultOutputFormat()).toBe('table');
+    });
+
+    it('should return "json" when not TTY', () => {
+      Object.defineProperty(process.stdout, 'isTTY', { value: undefined, writable: true, configurable: true });
+      expect(defaultOutputFormat()).toBe('json');
+    });
+  });
+
+  describe('formatSize()', () => {
+    it('should format 0 bytes', () => {
+      expect(formatSize(0)).toBe('0 B');
+    });
+
+    it('should format bytes under 1 KB', () => {
+      expect(formatSize(512)).toBe('512 B');
+    });
+
+    it('should format kilobytes', () => {
+      expect(formatSize(1024)).toBe('1.0 KB');
+    });
+
+    it('should format megabytes', () => {
+      expect(formatSize(2.5 * 1024 * 1024)).toBe('2.5 MB');
+    });
+  });
+
+  describe('levenshtein()', () => {
+    it('should return 0 for equal strings', () => {
+      expect(levenshtein('hello', 'hello')).toBe(0);
+    });
+
+    it('should return 1 for one character difference', () => {
+      expect(levenshtein('hello', 'hallo')).toBe(1);
+    });
+
+    it('should return length for empty vs non-empty', () => {
+      expect(levenshtein('', 'abc')).toBe(3);
+      expect(levenshtein('abc', '')).toBe(3);
+    });
+
+    it('should handle multi-character differences', () => {
+      expect(levenshtein('kitten', 'sitting')).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Boolean flags `allowNo`**: `--no-suspended`, `--no-public`, `--no-personal` теперь отправляют `false` — раньше не было способа отправить `false` через CLI
- **FormData wire names**: `direct-url` теперь отправляет правильные имена полей (`Content-Disposition`, `x-amz-credential`, etc.) вместо camelCase
- **Wrapper unwrap**: `users create` теперь имеет отдельные флаги (`--first-name`, `--email`) вместо `--user '{json}'`
- **Empty body warning**: `update` команды предупреждают если не указаны поля для обновления
- **Retry safety**: сетевые ошибки не ретраят POST/DELETE (предотвращение дубликатов)
- **retry-after NaN**: корректная обработка HTTP-date формата заголовка
- **Streaming download**: `downloadFile` стримит на диск вместо загрузки в память (OOM на больших файлах)
- **Windows postrun**: `fileURLToPath` вместо `URL.pathname` для корректных путей
- **Config validation**: `config set` принимает только `defaults.output` и `defaults.timeout`
- **parseJSON**: безопасный парсинг JSON-флагов с понятной ошибкой
- **Unused import**: удалён неиспользуемый `import { Readable }` из генерируемых команд

## Test plan
- [x] `npx turbo check` — 8/8 tasks, 697 tests pass
- [ ] `pachca users update 123 --no-suspended` отправляет `suspended: false`
- [ ] `pachca chats list --no-personal` отправляет `personal=false`
- [ ] `pachca users create --first-name Олег --email o@t.com` — работает без JSON
- [ ] `pachca chats update 123` без флагов — показывает предупреждение

🤖 Generated with [Claude Code](https://claude.com/claude-code)