### PR TITLE
docs: add pachca-threads and pachca-read-members to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ npx skills add pachca/openapi
 | `pachca-profile` | Профиль, статус, кастомные поля |
 | `pachca-users` | Сотрудники и теги (группы) |
 | `pachca-chats` | Каналы, беседы, участники, экспорт |
-| `pachca-messages` | Сообщения, треды, файлы, реакции, кнопки |
+| `pachca-messages` | Сообщения, файлы, реакции, кнопки |
+| `pachca-threads` | Треды (комментарии к сообщениям) |
+| `pachca-read-members` | Прочтение сообщений |
 | `pachca-bots` | Боты, вебхуки, unfurling |
 | `pachca-forms` | Интерактивные формы |
 | `pachca-tasks` | Напоминания (задачи) |


### PR DESCRIPTION
## Summary
- Added `pachca-threads` and `pachca-read-members` to skills table in README.md
- Removed "треды" from `pachca-messages` description (now a separate skill)
- `CLAUDE.md` is a symlink to `AGENTS.md` which is generated — no manual update needed

## Context
After PR #136, threads and read-members were split into separate skills but README wasn't updated.