### PR TITLE
feat: SDK documentation page with multi-language examples

### DIFF
--- a/apps/docs/components/api/code-block.tsx
+++ b/apps/docs/components/api/code-block.tsx
@@ -18,6 +18,7 @@ function getHighlighter() {
         langs: [
           'json',
           'javascript',
+          'typescript',
           'python',
           'bash',
           'shell',
@@ -26,6 +27,8 @@ function getHighlighter() {
           'php',
           'java',
           'go',
+          'kotlin',
+          'swift',
           'csharp',
         ],
       })

--- a/apps/docs/components/api/markdown-content.tsx
+++ b/apps/docs/components/api/markdown-content.tsx
@@ -30,6 +30,7 @@ import { ImageCard } from '@/components/mdx/image-card';
 import { AgentSkillsWorkflows } from '@/components/mdx/agent-skills-workflows';
 import { CliCommands } from '@/components/mdx/cli-commands';
 import { NpmBadge } from '@/components/mdx/npm-badge';
+import { CodeTabs } from '@/components/mdx/code-tabs';
 import { CopyableInlineCode } from './copyable-inline-code';
 import { EndpointLink } from './endpoint-link';
 import { HeadingLink } from './heading-link';
@@ -165,6 +166,7 @@ const components = {
   AgentSkillsWorkflows,
   CliCommands,
   NpmBadge,
+  CodeTabs,
 };
 
 interface MarkdownContentProps {

--- a/apps/docs/components/mdx/code-tabs.tsx
+++ b/apps/docs/components/mdx/code-tabs.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { CodeBlock } from '../api/code-block';
+import { CopyButton } from '../api/copy-button';
+import { BoxedPanel } from '../api/boxed-panel';
+
+interface Tab {
+  label: string;
+  language: string;
+  code: string;
+}
+
+interface CodeTabsProps {
+  tabs: Tab[];
+  title?: string;
+}
+
+export function CodeTabs({ tabs, title }: CodeTabsProps) {
+  const [active, setActive] = useState(0);
+  const current = tabs[active];
+
+  return (
+    <BoxedPanel
+      header={
+        <>
+          <div className="flex items-center gap-0 overflow-x-auto custom-scrollbar -mx-1">
+            {tabs.map((tab, i) => (
+              <button
+                key={tab.label}
+                onClick={() => setActive(i)}
+                className={`px-2.5 h-7 rounded-md text-[13px] font-medium whitespace-nowrap transition-all outline-none cursor-pointer select-none ${
+                  active === i
+                    ? 'text-text-primary bg-background'
+                    : 'text-text-tertiary hover:text-text-secondary'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-0 shrink-0">
+            {title && (
+              <span className="text-[12px] text-text-tertiary font-medium mr-1 whitespace-nowrap">
+                {title}
+              </span>
+            )}
+            <CopyButton text={current.code} />
+          </div>
+        </>
+      }
+      contentClassName="px-6 py-2 pl-0 overflow-x-auto custom-scrollbar"
+    >
+      <CodeBlock code={current.code.trim()} language={current.language} />
+    </BoxedPanel>
+  );
+}

--- a/apps/docs/components/mdx/mdx-components.tsx
+++ b/apps/docs/components/mdx/mdx-components.tsx
@@ -13,6 +13,7 @@ import { ImageCard } from '@/components/mdx/image-card';
 import { AgentSkillsWorkflows } from '@/components/mdx/agent-skills-workflows';
 import { CliCommands } from '@/components/mdx/cli-commands';
 import { NpmBadge } from '@/components/mdx/npm-badge';
+import { CodeTabs } from '@/components/mdx/code-tabs';
 import { getOrderedGuidePages } from '@/lib/guides-config';
 import { generateNavigation } from '@/lib/navigation';
 import type { Schema } from '@/lib/openapi/types';
@@ -295,4 +296,5 @@ export const customMdxComponents = {
   AgentSkillsWorkflows,
   CliCommands,
   NpmBadge,
+  CodeTabs,
 };

--- a/apps/docs/content/guides/ai-agents.mdx
+++ b/apps/docs/content/guides/ai-agents.mdx
@@ -139,6 +139,28 @@ pachca users list -o json`}
   </Card>
 </CardGroup>
 
+### SDK
+
+Типизированные клиенты для TypeScript, Python, Go, Kotlin и Swift. Все SDK сгенерированы из OpenAPI-спецификации — типы, методы и параметры совпадают с документацией. Подходит для собственных интеграций и ботов на любом языке.
+
+<CodeBlock language="typescript" title="TypeScript">
+{`import { Pachca } from "@pachca/sdk";
+
+const pachca = new Pachca({ token: "YOUR_TOKEN" });
+const { data } = await pachca.messages.createMessage({
+  body: { message: { entity_id: 123, content: "Привет!" } },
+});`}
+</CodeBlock>
+
+<CardGroup columns={2}>
+  <Card title="Руководство SDK" href="/guides/sdk">
+    Установка, примеры и документация для всех 5 языков
+  </Card>
+  <Card title="@pachca/sdk" href="https://www.npmjs.com/package/@pachca/sdk">
+    TypeScript SDK на npm
+  </Card>
+</CardGroup>
+
 ### Context7 MCP
 
 Самый надёжный вариант для постоянной работы с API. [Context7](https://context7.com) — MCP-сервер, который отдаёт актуальную документацию прямо в контекст агента. Подходит для удалённых интеграций с OAuth, многошаговых сценариев и когда вы часто просите агента выполнять разные задачи в Пачке из промптов.

--- a/apps/docs/content/guides/sdk.mdx
+++ b/apps/docs/content/guides/sdk.mdx
@@ -1,0 +1,357 @@
+---
+title: SDK
+description: Типизированные клиенты для Pachca API — TypeScript, Python, Go, Kotlin и Swift
+---
+
+# SDK
+
+Официальные SDK для работы с Pachca API на пяти языках. Все клиенты автоматически сгенерированы из [OpenAPI-спецификации](/openapi.yaml) — типы, названия методов и параметров совпадают с [документацией API](/).
+
+## Быстрый старт
+
+<Steps>
+  <Step title="Получение токена">
+    Получите API-токен в интерфейсе Пачки: в разделе **«Автоматизации» → «API»** или в модуле **«Интеграции»** — подробнее в руководстве [Авторизация](/guides/authorization).
+  </Step>
+  <Step title="Установка">
+
+<CodeTabs tabs={[
+  { label: "TypeScript", language: "bash", code: "npm install @pachca/sdk@<latest>" },
+  { label: "Python", language: "bash", code: "pip install pachca==<latest>" },
+  { label: "Go", language: "bash", code: "go get github.com/pachca/openapi/sdk/go/generated@v<latest>" },
+  { label: "Kotlin", language: "kotlin", code: `// build.gradle.kts
+dependencies {
+    implementation("com.pachca:pachca-sdk:<latest>")
+}` },
+  { label: "Swift", language: "swift", code: `// Package.swift
+dependencies: [
+    .package(url: "https://github.com/pachca/openapi", from: "<latest>")
+]` },
+]} />
+
+  </Step>
+  <Step title="Инициализация клиента">
+
+<CodeTabs tabs={[
+  { label: "TypeScript", language: "typescript", code: `import { Pachca } from "@pachca/sdk";
+
+const pachca = new Pachca({ token: "YOUR_TOKEN" });` },
+  { label: "Python", language: "python", code: `from pachca.pachca_client import Pachca
+
+client = Pachca("YOUR_TOKEN")` },
+  { label: "Go", language: "go", code: `import pachca "github.com/pachca/openapi/sdk/go/generated"
+
+client, err := pachca.NewPachcaClient(pachca.DefaultBaseURL, "YOUR_TOKEN")` },
+  { label: "Kotlin", language: "kotlin", code: `import com.pachca.PachcaClient
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+
+val pachca = PachcaClient(
+    httpClientConfig = {
+        it.defaultRequest {
+            header("Authorization", "Bearer YOUR_TOKEN")
+        }
+    }
+)` },
+  { label: "Swift", language: "swift", code: `import PachcaSDK
+
+let pachca = try PachcaClient("YOUR_TOKEN")` },
+]} />
+
+  </Step>
+  <Step title="Отправка сообщения">
+
+<CodeTabs tabs={[
+  { label: "TypeScript", language: "typescript", code: `const { data } = await pachca.messages.createMessage({
+  body: {
+    message: { entity_id: 123, content: "Привет из TypeScript SDK!" },
+  },
+});
+console.log(data!.data.id);` },
+  { label: "Python", language: "python", code: `from pachca.models.message_create_request_message import MessageCreateRequestMessage
+
+msg = client.messages.create_message(
+    MessageCreateRequestMessage(entity_id=123, content="Привет из Python SDK!")
+)
+print(msg.id)` },
+  { label: "Go", language: "go", code: `res, err := client.Messages.CreateMessage(ctx, &pachca.MessageCreateRequest{
+    Message: pachca.MessageCreateRequestMessage{
+        EntityID: 123,
+        Content:  "Привет из Go SDK!",
+    },
+})
+created := res.(*pachca.MessageOperationsCreateMessageCreated)
+fmt.Println(created.Data.ID)` },
+  { label: "Kotlin", language: "kotlin", code: `import com.pachca.models.*
+
+val message = pachca.messages.createMessage(MessageCreateRequest(
+    message = MessageCreateRequestMessage(
+        entityId = 123,
+        content = "Привет из Kotlin SDK!"
+    )
+)).body()` },
+  { label: "Swift", language: "swift", code: `let message = try await pachca.messages.createMessage(.init(
+    body: .json(.init(message: .init(
+        entity_id: 123,
+        content: "Привет из Swift SDK!"
+    )))
+))` },
+]} />
+
+  </Step>
+</Steps>
+
+## Загрузка файлов
+
+Загрузка файла — трёхшаговый процесс, одинаковый во всех SDK:
+
+<Steps>
+  <Step title="Получить параметры загрузки">
+    Запросите URL и поля для загрузки на S3.
+  </Step>
+  <Step title="Загрузить файл на S3">
+    Отправьте файл по полученному URL с полями формы.
+  </Step>
+  <Step title="Прикрепить к сообщению">
+    Передайте ключ загруженного файла при создании сообщения.
+  </Step>
+</Steps>
+
+<CodeTabs tabs={[
+  { label: "TypeScript", language: "typescript", code: `// 1. Параметры загрузки
+const { data: params } = await pachca.common.getUploadParams({
+  body: { file_name: "report.pdf", file_size: 1024 },
+});
+
+// 2. Загрузка на S3 (multipart/form-data по direct_url)
+
+// 3. Сообщение с файлом
+await pachca.messages.createMessage({
+  body: {
+    message: {
+      entity_id: chatId,
+      content: "Отчёт во вложении",
+      files: [params!.data.key],
+    },
+  },
+});` },
+  { label: "Python", language: "python", code: `# 1. Параметры загрузки
+params = client.common.get_upload_params()
+
+# 2. Загрузка на S3
+file_bytes = open("report.pdf", "rb").read()
+key = client.common.upload_file(params, file_bytes, "report.pdf")
+
+# 3. Сообщение с файлом
+client.messages.create_message(
+    MessageCreateRequestMessage(
+        entity_id=chat_id,
+        content="Отчёт во вложении",
+        files=[{"key": key, "name": "report.pdf", "file_type": "file", "size": len(file_bytes)}],
+    )
+)` },
+  { label: "Go", language: "go", code: `// 1. Параметры загрузки
+res, err := client.Uploads.GetUploadParams(ctx)
+params := res.(*pachca.UploadParams)
+
+// 2. Загрузка на S3
+file, _ := os.Open("report.pdf")
+err = client.Uploads.UploadFile(ctx, params, file, "report.pdf")
+
+// 3. Прикрепить ключ params.Key к сообщению` },
+  { label: "Kotlin", language: "kotlin", code: `// 1. Параметры загрузки
+val params = client.common.getUploadParams().body()
+
+// 2. Загрузка на S3
+val fileBytes = java.io.File("report.pdf").readBytes()
+val key = client.uploadFile(params, fileBytes, "report.pdf")
+
+// 3. Сообщение с файлом
+client.messages.createMessage(MessageCreateRequest(
+    message = MessageCreateRequestMessage(
+        entityId = chatId,
+        content = "Отчёт во вложении",
+        files = listOf(MessageCreateRequestMessageFilesInner(
+            key = key, name = "report.pdf",
+            fileType = FileType.file, propertySize = fileBytes.size,
+        )),
+    )
+))` },
+  { label: "Swift", language: "swift", code: `// 1. Параметры загрузки
+let params = try await pachca.upload.getUploadParams(.init())
+
+// 2. Загрузка на S3
+let fileData = try Data(contentsOf: URL(fileURLWithPath: "report.pdf"))
+let key = try await pachca.uploadFile(params, file: fileData, filename: "report.pdf")
+
+// 3. Сообщение с файлом
+try await pachca.messages.createMessage(.init(
+    body: .json(.init(message: .init(
+        entity_id: chatId,
+        content: "Отчёт во вложении",
+        files: [.init(key: key, name: "report.pdf",
+                      file_type: .init(value1: .file),
+                      size: Int32(fileData.count))]
+    )))
+))` },
+]} />
+
+## Обработка ошибок
+
+<CodeTabs tabs={[
+  { label: "TypeScript", language: "typescript", code: `const { data, error, response } = await pachca.messages.getMessage({
+  path: { id: 999999 },
+});
+
+if (error) {
+  // error типизирован: ApiError | OAuthError
+  console.error(response.status, error);
+} else {
+  console.log(data.data.id);
+}` },
+  { label: "Python", language: "python", code: `from pachca.pachca_client import PachcaAPIError, PachcaAuthError
+
+try:
+    client.messages.get_message(999999)
+except PachcaAuthError as e:
+    # 401/403 — e.message
+    print(f"Ошибка авторизации: {e.message}")
+except PachcaAPIError as e:
+    # 400/404/422 — e.errors: list[{key, message}]
+    print(f"Ошибка API: {e.errors}")` },
+  { label: "Go", language: "go", code: `res, err := client.Messages.GetMessage(ctx, 999999)
+if err != nil {
+    var apiErr *pachca.ApiError
+    var oauthErr *pachca.OAuthErrorResponse
+    if errors.As(err, &apiErr) {
+        // 400/404/422 — apiErr.Errors[].Key, .Message
+        fmt.Println(apiErr.Errors[0].Message)
+    } else if errors.As(err, &oauthErr) {
+        // 401/403 — oauthErr.ErrorDescription
+        fmt.Println(oauthErr.ErrorDescription)
+    }
+}` },
+  { label: "Kotlin", language: "kotlin", code: `import com.pachca.models.ApiError
+import com.pachca.models.OAuthError
+
+val response = pachca.messages.getMessage(id = 999999)
+if (!response.success) {
+    when (response.status) {
+        401, 403 -> {
+            val error = response.typedBody<OAuthError>(response.response, typeInfo<OAuthError>())
+            println("\${error.error}: \${error.errorDescription}")
+        }
+        else -> {
+            val error = response.typedBody<ApiError>(response.response, typeInfo<ApiError>())
+            error.errors?.forEach { println("\${it.key}: \${it.message}") }
+        }
+    }
+}` },
+  { label: "Swift", language: "swift", code: `// Фасад — бросает исключение при любой ошибке
+do {
+    let msg = try await pachca.messages.getMessage(.init(path: .init(id: 999999)))
+} catch {
+    print("Ошибка: \\(error)")
+}
+
+// Или через raw-клиент для типизированных ошибок:
+// switch response {
+// case .unauthorized(let e): e.body.json — OAuthError
+// case .notFound(let e):     e.body.json — ApiError
+// case .undocumented(statusCode: let code, _): ...
+// }` },
+]} />
+
+Все SDK возвращают стандартные HTTP-ошибки API — подробнее в [Ошибки](/guides/errors).
+
+<CardGroup columns={2}>
+  <Card title="@pachca/sdk" href="https://www.npmjs.com/package/@pachca/sdk">
+    TypeScript SDK на npm
+  </Card>
+  <Card title="pachca" href="https://pypi.org/project/pachca/">
+    Python SDK на PyPI
+  </Card>
+  <Card title="Go SDK" href="https://pkg.go.dev/github.com/pachca/openapi/sdk/go/generated">
+    Go SDK на pkg.go.dev
+  </Card>
+  <Card title="Kotlin SDK" href="https://jitpack.io/#pachca/openapi">
+    Kotlin SDK на JitPack
+  </Card>
+</CardGroup>
+
+## Примеры
+
+Каждый SDK включает рабочий пример — echo-бот из 8 шагов, демонстрирующий основные операции: создание, чтение, реакции, треды, пины, обновление и удаление.
+
+<CardGroup columns={2}>
+  <Card title="TypeScript" href="https://github.com/pachca/openapi/blob/main/sdk/typescript/examples/main.ts">
+    Echo-бот на TypeScript
+  </Card>
+  <Card title="Python" href="https://github.com/pachca/openapi/blob/main/sdk/python/examples/main.py">
+    Echo-бот на Python
+  </Card>
+  <Card title="Go" href="https://github.com/pachca/openapi/blob/main/sdk/go/examples/main.go">
+    Echo-бот на Go
+  </Card>
+  <Card title="Kotlin" href="https://github.com/pachca/openapi/blob/main/sdk/kotlin/examples/main.kt">
+    Echo-бот на Kotlin
+  </Card>
+  <Card title="Swift" href="https://github.com/pachca/openapi/blob/main/sdk/swift/examples/Sources/EchoBot/main.swift">
+    Echo-бот на Swift
+  </Card>
+</CardGroup>
+
+## Сервисы
+
+Методы API сгруппированы по сервисам. Названия сервисов одинаковы во всех SDK:
+
+| Сервис | Описание |
+|--------|---------|
+| `messages` | Сообщения, пины |
+| `chats` | Каналы и беседы |
+| `users` | Управление сотрудниками |
+| `tasks` | Задачи (напоминания) |
+| `tags` | Теги (группы) |
+| `members` | Участники чатов |
+| `reactions` | Реакции на сообщения |
+| `threads` | Треды |
+| `profile` | Профиль текущего пользователя |
+| `bots` | Управление ботами |
+| `security` | Журнал аудита |
+| `common` | Поиск, загрузки, формы и др. |
+
+<Info>Названия методов и параметров совпадают с URL документации. Например, метод `createMessage` соответствует эндпоинту [Новое сообщение](POST /messages).</Info>
+
+## Автопагинация
+
+TypeScript SDK поддерживает автоматическую пагинацию через async-итераторы — все страницы загружаются автоматически:
+
+<CodeBlock language="typescript" title="Автопагинация (TypeScript)">
+{`// Перебрать всех пользователей (все страницы)
+for await (const user of pachca.users.listAllUsers()) {
+  console.log(user.first_name);
+}
+
+// Или получить одну страницу
+const { data } = await pachca.users.listUsers({
+  query: { per: 50 },
+});`}
+</CodeBlock>
+
+В остальных SDK пагинацию нужно обрабатывать вручную через параметр `cursor` — подробнее в [Запросы и ответы](/guides/requests-responses).
+
+## Прямой импорт функций
+
+TypeScript SDK поддерживает tree-shaking — можно импортировать только нужные функции для минимального размера бандла:
+
+<CodeBlock language="typescript" title="Tree-shaking">
+{`import { createClient, listUsers, createMessage } from "@pachca/sdk";
+
+const client = createClient({
+  baseUrl: "https://api.pachca.com/api/shared/v1",
+  auth: () => "YOUR_TOKEN",
+});
+
+const { data } = await listUsers({ client });
+await createMessage({ client, body: { message: { entity_id: 123, content: "Привет!" } } });`}
+</CodeBlock>

--- a/apps/docs/lib/guides-config.ts
+++ b/apps/docs/lib/guides-config.ts
@@ -51,6 +51,7 @@ const GUIDES_ORDER = [
   '/',
   '/guides/ai-agents',
   '/guides/cli',
+  '/guides/sdk',
   '/guides/workflows',
   '/guides/webhook',
   '/guides/authorization',

--- a/apps/docs/lib/mdx-expander.ts
+++ b/apps/docs/lib/mdx-expander.ts
@@ -347,25 +347,23 @@ export async function expandMdxComponents(content: string): Promise<string> {
   );
 
   // <CodeTabs tabs={[...]} /> -> sequential code blocks
-  result = result.replace(
-    /<CodeTabs\s+tabs=\{(\[[\s\S]*?\])\}\s*\/>/g,
-    (_, tabsStr) => {
-      try {
-        // Parse the tabs array from JSX-like syntax
-        const tabs: { label: string; language: string; code: string }[] = [];
-        const tabRegex = /\{\s*label:\s*"([^"]*)",\s*language:\s*"([^"]*)",\s*code:\s*`([\s\S]*?)`\s*\}/g;
-        let tabMatch;
-        while ((tabMatch = tabRegex.exec(tabsStr)) !== null) {
-          tabs.push({ label: tabMatch[1], language: tabMatch[2], code: tabMatch[3] });
-        }
-        return tabs
-          .map((tab) => `**${tab.label}**\n\n\`\`\`${tab.language}\n${tab.code}\n\`\`\`\n`)
-          .join('\n');
-      } catch {
-        return '';
+  result = result.replace(/<CodeTabs\s+tabs=\{(\[[\s\S]*?\])\}\s*\/>/g, (_, tabsStr) => {
+    try {
+      // Parse the tabs array from JSX-like syntax
+      const tabs: { label: string; language: string; code: string }[] = [];
+      const tabRegex =
+        /\{\s*label:\s*"([^"]*)",\s*language:\s*"([^"]*)",\s*code:\s*`([\s\S]*?)`\s*\}/g;
+      let tabMatch;
+      while ((tabMatch = tabRegex.exec(tabsStr)) !== null) {
+        tabs.push({ label: tabMatch[1], language: tabMatch[2], code: tabMatch[3] });
       }
+      return tabs
+        .map((tab) => `**${tab.label}**\n\n\`\`\`${tab.language}\n${tab.code}\n\`\`\`\n`)
+        .join('\n');
+    } catch {
+      return '';
     }
-  );
+  });
 
   // <Mermaid title="..." chart={`...`} /> -> ```mermaid ... ```
   result = result.replace(

--- a/apps/docs/lib/mdx-expander.ts
+++ b/apps/docs/lib/mdx-expander.ts
@@ -346,6 +346,27 @@ export async function expandMdxComponents(content: string): Promise<string> {
     }
   );
 
+  // <CodeTabs tabs={[...]} /> -> sequential code blocks
+  result = result.replace(
+    /<CodeTabs\s+tabs=\{(\[[\s\S]*?\])\}\s*\/>/g,
+    (_, tabsStr) => {
+      try {
+        // Parse the tabs array from JSX-like syntax
+        const tabs: { label: string; language: string; code: string }[] = [];
+        const tabRegex = /\{\s*label:\s*"([^"]*)",\s*language:\s*"([^"]*)",\s*code:\s*`([\s\S]*?)`\s*\}/g;
+        let tabMatch;
+        while ((tabMatch = tabRegex.exec(tabsStr)) !== null) {
+          tabs.push({ label: tabMatch[1], language: tabMatch[2], code: tabMatch[3] });
+        }
+        return tabs
+          .map((tab) => `**${tab.label}**\n\n\`\`\`${tab.language}\n${tab.code}\n\`\`\`\n`)
+          .join('\n');
+      } catch {
+        return '';
+      }
+    }
+  );
+
   // <Mermaid title="..." chart={`...`} /> -> ```mermaid ... ```
   result = result.replace(
     /<Mermaid\s+(?:title="([^"]*?)"\s+)?chart=\{`([\s\S]*?)`\}\s*\/>/g,

--- a/sdk/go/generate-client.ts
+++ b/sdk/go/generate-client.ts
@@ -583,6 +583,11 @@ w("\treturn BearerAuth{Token: s.token}, nil");
 w("}");
 w("");
 
+// DefaultBaseURL constant
+w('// DefaultBaseURL is the default Pachca API base URL.');
+w('const DefaultBaseURL = "https://api.pachca.com/api/shared/v1"');
+w("");
+
 // PachcaClient struct
 w("// PachcaClient provides a convenient grouped interface to the Pachca API.");
 w("type PachcaClient struct {");
@@ -596,7 +601,7 @@ w("}");
 w("");
 
 // Constructor
-w("// NewPachcaClient creates a new Pachca API client.");
+w("// NewPachcaClient creates a new Pachca API client with a custom base URL.");
 w(
   "func NewPachcaClient(serverURL, token string) (*PachcaClient, error) {"
 );
@@ -625,6 +630,8 @@ for (const [tag] of groups) {
 }
 w("\treturn p, nil");
 w("}");
+w("");
+
 
 // Service structs and methods
 for (const [tag, tagMethods] of groups) {

--- a/sdk/go/generated/pachca_client.go
+++ b/sdk/go/generated/pachca_client.go
@@ -132,6 +132,9 @@ func (s *bearerTokenSource) BearerAuth(ctx context.Context, operationName string
 	return BearerAuth{Token: s.token}, nil
 }
 
+// DefaultBaseURL is the default Pachca API base URL.
+const DefaultBaseURL = "https://api.pachca.com/api/shared/v1"
+
 // PachcaClient provides a convenient grouped interface to the Pachca API.
 type PachcaClient struct {
 	serverURL string
@@ -154,7 +157,7 @@ type PachcaClient struct {
 	Views *ViewsService
 }
 
-// NewPachcaClient creates a new Pachca API client.
+// NewPachcaClient creates a new Pachca API client with a custom base URL.
 func NewPachcaClient(serverURL, token string) (*PachcaClient, error) {
 	client, err := NewClient(serverURL, &bearerTokenSource{token: token})
 	if err != nil {
@@ -182,6 +185,7 @@ func NewPachcaClient(serverURL, token string) (*PachcaClient, error) {
 	p.Views = &ViewsService{client: client, serverURL: serverURL, token: token}
 	return p, nil
 }
+
 
 // BotsService provides Bots API operations.
 type BotsService struct {

--- a/sdk/kotlin/README.md
+++ b/sdk/kotlin/README.md
@@ -55,6 +55,15 @@ val users = pachca.users.listUsers().body()
 
 Полное описание параметров: [документация API](https://dev.pachca.com)
 
+## Примеры
+
+- [examples/main.kt](examples/main.kt) — echo-бот из 8 шагов, демонстрирующий CRUD, реакции, треды, пины.
+- [examples/upload.kt](examples/upload.kt) — загрузка файла и отправка как вложение.
+
+```bash
+PACHCA_TOKEN=<token> PACHCA_CHAT_ID=<id> kotlin examples/main.kt
+```
+
 ## Разработка
 
 Генерация SDK:

--- a/sdk/kotlin/examples/main.kt
+++ b/sdk/kotlin/examples/main.kt
@@ -1,0 +1,96 @@
+/**
+ * Echo bot example demonstrating the Pachca Kotlin SDK.
+ *
+ * Covers 8 steps: create → read → reaction → thread → reply → pin → update → unpin
+ *
+ * Usage:
+ *
+ *   PACHCA_TOKEN=your_token PACHCA_CHAT_ID=12345 kotlin main.kt
+ */
+
+import com.pachca.PachcaClient
+import com.pachca.models.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    val token = System.getenv("PACHCA_TOKEN")
+        ?: error("Set PACHCA_TOKEN environment variable")
+    val chatId = System.getenv("PACHCA_CHAT_ID")?.toIntOrNull()
+        ?: error("Set PACHCA_CHAT_ID environment variable")
+
+    val client = PachcaClient(
+        httpClientConfig = {
+            it.defaultRequest {
+                header("Authorization", "Bearer $token")
+            }
+        }
+    )
+
+    // ── Step 1: Create a message ─────────────────────────────────────
+    println("1. Creating message...")
+    val created = client.messages.createMessage(
+        MessageCreateRequest(
+            message = MessageCreateRequestMessage(
+                entityType = MessageEntityType.discussion,
+                entityId = chatId,
+                content = "SDK test 🚀",
+            )
+        )
+    ).body()
+    val msgId = created.data.id
+    println("   Message ID: $msgId")
+
+    // ── Step 2: Read message back ────────────────────────────────────
+    println("2. Reading message...")
+    val msg = client.messages.getMessage(msgId).body()
+    println("   Content: ${msg.data.content}")
+
+    // ── Step 3: Add reaction ─────────────────────────────────────────
+    println("3. Adding reaction...")
+    client.reactions.addReaction(msgId, ReactionRequest(code = "👀"))
+    println("   Reaction added")
+
+    // ── Step 4: Create thread ────────────────────────────────────────
+    println("4. Creating thread...")
+    val thread = client.threads.createThread(msgId).body()
+    println("   Thread ID: ${thread.data.id}")
+
+    // ── Step 5: Reply in thread ──────────────────────────────────────
+    println("5. Replying in thread...")
+    val reply = client.messages.createMessage(
+        MessageCreateRequest(
+            message = MessageCreateRequestMessage(
+                entityType = MessageEntityType.thread,
+                entityId = thread.data.id,
+                content = "Echo: ${msg.data.content}",
+            )
+        )
+    ).body()
+    println("   Reply ID: ${reply.data.id}")
+
+    // ── Step 6: Pin message ──────────────────────────────────────────
+    println("6. Pinning message...")
+    client.messages.pinMessage(msgId)
+    println("   Pinned")
+
+    // ── Step 7: Update reply ─────────────────────────────────────────
+    println("7. Updating reply...")
+    client.messages.updateMessage(
+        reply.data.id,
+        MessageUpdateRequest(
+            message = MessageUpdateRequestMessage(
+                content = "${reply.data.content} (processed)",
+            )
+        )
+    )
+    println("   Updated")
+
+    // ── Step 8: Unpin message ────────────────────────────────────────
+    println("8. Unpinning message...")
+    client.messages.unpinMessage(msgId)
+    println("   Unpinned")
+
+    println("\nDone! All 8 steps completed.")
+}

--- a/sdk/swift/README.md
+++ b/sdk/swift/README.md
@@ -47,6 +47,15 @@ let users = try await pachca.users.listUsers(.init())
 
 Полное описание параметров: [документация API](https://dev.pachca.com)
 
+## Примеры
+
+- [examples/Sources/EchoBot/main.swift](examples/Sources/EchoBot/main.swift) — echo-бот из 8 шагов, демонстрирующий CRUD, реакции, треды, пины.
+- [examples/Sources/Upload/main.swift](examples/Sources/Upload/main.swift) — загрузка файла и отправка как вложение.
+
+```bash
+PACHCA_TOKEN=<token> PACHCA_CHAT_ID=<id> swift run EchoBot
+```
+
 ## Разработка
 
 Генерация SDK:


### PR DESCRIPTION
## Summary
- New `/guides/sdk` documentation page with quick start, file uploads, error handling examples for all 5 SDKs (TypeScript, Python, Go, Kotlin, Swift)
- New `CodeTabs` MDX component for multi-language code snippets with tab switching
- Go SDK: added `DefaultBaseURL` constant for easier client initialization
- Kotlin echo-bot example + examples section in Kotlin/Swift READMEs

## Test plan
- [ ] Verify `/guides/sdk` page renders correctly with all CodeTabs sections
- [ ] Check tab switching works in CodeTabs component
- [ ] Verify SDK section appears in ai-agents guide
- [ ] Confirm navigation includes SDK guide entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)