### PR TITLE
fix: inline naming utils to fix Turbopack build

### DIFF
--- a/apps/docs/knip.json
+++ b/apps/docs/knip.json
@@ -3,5 +3,5 @@
   "project": ["**/*.{ts,tsx}"],
   "next": true,
   "ignore": ["**/*.d.ts"],
-  "ignoreDependencies": ["tailwindcss", "@pachca/spec", "@pachca/generator", "postcss"]
+  "ignoreDependencies": ["tailwindcss", "@pachca/spec", "postcss"]
 }

--- a/apps/docs/lib/code-generators/sdk-utils.ts
+++ b/apps/docs/lib/code-generators/sdk-utils.ts
@@ -1,9 +1,6 @@
 /**
  * Shared utilities for SDK code example generators.
  * Maps Endpoint (from OpenAPI parser) → SDK call structure.
- *
- * Core naming functions are imported from @pachca/generator to stay
- * in sync with the generated SDK code (single source of truth).
  */
 
 import type { Endpoint, Schema } from '../openapi/types';
@@ -12,17 +9,48 @@ import {
   generateParameterExample,
   type ExampleOptions,
 } from '../openapi/example-generator';
-import {
-  snakeToCamel,
-  snakeToPascal,
-  camelToSnake,
-  tagToProperty,
-  operationIdToMethod,
-  refName,
-} from '@pachca/generator/naming';
 
-// Re-export naming functions used by individual language generators
-export { snakeToCamel, snakeToPascal, camelToSnake, tagToProperty, operationIdToMethod };
+// ─── Naming utilities (inlined to avoid cross-package Turbopack issues) ───
+
+/** snake_case → camelCase: "first_name" → "firstName" */
+export function snakeToCamel(str: string): string {
+  return str.replace(/_([a-zA-Z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
+/** snake_case → PascalCase: "first_name" → "FirstName" */
+export function snakeToPascal(str: string): string {
+  const camel = snakeToCamel(str);
+  return camel.charAt(0).toUpperCase() + camel.slice(1);
+}
+
+/** camelCase → snake_case: "firstName" → "first_name" */
+export function camelToSnake(str: string): string {
+  return str
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/** Tag name → service property: "Chats" → "chats", "Link Previews" → "linkPreviews" */
+export function tagToProperty(tag: string): string {
+  const words = tag.split(/\s+/);
+  return words
+    .map((w, i) =>
+      i === 0 ? w.toLowerCase() : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+    )
+    .join('');
+}
+
+/** "ChatOperations_listChats" → "listChats" */
+export function operationIdToMethod(operationId: string): string {
+  const parts = operationId.split('_');
+  return parts.length > 1 ? parts.slice(1).join('_') : parts[0];
+}
+
+/** Extract schema name from $ref: "#/components/schemas/Chat" → "Chat" */
+function refName(ref: string): string {
+  return ref.split('/').pop()!;
+}
 
 // ─── Docs-specific naming helpers ───
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,7 +15,6 @@
     "check-urls": "node scripts/check-url-conflicts.mjs"
   },
   "dependencies": {
-    "@pachca/generator": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-tooltip": "^1.1.7",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,6 @@
       "name": "@pachca/docs",
       "version": "1.0.0",
       "dependencies": {
-        "@pachca/generator": "workspace:*",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-tooltip": "^1.1.7",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -9,9 +9,6 @@
   "exports": {
     ".": {
       "import": "./dist/src/index.js"
-    },
-    "./naming": {
-      "import": "./dist/src/naming.js"
     }
   },
   "files": ["dist"],
@@ -19,7 +16,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/naming.ts bin/generator.ts --outdir dist --target node --format esm --splitting",
+    "build": "bun build src/index.ts bin/generator.ts --outdir dist --target node --format esm --splitting",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- Bun 1.3.4 (Docker) with `--splitting` inlines naming functions into both `index.js` and `naming.js` entry points, causing Turbopack to reject duplicate exports (`camelToSnake`, `snakeToCamel`, etc.)
- Inlined the 6 naming utility functions directly into `sdk-utils.ts`, removing the `@pachca/generator` dependency from docs entirely
- Removed the `./naming` subpath export from the generator package

## Test plan
- [x] `npx turbo check` passes
- [x] `npx turbo build --filter=@pachca/docs --force` succeeds