### PR TITLE
fix: docs styling fixes, CLI URL correction, and add missing error code

### DIFF
--- a/packages/spec/openapi.yaml
+++ b/packages/spec/openapi.yaml
@@ -7000,6 +7000,7 @@ components:
         - payment_required
         - min_length
         - max_length
+        - use_of_system_words
       description: Коды ошибок валидации
       x-enum-descriptions:
         blank: Обязательное поле (не может быть пустым)
@@ -7037,6 +7038,7 @@ components:
         payment_required: Требуется оплата
         min_length: Значение слишком короткое (пояснения вы получите в поле message)
         max_length: Значение слишком длинное (пояснения вы получите в поле message)
+        use_of_system_words: Использовано зарезервированное системное слово (here, all)
     ViewBlock:
       type: object
       required:

--- a/packages/spec/typespec.tsp
+++ b/packages/spec/typespec.tsp
@@ -368,6 +368,7 @@ enum ChatSubtype {
   payment_required: "Требуется оплата",
   min_length: "Значение слишком короткое (пояснения вы получите в поле message)",
   max_length: "Значение слишком длинное (пояснения вы получите в поле message)",
+  use_of_system_words: "Использовано зарезервированное системное слово (here, all)",
 })
 enum ValidationErrorCode {
   @doc("Обязательное поле (не может быть пустым)")
@@ -474,6 +475,9 @@ enum ValidationErrorCode {
 
   @doc("Значение слишком длинное (пояснения вы получите в поле message)")
   max_length: "max_length",
+
+  @doc("Использовано зарезервированное системное слово (here, all)")
+  use_of_system_words: "use_of_system_words",
 }
 
 @doc("Тип аудит-события")


### PR DESCRIPTION
## Summary

- Фикс line-height и layout заголовков в компоненте Steps
- Фикс цвета ссылок в info callout (text-primary → text-primary/90)
- Фикс URL в гайде CLI: добавлен `/api/` prefix
- Добавлен пропущенный код ошибки `use_of_system_words` в enum `ValidationErrorCode` (найден при аудите API)

## Test plan

- [x] TypeSpec компилируется без ошибок
- [x] `npx turbo check` проходит
- [ ] Визуально проверить Steps и Callout компоненты
- [ ] Проверить страницу CLI гайда

🤖 Generated with [Claude Code](https://claude.com/claude-code)