### PR TITLE
feat(generator): pass example values from OpenAPI spec through IR

### DIFF
--- a/packages/generator/src/ir.ts
+++ b/packages/generator/src/ir.ts
@@ -26,6 +26,8 @@ export interface IRFieldType {
   members?: IRFieldType[];
   /** For literal: the literal string value */
   literalValue?: string;
+  /** Example value from the OpenAPI spec */
+  example?: unknown;
 }
 
 // ----- Fields -----

--- a/packages/generator/src/lang/go.ts
+++ b/packages/generator/src/lang/go.ts
@@ -766,6 +766,21 @@ function goLiteral(
   visited: Set<string> = new Set(),
   indent: number = 0,
 ): string {
+  if (ft.example !== undefined) {
+    if (ft.kind === 'primitive') {
+      if ((ft.primitive === 'integer' || ft.primitive === 'number') && typeof ft.example === 'number') {
+        if (ft.primitive === 'integer') return ft.format === 'int64' ? `int64(${ft.example})` : `int32(${ft.example})`;
+        return String(ft.example);
+      }
+      if (ft.primitive === 'boolean' && typeof ft.example === 'boolean') return String(ft.example);
+      if (ft.primitive === 'string' && typeof ft.example === 'string') return JSON.stringify(ft.example);
+    }
+    if (ft.kind === 'enum' && typeof ft.example === 'string') {
+      const e = ir.enums.find((en) => en.name === ft.ref);
+      const member = e?.members.find((m) => m.value === ft.example);
+      if (e && member) return `${e.name}${goExportName(member.value)}`;
+    }
+  }
   switch (ft.kind) {
     case 'primitive': {
       if (ft.primitive === 'integer') return ft.format === 'int64' ? 'int64(123)' : 'int32(123)';

--- a/packages/generator/src/lang/kotlin.ts
+++ b/packages/generator/src/lang/kotlin.ts
@@ -829,6 +829,21 @@ function ktLiteral(
   visited: Set<string> = new Set(),
   indent: number = 0,
 ): string {
+  if (ft.example !== undefined) {
+    if (ft.kind === 'primitive') {
+      if ((ft.primitive === 'integer' || ft.primitive === 'number') && typeof ft.example === 'number') {
+        if (ft.primitive === 'integer') return ft.format === 'int64' ? `${ft.example}L` : String(ft.example);
+        return String(ft.example);
+      }
+      if (ft.primitive === 'boolean' && typeof ft.example === 'boolean') return String(ft.example);
+      if (ft.primitive === 'string' && typeof ft.example === 'string') return JSON.stringify(ft.example);
+    }
+    if (ft.kind === 'enum' && typeof ft.example === 'string') {
+      const e = ir.enums.find((en) => en.name === ft.ref);
+      const member = e?.members.find((m) => m.value === ft.example);
+      if (e && member) return `${e.name}.${snakeToUpperSnake(member.value)}`;
+    }
+  }
   switch (ft.kind) {
     case 'primitive': {
       if (ft.primitive === 'integer') return ft.format === 'int64' ? '123L' : '123';

--- a/packages/generator/src/lang/python.ts
+++ b/packages/generator/src/lang/python.ts
@@ -824,6 +824,18 @@ function pyLiteral(
   visited: Set<string> = new Set(),
   indent: number = 0,
 ): string {
+  if (ft.example !== undefined) {
+    if (ft.kind === 'primitive') {
+      if ((ft.primitive === 'integer' || ft.primitive === 'number') && typeof ft.example === 'number') return String(ft.example);
+      if (ft.primitive === 'boolean' && typeof ft.example === 'boolean') return ft.example ? 'True' : 'False';
+      if (ft.primitive === 'string' && typeof ft.example === 'string') return JSON.stringify(ft.example);
+    }
+    if (ft.kind === 'enum' && typeof ft.example === 'string') {
+      const e = ir.enums.find((en) => en.name === ft.ref);
+      const member = e?.members.find((m) => m.value === ft.example);
+      if (e && member) return `${e.name}.${pyEnumMemberName(member.value)}`;
+    }
+  }
   switch (ft.kind) {
     case 'primitive': {
       if (ft.primitive === 'integer') return '123';

--- a/packages/generator/src/lang/swift.ts
+++ b/packages/generator/src/lang/swift.ts
@@ -628,6 +628,21 @@ function swiftLiteral(
   visited: Set<string> = new Set(),
   indent: number = 0,
 ): string {
+  if (ft.example !== undefined) {
+    if (ft.kind === 'primitive') {
+      if ((ft.primitive === 'integer' || ft.primitive === 'number') && typeof ft.example === 'number') {
+        if (ft.primitive === 'integer') return ft.format === 'int64' ? `Int64(${ft.example})` : String(ft.example);
+        return String(ft.example);
+      }
+      if (ft.primitive === 'boolean' && typeof ft.example === 'boolean') return String(ft.example);
+      if (ft.primitive === 'string' && typeof ft.example === 'string') return JSON.stringify(ft.example);
+    }
+    if (ft.kind === 'enum' && typeof ft.example === 'string') {
+      const e = ir.enums.find((en) => en.name === ft.ref);
+      const member = e?.members.find((m) => m.value === ft.example);
+      if (e && member) return `.${swiftIdentifier(member.value)}`;
+    }
+  }
   switch (ft.kind) {
     case 'primitive': {
       if (ft.primitive === 'integer') return ft.format === 'int64' ? 'Int64(123)' : '123';

--- a/packages/generator/src/lang/typescript.ts
+++ b/packages/generator/src/lang/typescript.ts
@@ -826,6 +826,18 @@ function tsLiteral(
   visited: Set<string> = new Set(),
   indent: number = 0,
 ): string {
+  if (ft.example !== undefined) {
+    if (ft.kind === 'primitive') {
+      if ((ft.primitive === 'integer' || ft.primitive === 'number') && typeof ft.example === 'number') return String(ft.example);
+      if (ft.primitive === 'boolean' && typeof ft.example === 'boolean') return String(ft.example);
+      if (ft.primitive === 'string' && typeof ft.example === 'string') return JSON.stringify(ft.example);
+    }
+    if (ft.kind === 'enum' && typeof ft.example === 'string') {
+      const e = ir.enums.find((en) => en.name === ft.ref);
+      const member = e?.members.find((m) => m.value === ft.example);
+      if (e && member) return `${e.name}.${enumMemberName(member.value)}`;
+    }
+  }
   switch (ft.kind) {
     case 'primitive': {
       if (ft.primitive === 'integer' || ft.primitive === 'number') return ft.primitive === 'integer' ? '123' : '1.5';

--- a/packages/generator/src/transform.ts
+++ b/packages/generator/src/transform.ts
@@ -178,7 +178,7 @@ function extractFields(
       inlineObjects.push(extracted);
       fields.push({
         name: propName,
-        type: { kind: 'model', ref: extractedName },
+        type: { kind: 'model', ref: extractedName, example: propSchema.example },
         required: required.has(propName),
         nullable: !!propSchema.nullable,
         description: propSchema.description,
@@ -243,9 +243,11 @@ function extractFields(
       continue;
     }
 
+    const fieldType = resolveFieldType(propSchema);
+    if (propSchema.example !== undefined) fieldType.example = propSchema.example;
     fields.push({
       name: propName,
-      type: resolveFieldType(propSchema),
+      type: fieldType,
       required: required.has(propName),
       nullable: !!propSchema.nullable,
       description: propSchema.description,
@@ -385,6 +387,8 @@ function transformParam(param: Parameter): IRParam {
   }
 
   let type = resolveFieldType(param.schema);
+  const ex = param.example ?? param.schema.example;
+  if (ex !== undefined) type.example = ex;
   if (isArray && type.kind !== 'array') {
     type = { kind: 'array', items: type };
   }

--- a/sdk/go/generated/examples.json
+++ b/sdk/go/generated/examples.json
@@ -3,7 +3,7 @@
     "usage": "import pachca \"github.com/pachca/openapi/sdk/go/generated\"\n\nclient := pachca.NewPachcaClient(\"YOUR_TOKEN\")"
   },
   "SecurityOperations_getAuditEvents": {
-    "usage": "params := GetAuditEventsParams{\n\tStartTime: \"2024-01-01T00:00:00Z\",\n\tEndTime: \"2024-01-01T00:00:00Z\",\n\tEventKey: Ptr(AuditEventKeyUserLogin),\n\tActorID: Ptr(\"example\"),\n\tActorType: Ptr(\"example\"),\n\tEntityID: Ptr(\"example\"),\n\tEntityType: Ptr(\"example\"),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Security.GetAuditEvents(ctx, params)",
+    "usage": "params := GetAuditEventsParams{\n\tStartTime: \"2025-05-01T09:11:00Z\",\n\tEndTime: \"2025-05-02T09:11:00Z\",\n\tEventKey: Ptr(AuditEventKeyUserLogin),\n\tActorID: Ptr(\"98765\"),\n\tActorType: Ptr(\"User\"),\n\tEntityID: Ptr(\"98765\"),\n\tEntityType: Ptr(\"User\"),\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Security.GetAuditEvents(ctx, params)",
     "output": "GetAuditEventsResponse{Data: []AuditEvent, Meta: *PaginationMeta}",
     "imports": [
       "AuditEventKey",
@@ -11,14 +11,14 @@
     ]
   },
   "BotOperations_getWebhookEvents": {
-    "usage": "params := &GetWebhookEventsParams{\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Bots.GetWebhookEvents(ctx, params)",
+    "usage": "params := &GetWebhookEventsParams{\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Bots.GetWebhookEvents(ctx, params)",
     "output": "GetWebhookEventsResponse{Data: []WebhookEvent, Meta: *PaginationMeta}",
     "imports": [
       "GetWebhookEventsParams"
     ]
   },
   "BotOperations_updateBot": {
-    "usage": "request := BotUpdateRequest{\n\tBot: BotUpdateRequestBot{\n\t\tWebhook: BotUpdateRequestBotWebhook{\n\t\t\tOutgoingURL: \"example\",\n\t\t},\n\t},\n}\nresponse, err := client.Bots.UpdateBot(ctx, int32(123), request)",
+    "usage": "request := BotUpdateRequest{\n\tBot: BotUpdateRequestBot{\n\t\tWebhook: BotUpdateRequestBotWebhook{\n\t\t\tOutgoingURL: \"https://www.website.com/tasks/new\",\n\t\t},\n\t},\n}\nresponse, err := client.Bots.UpdateBot(ctx, int32(1738816), request)",
     "output": "BotResponse{ID: int32, Webhook: BotResponseWebhook{OutgoingURL: string}}",
     "imports": [
       "BotUpdateRequest",
@@ -27,10 +27,10 @@
     ]
   },
   "BotOperations_deleteWebhookEvent": {
-    "usage": "client.Bots.DeleteWebhookEvent(ctx, \"example\")"
+    "usage": "client.Bots.DeleteWebhookEvent(ctx, \"01KAJZ2XDSS2S3DSW9EXJZ0TBV\")"
   },
   "ChatOperations_listChats": {
-    "usage": "params := &ListChatsParams{\n\tSortID: Ptr(SortOrderAsc),\n\tAvailability: Ptr(ChatAvailabilityIsMember),\n\tLastMessageAtAfter: Ptr(\"2024-01-01T00:00:00Z\"),\n\tLastMessageAtBefore: Ptr(\"2024-01-01T00:00:00Z\"),\n\tPersonal: Ptr(true),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Chats.ListChats(ctx, params)",
+    "usage": "params := &ListChatsParams{\n\tSortID: Ptr(SortOrderDesc),\n\tAvailability: Ptr(ChatAvailabilityIsMember),\n\tLastMessageAtAfter: Ptr(\"2025-01-01T00:00:00.000Z\"),\n\tLastMessageAtBefore: Ptr(\"2025-02-01T00:00:00.000Z\"),\n\tPersonal: Ptr(false),\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Chats.ListChats(ctx, params)",
     "output": "ListChatsResponse{Data: []Chat, Meta: *PaginationMeta}",
     "imports": [
       "ChatAvailability",
@@ -39,11 +39,11 @@
     ]
   },
   "ChatOperations_getChat": {
-    "usage": "response, err := client.Chats.GetChat(ctx, int32(123))",
+    "usage": "response, err := client.Chats.GetChat(ctx, int32(334))",
     "output": "Chat{ID: int32, Name: string, CreatedAt: string, OwnerID: int32, MemberIDs: []int32, GroupTagIDs: []int32, Channel: bool, Personal: bool, Public: bool, LastMessageAt: string, MeetRoomURL: string}"
   },
   "ChatOperations_createChat": {
-    "usage": "request := ChatCreateRequest{\n\tChat: ChatCreateRequestChat{\n\t\tName: \"example\",\n\t\tMemberIDs: []int32{int32(123)},\n\t\tGroupTagIDs: []int32{int32(123)},\n\t\tChannel: Ptr(true),\n\t\tPublic: Ptr(true),\n\t},\n}\nresponse, err := client.Chats.CreateChat(ctx, request)",
+    "usage": "request := ChatCreateRequest{\n\tChat: ChatCreateRequestChat{\n\t\tName: \"🤿 aqua\",\n\t\tMemberIDs: []int32{int32(123)},\n\t\tGroupTagIDs: []int32{int32(123)},\n\t\tChannel: Ptr(true),\n\t\tPublic: Ptr(false),\n\t},\n}\nresponse, err := client.Chats.CreateChat(ctx, request)",
     "output": "Chat{ID: int32, Name: string, CreatedAt: string, OwnerID: int32, MemberIDs: []int32, GroupTagIDs: []int32, Channel: bool, Personal: bool, Public: bool, LastMessageAt: string, MeetRoomURL: string}",
     "imports": [
       "ChatCreateRequest",
@@ -51,7 +51,7 @@
     ]
   },
   "ChatOperations_updateChat": {
-    "usage": "request := ChatUpdateRequest{\n\tChat: ChatUpdateRequestChat{\n\t\tName: Ptr(\"example\"),\n\t\tPublic: Ptr(true),\n\t},\n}\nresponse, err := client.Chats.UpdateChat(ctx, int32(123), request)",
+    "usage": "request := ChatUpdateRequest{\n\tChat: ChatUpdateRequestChat{\n\t\tName: Ptr(\"Бассейн\"),\n\t\tPublic: Ptr(true),\n\t},\n}\nresponse, err := client.Chats.UpdateChat(ctx, int32(334), request)",
     "output": "Chat{ID: int32, Name: string, CreatedAt: string, OwnerID: int32, MemberIDs: []int32, GroupTagIDs: []int32, Channel: bool, Personal: bool, Public: bool, LastMessageAt: string, MeetRoomURL: string}",
     "imports": [
       "ChatUpdateRequest",
@@ -59,13 +59,13 @@
     ]
   },
   "ChatOperations_archiveChat": {
-    "usage": "client.Chats.ArchiveChat(ctx, int32(123))"
+    "usage": "client.Chats.ArchiveChat(ctx, int32(334))"
   },
   "ChatOperations_unarchiveChat": {
-    "usage": "client.Chats.UnarchiveChat(ctx, int32(123))"
+    "usage": "client.Chats.UnarchiveChat(ctx, int32(334))"
   },
   "ExportOperations_downloadExport": {
-    "usage": "response, err := client.Common.DownloadExport(ctx, int32(123))",
+    "usage": "response, err := client.Common.DownloadExport(ctx, int32(22322))",
     "output": "string"
   },
   "CommonOperations_listProperties": {
@@ -77,7 +77,7 @@
     ]
   },
   "ExportOperations_requestExport": {
-    "usage": "request := ExportRequest{\n\tStartAt: \"2024-01-01\",\n\tEndAt: \"2024-01-01\",\n\tWebhookURL: \"example\",\n\tChatIDs: []int32{int32(123)},\n\tSkipChatsFile: Ptr(true),\n}\nclient.Common.RequestExport(ctx, request)",
+    "usage": "request := ExportRequest{\n\tStartAt: \"2025-03-20\",\n\tEndAt: \"2025-03-20\",\n\tWebhookURL: \"https://webhook.site/9227d3b8-6e82-4e64-bf5d-ad972ad270f2\",\n\tChatIDs: []int32{int32(123)},\n\tSkipChatsFile: Ptr(false),\n}\nclient.Common.RequestExport(ctx, request)",
     "imports": [
       "ExportRequest"
     ]
@@ -93,7 +93,7 @@
     "output": "UploadParams{ContentDisposition: string, ACL: string, Policy: string, XAMZCredential: string, XAMZAlgorithm: string, XAMZDate: string, XAMZSignature: string, Key: string, DirectURL: string}"
   },
   "ChatMemberOperations_listMembers": {
-    "usage": "params := &ListMembersParams{\n\tRole: Ptr(ChatMemberRoleFilterAll),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Members.ListMembers(ctx, int32(123), params)",
+    "usage": "params := &ListMembersParams{\n\tRole: Ptr(ChatMemberRoleFilterAll),\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Members.ListMembers(ctx, int32(334), params)",
     "output": "ListMembersResponse{Data: []User, Meta: *PaginationMeta}",
     "imports": [
       "ChatMemberRoleFilter",
@@ -101,31 +101,31 @@
     ]
   },
   "ChatMemberOperations_addTags": {
-    "usage": "groupTagIds := []int32{int32(123)}\nclient.Members.AddTags(ctx, int32(123), groupTagIds)"
+    "usage": "groupTagIds := []int32{int32(123)}\nclient.Members.AddTags(ctx, int32(334), groupTagIds)"
   },
   "ChatMemberOperations_addMembers": {
-    "usage": "request := AddMembersRequest{\n\tMemberIDs: []int32{int32(123)},\n\tSilent: Ptr(true),\n}\nclient.Members.AddMembers(ctx, int32(123), request)",
+    "usage": "request := AddMembersRequest{\n\tMemberIDs: []int32{int32(123)},\n\tSilent: Ptr(true),\n}\nclient.Members.AddMembers(ctx, int32(334), request)",
     "imports": [
       "AddMembersRequest"
     ]
   },
   "ChatMemberOperations_updateMemberRole": {
-    "usage": "client.Members.UpdateMemberRole(ctx, int32(123), int32(123), ChatMemberRoleAdmin)",
+    "usage": "client.Members.UpdateMemberRole(ctx, int32(334), int32(186), ChatMemberRoleAdmin)",
     "imports": [
       "ChatMemberRole"
     ]
   },
   "ChatMemberOperations_removeTag": {
-    "usage": "client.Members.RemoveTag(ctx, int32(123), int32(123))"
+    "usage": "client.Members.RemoveTag(ctx, int32(334), int32(86))"
   },
   "ChatMemberOperations_leaveChat": {
-    "usage": "client.Members.LeaveChat(ctx, int32(123))"
+    "usage": "client.Members.LeaveChat(ctx, int32(334))"
   },
   "ChatMemberOperations_removeMember": {
-    "usage": "client.Members.RemoveMember(ctx, int32(123), int32(123))"
+    "usage": "client.Members.RemoveMember(ctx, int32(334), int32(186))"
   },
   "GroupTagOperations_listTags": {
-    "usage": "params := &ListTagsParams{\n\tNames: Ptr(TagNamesFilter{}),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.GroupTags.ListTags(ctx, params)",
+    "usage": "params := &ListTagsParams{\n\tNames: Ptr(TagNamesFilter{}),\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.GroupTags.ListTags(ctx, params)",
     "output": "ListTagsResponse{Data: []GroupTag, Meta: *PaginationMeta}",
     "imports": [
       "ListTagsParams",
@@ -133,18 +133,18 @@
     ]
   },
   "GroupTagOperations_getTag": {
-    "usage": "response, err := client.GroupTags.GetTag(ctx, int32(123))",
+    "usage": "response, err := client.GroupTags.GetTag(ctx, int32(9111))",
     "output": "GroupTag{ID: int32, Name: string, UsersCount: int32}"
   },
   "GroupTagOperations_getTagUsers": {
-    "usage": "params := &GetTagUsersParams{\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.GroupTags.GetTagUsers(ctx, int32(123), params)",
+    "usage": "params := &GetTagUsersParams{\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.GroupTags.GetTagUsers(ctx, int32(9111), params)",
     "output": "GetTagUsersResponse{Data: []User, Meta: *PaginationMeta}",
     "imports": [
       "GetTagUsersParams"
     ]
   },
   "GroupTagOperations_createTag": {
-    "usage": "request := GroupTagRequest{\n\tGroupTag: GroupTagRequestGroupTag{\n\t\tName: \"example\",\n\t},\n}\nresponse, err := client.GroupTags.CreateTag(ctx, request)",
+    "usage": "request := GroupTagRequest{\n\tGroupTag: GroupTagRequestGroupTag{\n\t\tName: \"Новое название тега\",\n\t},\n}\nresponse, err := client.GroupTags.CreateTag(ctx, request)",
     "output": "GroupTag{ID: int32, Name: string, UsersCount: int32}",
     "imports": [
       "GroupTagRequest",
@@ -152,7 +152,7 @@
     ]
   },
   "GroupTagOperations_updateTag": {
-    "usage": "request := GroupTagRequest{\n\tGroupTag: GroupTagRequestGroupTag{\n\t\tName: \"example\",\n\t},\n}\nresponse, err := client.GroupTags.UpdateTag(ctx, int32(123), request)",
+    "usage": "request := GroupTagRequest{\n\tGroupTag: GroupTagRequestGroupTag{\n\t\tName: \"Новое название тега\",\n\t},\n}\nresponse, err := client.GroupTags.UpdateTag(ctx, int32(9111), request)",
     "output": "GroupTag{ID: int32, Name: string, UsersCount: int32}",
     "imports": [
       "GroupTagRequest",
@@ -160,10 +160,10 @@
     ]
   },
   "GroupTagOperations_deleteTag": {
-    "usage": "client.GroupTags.DeleteTag(ctx, int32(123))"
+    "usage": "client.GroupTags.DeleteTag(ctx, int32(9111))"
   },
   "ChatMessageOperations_listChatMessages": {
-    "usage": "params := ListChatMessagesParams{\n\tChatID: int32(123),\n\tSortID: Ptr(SortOrderAsc),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Messages.ListChatMessages(ctx, params)",
+    "usage": "params := ListChatMessagesParams{\n\tChatID: int32(198),\n\tSortID: Ptr(SortOrderDesc),\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Messages.ListChatMessages(ctx, params)",
     "output": "ListChatMessagesResponse{Data: []Message, Meta: *PaginationMeta}",
     "imports": [
       "ListChatMessagesParams",
@@ -171,11 +171,11 @@
     ]
   },
   "MessageOperations_getMessage": {
-    "usage": "response, err := client.Messages.GetMessage(ctx, int32(123))",
+    "usage": "response, err := client.Messages.GetMessage(ctx, int32(194275))",
     "output": "Message{ID: int32, EntityType: MessageEntityType, EntityID: int32, ChatID: int32, RootChatID: int32, Content: string, UserID: int32, CreatedAt: string, URL: string, Files: []File{ID: int32, Key: string, Name: string, FileType: FileType, URL: string, Width: *int32, Height: *int32}, Buttons: *[][]Button{Text: string, URL: *string, Data: *string}, Thread: *Thread{ID: int64, ChatID: int64, MessageID: int64, MessageChatID: int64, UpdatedAt: string}, Forwarding: *Forwarding{OriginalMessageID: int32, OriginalChatID: int32, AuthorID: int32, OriginalCreatedAt: string, OriginalThreadID: *int32, OriginalThreadMessageID: *int32, OriginalThreadParentChatID: *int32}, ParentMessageID: *int32, DisplayAvatarURL: *string, DisplayName: *string, ChangedAt: *string, DeletedAt: *string}"
   },
   "MessageOperations_createMessage": {
-    "usage": "request := MessageCreateRequest{\n\tMessage: MessageCreateRequestMessage{\n\t\tEntityType: Ptr(MessageEntityTypeDiscussion),\n\t\tEntityID: int32(123),\n\t\tContent: \"example\",\n\t\tFiles: []MessageCreateRequestFile{MessageCreateRequestFile{\n\t\t\tKey: \"example\",\n\t\t\tName: \"example\",\n\t\t\tFileType: FileTypeFile,\n\t\t\tSize: int32(123),\n\t\t\tWidth: Ptr(int32(123)),\n\t\t\tHeight: Ptr(int32(123)),\n\t\t}},\n\t\tButtons: [][]Button{[]Button{Button{\n\t\t\tText: \"example\",\n\t\t\tURL: Ptr(\"example\"),\n\t\t\tData: Ptr(\"example\"),\n\t\t}}},\n\t\tParentMessageID: Ptr(int32(123)),\n\t\tDisplayAvatarURL: Ptr(\"example\"),\n\t\tDisplayName: Ptr(\"example\"),\n\t\tSkipInviteMentions: Ptr(true),\n\t\tLinkPreview: Ptr(true),\n\t},\n}\nresponse, err := client.Messages.CreateMessage(ctx, request)",
+    "usage": "request := MessageCreateRequest{\n\tMessage: MessageCreateRequestMessage{\n\t\tEntityType: Ptr(MessageEntityTypeDiscussion),\n\t\tEntityID: int32(334),\n\t\tContent: \"Вчера мы продали 756 футболок (что на 10% больше, чем в прошлое воскресенье)\",\n\t\tFiles: []MessageCreateRequestFile{MessageCreateRequestFile{\n\t\t\tKey: \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n\t\t\tName: \"logo.png\",\n\t\t\tFileType: FileTypeImage,\n\t\t\tSize: int32(12345),\n\t\t\tWidth: Ptr(int32(800)),\n\t\t\tHeight: Ptr(int32(600)),\n\t\t}},\n\t\tButtons: [][]Button{[]Button{Button{\n\t\t\tText: \"Подробнее\",\n\t\t\tURL: Ptr(\"https://example.com/details\"),\n\t\t\tData: Ptr(\"awesome\"),\n\t\t}}},\n\t\tParentMessageID: Ptr(int32(194270)),\n\t\tDisplayAvatarURL: Ptr(\"https://example.com/avatar.png\"),\n\t\tDisplayName: Ptr(\"Бот Поддержки\"),\n\t\tSkipInviteMentions: Ptr(false),\n\t\tLinkPreview: Ptr(false),\n\t},\n}\nresponse, err := client.Messages.CreateMessage(ctx, request)",
     "output": "Message{ID: int32, EntityType: MessageEntityType, EntityID: int32, ChatID: int32, RootChatID: int32, Content: string, UserID: int32, CreatedAt: string, URL: string, Files: []File{ID: int32, Key: string, Name: string, FileType: FileType, URL: string, Width: *int32, Height: *int32}, Buttons: *[][]Button{Text: string, URL: *string, Data: *string}, Thread: *Thread{ID: int64, ChatID: int64, MessageID: int64, MessageChatID: int64, UpdatedAt: string}, Forwarding: *Forwarding{OriginalMessageID: int32, OriginalChatID: int32, AuthorID: int32, OriginalCreatedAt: string, OriginalThreadID: *int32, OriginalThreadMessageID: *int32, OriginalThreadParentChatID: *int32}, ParentMessageID: *int32, DisplayAvatarURL: *string, DisplayName: *string, ChangedAt: *string, DeletedAt: *string}",
     "imports": [
       "Button",
@@ -187,10 +187,10 @@
     ]
   },
   "MessageOperations_pinMessage": {
-    "usage": "client.Messages.PinMessage(ctx, int32(123))"
+    "usage": "client.Messages.PinMessage(ctx, int32(194275))"
   },
   "MessageOperations_updateMessage": {
-    "usage": "request := MessageUpdateRequest{\n\tMessage: MessageUpdateRequestMessage{\n\t\tContent: Ptr(\"example\"),\n\t\tFiles: []MessageUpdateRequestFile{MessageUpdateRequestFile{\n\t\t\tKey: \"example\",\n\t\t\tName: \"example\",\n\t\t\tFileType: Ptr(\"example\"),\n\t\t\tSize: Ptr(int32(123)),\n\t\t\tWidth: Ptr(int32(123)),\n\t\t\tHeight: Ptr(int32(123)),\n\t\t}},\n\t\tButtons: [][]Button{[]Button{Button{\n\t\t\tText: \"example\",\n\t\t\tURL: Ptr(\"example\"),\n\t\t\tData: Ptr(\"example\"),\n\t\t}}},\n\t\tDisplayAvatarURL: Ptr(\"example\"),\n\t\tDisplayName: Ptr(\"example\"),\n\t},\n}\nresponse, err := client.Messages.UpdateMessage(ctx, int32(123), request)",
+    "usage": "request := MessageUpdateRequest{\n\tMessage: MessageUpdateRequestMessage{\n\t\tContent: Ptr(\"Вот попробуйте написать правильно это с первого раза: Будущий, Полощи, Прийти, Грейпфрут, Мозаика, Бюллетень, Дуршлаг, Винегрет.\"),\n\t\tFiles: []MessageUpdateRequestFile{MessageUpdateRequestFile{\n\t\t\tKey: \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n\t\t\tName: \"logo.png\",\n\t\t\tFileType: Ptr(\"image\"),\n\t\t\tSize: Ptr(int32(12345)),\n\t\t\tWidth: Ptr(int32(800)),\n\t\t\tHeight: Ptr(int32(600)),\n\t\t}},\n\t\tButtons: [][]Button{[]Button{Button{\n\t\t\tText: \"Подробнее\",\n\t\t\tURL: Ptr(\"https://example.com/details\"),\n\t\t\tData: Ptr(\"awesome\"),\n\t\t}}},\n\t\tDisplayAvatarURL: Ptr(\"https://example.com/avatar.png\"),\n\t\tDisplayName: Ptr(\"Бот Поддержки\"),\n\t},\n}\nresponse, err := client.Messages.UpdateMessage(ctx, int32(194275), request)",
     "output": "Message{ID: int32, EntityType: MessageEntityType, EntityID: int32, ChatID: int32, RootChatID: int32, Content: string, UserID: int32, CreatedAt: string, URL: string, Files: []File{ID: int32, Key: string, Name: string, FileType: FileType, URL: string, Width: *int32, Height: *int32}, Buttons: *[][]Button{Text: string, URL: *string, Data: *string}, Thread: *Thread{ID: int64, ChatID: int64, MessageID: int64, MessageChatID: int64, UpdatedAt: string}, Forwarding: *Forwarding{OriginalMessageID: int32, OriginalChatID: int32, AuthorID: int32, OriginalCreatedAt: string, OriginalThreadID: *int32, OriginalThreadMessageID: *int32, OriginalThreadParentChatID: *int32}, ParentMessageID: *int32, DisplayAvatarURL: *string, DisplayName: *string, ChangedAt: *string, DeletedAt: *string}",
     "imports": [
       "Button",
@@ -200,13 +200,13 @@
     ]
   },
   "MessageOperations_deleteMessage": {
-    "usage": "client.Messages.DeleteMessage(ctx, int32(123))"
+    "usage": "client.Messages.DeleteMessage(ctx, int32(194275))"
   },
   "MessageOperations_unpinMessage": {
-    "usage": "client.Messages.UnpinMessage(ctx, int32(123))"
+    "usage": "client.Messages.UnpinMessage(ctx, int32(194275))"
   },
   "LinkPreviewOperations_createLinkPreviews": {
-    "usage": "request := LinkPreviewsRequest{\n\tLinkPreviews: map[string]LinkPreview{\"key\": LinkPreview{\n\t\tTitle: \"example\",\n\t\tDescription: \"example\",\n\t\tImageURL: Ptr(\"example\"),\n\t\tImage: Ptr(LinkPreviewImage{\n\t\t\tKey: \"example\",\n\t\t\tName: \"example\",\n\t\t\tSize: Ptr(int32(123)),\n\t\t}),\n\t}},\n}\nclient.LinkPreviews.CreateLinkPreviews(ctx, int32(123), request)",
+    "usage": "request := LinkPreviewsRequest{\n\tLinkPreviews: map[string]LinkPreview{\"key\": LinkPreview{\n\t\tTitle: \"Статья: Отправка файлов\",\n\t\tDescription: \"Пример отправки файлов на удаленный сервер\",\n\t\tImageURL: Ptr(\"https://website.com/img/landing.png\"),\n\t\tImage: Ptr(LinkPreviewImage{\n\t\t\tKey: \"attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/${filename}\",\n\t\t\tName: \"files-to-server.jpg\",\n\t\t\tSize: Ptr(int32(695604)),\n\t\t}),\n\t}},\n}\nclient.LinkPreviews.CreateLinkPreviews(ctx, int32(194275), request)",
     "imports": [
       "LinkPreview",
       "LinkPreviewImage",
@@ -214,38 +214,38 @@
     ]
   },
   "ReactionOperations_listReactions": {
-    "usage": "params := &ListReactionsParams{\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Reactions.ListReactions(ctx, int32(123), params)",
+    "usage": "params := &ListReactionsParams{\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Reactions.ListReactions(ctx, int32(194275), params)",
     "output": "ListReactionsResponse{Data: []Reaction, Meta: *PaginationMeta}",
     "imports": [
       "ListReactionsParams"
     ]
   },
   "ReactionOperations_addReaction": {
-    "usage": "request := ReactionRequest{\n\tCode: \"example\",\n\tName: Ptr(\"example\"),\n}\nresponse, err := client.Reactions.AddReaction(ctx, int32(123), request)",
+    "usage": "request := ReactionRequest{\n\tCode: \"👍\",\n\tName: Ptr(\":+1:\"),\n}\nresponse, err := client.Reactions.AddReaction(ctx, int32(7231942), request)",
     "output": "Reaction{UserID: int32, CreatedAt: string, Code: string, Name: *string}",
     "imports": [
       "ReactionRequest"
     ]
   },
   "ReactionOperations_removeReaction": {
-    "usage": "params := RemoveReactionParams{\n\tCode: \"example\",\n\tName: Ptr(\"example\"),\n}\nclient.Reactions.RemoveReaction(ctx, int32(123), params)",
+    "usage": "params := RemoveReactionParams{\n\tCode: \"👍\",\n\tName: Ptr(\":+1:\"),\n}\nclient.Reactions.RemoveReaction(ctx, int32(7231942), params)",
     "imports": [
       "RemoveReactionParams"
     ]
   },
   "ReadMemberOperations_listReadMembers": {
-    "usage": "params := &ListReadMembersParams{\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.ReadMembers.ListReadMembers(ctx, int32(123), params)",
+    "usage": "params := &ListReadMembersParams{\n\tLimit: Ptr(int32(300)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.ReadMembers.ListReadMembers(ctx, int32(194275), params)",
     "output": "any",
     "imports": [
       "ListReadMembersParams"
     ]
   },
   "ThreadOperations_getThread": {
-    "usage": "response, err := client.Threads.GetThread(ctx, int32(123))",
+    "usage": "response, err := client.Threads.GetThread(ctx, int32(265142))",
     "output": "Thread{ID: int64, ChatID: int64, MessageID: int64, MessageChatID: int64, UpdatedAt: string}"
   },
   "ThreadOperations_createThread": {
-    "usage": "response, err := client.Threads.CreateThread(ctx, int32(123))",
+    "usage": "response, err := client.Threads.CreateThread(ctx, int32(154332686))",
     "output": "Thread{ID: int64, ChatID: int64, MessageID: int64, MessageChatID: int64, UpdatedAt: string}"
   },
   "OAuthOperations_getTokenInfo": {
@@ -261,7 +261,7 @@
     "output": "any"
   },
   "ProfileOperations_updateStatus": {
-    "usage": "request := StatusUpdateRequest{\n\tStatus: StatusUpdateRequestStatus{\n\t\tEmoji: \"example\",\n\t\tTitle: \"example\",\n\t\tExpiresAt: Ptr(\"2024-01-01T00:00:00Z\"),\n\t\tIsAway: Ptr(true),\n\t\tAwayMessage: Ptr(\"example\"),\n\t},\n}\nresponse, err := client.Profile.UpdateStatus(ctx, request)",
+    "usage": "request := StatusUpdateRequest{\n\tStatus: StatusUpdateRequestStatus{\n\t\tEmoji: \"🎮\",\n\t\tTitle: \"Очень занят\",\n\t\tExpiresAt: Ptr(\"2024-04-08T10:00:00.000Z\"),\n\t\tIsAway: Ptr(true),\n\t\tAwayMessage: Ptr(\"Вернусь после 15:00\"),\n\t},\n}\nresponse, err := client.Profile.UpdateStatus(ctx, request)",
     "output": "UserStatus{Emoji: string, Title: string, ExpiresAt: *string, IsAway: bool, AwayMessage: *UserStatusAwayMessage{Text: string}}",
     "imports": [
       "StatusUpdateRequest",
@@ -272,7 +272,7 @@
     "usage": "client.Profile.DeleteStatus(ctx)"
   },
   "SearchOperations_searchChats": {
-    "usage": "params := &SearchChatsParams{\n\tQuery: Ptr(\"example\"),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n\tOrder: Ptr(SortOrderAsc),\n\tCreatedFrom: Ptr(\"2024-01-01T00:00:00Z\"),\n\tCreatedTo: Ptr(\"2024-01-01T00:00:00Z\"),\n\tActive: Ptr(true),\n\tChatSubtype: Ptr(ChatSubtypeDiscussion),\n\tPersonal: Ptr(true),\n}\nresponse, err := client.Search.SearchChats(ctx, params)",
+    "usage": "params := &SearchChatsParams{\n\tQuery: Ptr(\"Разработка\"),\n\tLimit: Ptr(int32(10)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n\tOrder: Ptr(SortOrderDesc),\n\tCreatedFrom: Ptr(\"2025-01-01T00:00:00.000Z\"),\n\tCreatedTo: Ptr(\"2025-02-01T00:00:00.000Z\"),\n\tActive: Ptr(true),\n\tChatSubtype: Ptr(ChatSubtypeDiscussion),\n\tPersonal: Ptr(false),\n}\nresponse, err := client.Search.SearchChats(ctx, params)",
     "output": "SearchChatsResponse{Data: []Chat, Meta: SearchPaginationMeta}",
     "imports": [
       "ChatSubtype",
@@ -281,7 +281,7 @@
     ]
   },
   "SearchOperations_searchMessages": {
-    "usage": "params := &SearchMessagesParams{\n\tQuery: Ptr(\"example\"),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n\tOrder: Ptr(SortOrderAsc),\n\tCreatedFrom: Ptr(\"2024-01-01T00:00:00Z\"),\n\tCreatedTo: Ptr(\"2024-01-01T00:00:00Z\"),\n\tChatIDs: []int32{int32(123)},\n\tUserIDs: []int32{int32(123)},\n\tActive: Ptr(true),\n}\nresponse, err := client.Search.SearchMessages(ctx, params)",
+    "usage": "params := &SearchMessagesParams{\n\tQuery: Ptr(\"футболки\"),\n\tLimit: Ptr(int32(10)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n\tOrder: Ptr(SortOrderDesc),\n\tCreatedFrom: Ptr(\"2025-01-01T00:00:00.000Z\"),\n\tCreatedTo: Ptr(\"2025-02-01T00:00:00.000Z\"),\n\tChatIDs: []int32{int32(123)},\n\tUserIDs: []int32{int32(123)},\n\tActive: Ptr(true),\n}\nresponse, err := client.Search.SearchMessages(ctx, params)",
     "output": "SearchMessagesResponse{Data: []Message, Meta: SearchPaginationMeta}",
     "imports": [
       "SearchMessagesParams",
@@ -289,7 +289,7 @@
     ]
   },
   "SearchOperations_searchUsers": {
-    "usage": "params := &SearchUsersParams{\n\tQuery: Ptr(\"example\"),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n\tSort: Ptr(SearchSortOrderByScore),\n\tOrder: Ptr(SortOrderAsc),\n\tCreatedFrom: Ptr(\"2024-01-01T00:00:00Z\"),\n\tCreatedTo: Ptr(\"2024-01-01T00:00:00Z\"),\n\tCompanyRoles: []UserRole{UserRoleAdmin},\n}\nresponse, err := client.Search.SearchUsers(ctx, params)",
+    "usage": "params := &SearchUsersParams{\n\tQuery: Ptr(\"Олег\"),\n\tLimit: Ptr(int32(10)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n\tSort: Ptr(SearchSortOrderByScore),\n\tOrder: Ptr(SortOrderDesc),\n\tCreatedFrom: Ptr(\"2025-01-01T00:00:00.000Z\"),\n\tCreatedTo: Ptr(\"2025-02-01T00:00:00.000Z\"),\n\tCompanyRoles: []UserRole{UserRoleAdmin},\n}\nresponse, err := client.Search.SearchUsers(ctx, params)",
     "output": "SearchUsersResponse{Data: []User, Meta: SearchPaginationMeta}",
     "imports": [
       "SearchSortOrder",
@@ -299,18 +299,18 @@
     ]
   },
   "TaskOperations_listTasks": {
-    "usage": "params := &ListTasksParams{\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Tasks.ListTasks(ctx, params)",
+    "usage": "params := &ListTasksParams{\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Tasks.ListTasks(ctx, params)",
     "output": "ListTasksResponse{Data: []Task, Meta: *PaginationMeta}",
     "imports": [
       "ListTasksParams"
     ]
   },
   "TaskOperations_getTask": {
-    "usage": "response, err := client.Tasks.GetTask(ctx, int32(123))",
+    "usage": "response, err := client.Tasks.GetTask(ctx, int32(22283))",
     "output": "Task{ID: int32, Kind: TaskKind, Content: string, DueAt: *string, Priority: int32, UserID: int32, ChatID: *int32, Status: TaskStatus, CreatedAt: string, PerformerIDs: []int32, AllDay: bool, CustomProperties: []CustomProperty{ID: int32, Name: string, DataType: CustomPropertyDataType, Value: string}}"
   },
   "TaskOperations_createTask": {
-    "usage": "request := TaskCreateRequest{\n\tTask: TaskCreateRequestTask{\n\t\tKind: TaskKindCall,\n\t\tContent: Ptr(\"example\"),\n\t\tDueAt: Ptr(\"2024-01-01T00:00:00Z\"),\n\t\tPriority: Ptr(int32(123)),\n\t\tPerformerIDs: []int32{int32(123)},\n\t\tChatID: Ptr(int32(123)),\n\t\tAllDay: Ptr(true),\n\t\tCustomProperties: []TaskCreateRequestCustomProperty{TaskCreateRequestCustomProperty{\n\t\t\tID: int32(123),\n\t\t\tValue: \"example\",\n\t\t}},\n\t},\n}\nresponse, err := client.Tasks.CreateTask(ctx, request)",
+    "usage": "request := TaskCreateRequest{\n\tTask: TaskCreateRequestTask{\n\t\tKind: TaskKindReminder,\n\t\tContent: Ptr(\"Забрать со склада 21 заказ\"),\n\t\tDueAt: Ptr(\"2020-06-05T12:00:00.000+03:00\"),\n\t\tPriority: Ptr(int32(2)),\n\t\tPerformerIDs: []int32{int32(123)},\n\t\tChatID: Ptr(int32(456)),\n\t\tAllDay: Ptr(false),\n\t\tCustomProperties: []TaskCreateRequestCustomProperty{TaskCreateRequestCustomProperty{\n\t\t\tID: int32(78),\n\t\t\tValue: \"Синий склад\",\n\t\t}},\n\t},\n}\nresponse, err := client.Tasks.CreateTask(ctx, request)",
     "output": "Task{ID: int32, Kind: TaskKind, Content: string, DueAt: *string, Priority: int32, UserID: int32, ChatID: *int32, Status: TaskStatus, CreatedAt: string, PerformerIDs: []int32, AllDay: bool, CustomProperties: []CustomProperty{ID: int32, Name: string, DataType: CustomPropertyDataType, Value: string}}",
     "imports": [
       "TaskCreateRequest",
@@ -320,7 +320,7 @@
     ]
   },
   "TaskOperations_updateTask": {
-    "usage": "request := TaskUpdateRequest{\n\tTask: TaskUpdateRequestTask{\n\t\tKind: Ptr(TaskKindCall),\n\t\tContent: Ptr(\"example\"),\n\t\tDueAt: Ptr(\"2024-01-01T00:00:00Z\"),\n\t\tPriority: Ptr(int32(123)),\n\t\tPerformerIDs: []int32{int32(123)},\n\t\tStatus: Ptr(TaskStatusDone),\n\t\tAllDay: Ptr(true),\n\t\tDoneAt: Ptr(\"2024-01-01T00:00:00Z\"),\n\t\tCustomProperties: []TaskUpdateRequestCustomProperty{TaskUpdateRequestCustomProperty{\n\t\t\tID: int32(123),\n\t\t\tValue: \"example\",\n\t\t}},\n\t},\n}\nresponse, err := client.Tasks.UpdateTask(ctx, int32(123), request)",
+    "usage": "request := TaskUpdateRequest{\n\tTask: TaskUpdateRequestTask{\n\t\tKind: Ptr(TaskKindReminder),\n\t\tContent: Ptr(\"Забрать со склада 21 заказ\"),\n\t\tDueAt: Ptr(\"2020-06-05T12:00:00.000+03:00\"),\n\t\tPriority: Ptr(int32(2)),\n\t\tPerformerIDs: []int32{int32(123)},\n\t\tStatus: Ptr(TaskStatusDone),\n\t\tAllDay: Ptr(false),\n\t\tDoneAt: Ptr(\"2020-06-05T12:00:00.000Z\"),\n\t\tCustomProperties: []TaskUpdateRequestCustomProperty{TaskUpdateRequestCustomProperty{\n\t\t\tID: int32(78),\n\t\t\tValue: \"Синий склад\",\n\t\t}},\n\t},\n}\nresponse, err := client.Tasks.UpdateTask(ctx, int32(22283), request)",
     "output": "Task{ID: int32, Kind: TaskKind, Content: string, DueAt: *string, Priority: int32, UserID: int32, ChatID: *int32, Status: TaskStatus, CreatedAt: string, PerformerIDs: []int32, AllDay: bool, CustomProperties: []CustomProperty{ID: int32, Name: string, DataType: CustomPropertyDataType, Value: string}}",
     "imports": [
       "TaskKind",
@@ -331,25 +331,25 @@
     ]
   },
   "TaskOperations_deleteTask": {
-    "usage": "client.Tasks.DeleteTask(ctx, int32(123))"
+    "usage": "client.Tasks.DeleteTask(ctx, int32(22283))"
   },
   "UserOperations_listUsers": {
-    "usage": "params := &ListUsersParams{\n\tQuery: Ptr(\"example\"),\n\tLimit: Ptr(int32(123)),\n\tCursor: Ptr(\"example\"),\n}\nresponse, err := client.Users.ListUsers(ctx, params)",
+    "usage": "params := &ListUsersParams{\n\tQuery: Ptr(\"Олег\"),\n\tLimit: Ptr(int32(1)),\n\tCursor: Ptr(\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"),\n}\nresponse, err := client.Users.ListUsers(ctx, params)",
     "output": "ListUsersResponse{Data: []User, Meta: *PaginationMeta}",
     "imports": [
       "ListUsersParams"
     ]
   },
   "UserOperations_getUser": {
-    "usage": "response, err := client.Users.GetUser(ctx, int32(123))",
+    "usage": "response, err := client.Users.GetUser(ctx, int32(12))",
     "output": "User{ID: int32, FirstName: string, LastName: string, Nickname: string, Email: string, PhoneNumber: string, Department: string, Title: string, Role: UserRole, Suspended: bool, InviteStatus: InviteStatus, ListTags: []string, CustomProperties: []CustomProperty{ID: int32, Name: string, DataType: CustomPropertyDataType, Value: string}, UserStatus: *UserStatus{Emoji: string, Title: string, ExpiresAt: *string, IsAway: bool, AwayMessage: *UserStatusAwayMessage{Text: string}}, Bot: bool, Sso: bool, CreatedAt: string, LastActivityAt: string, TimeZone: string, ImageURL: *string}"
   },
   "UserStatusOperations_getUserStatus": {
-    "usage": "response, err := client.Users.GetUserStatus(ctx, int32(123))",
+    "usage": "response, err := client.Users.GetUserStatus(ctx, int32(12))",
     "output": "any"
   },
   "UserOperations_createUser": {
-    "usage": "request := UserCreateRequest{\n\tUser: UserCreateRequestUser{\n\t\tFirstName: Ptr(\"example\"),\n\t\tLastName: Ptr(\"example\"),\n\t\tEmail: \"example\",\n\t\tPhoneNumber: Ptr(\"example\"),\n\t\tNickname: Ptr(\"example\"),\n\t\tDepartment: Ptr(\"example\"),\n\t\tTitle: Ptr(\"example\"),\n\t\tRole: Ptr(UserRoleAdmin),\n\t\tSuspended: Ptr(true),\n\t\tListTags: []string{\"example\"},\n\t\tCustomProperties: []UserCreateRequestCustomProperty{UserCreateRequestCustomProperty{\n\t\t\tID: int32(123),\n\t\t\tValue: \"example\",\n\t\t}},\n\t},\n\tSkipEmailNotify: Ptr(true),\n}\nresponse, err := client.Users.CreateUser(ctx, request)",
+    "usage": "request := UserCreateRequest{\n\tUser: UserCreateRequestUser{\n\t\tFirstName: Ptr(\"Олег\"),\n\t\tLastName: Ptr(\"Петров\"),\n\t\tEmail: \"olegp@example.com\",\n\t\tPhoneNumber: Ptr(\"+79001234567\"),\n\t\tNickname: Ptr(\"olegpetrov\"),\n\t\tDepartment: Ptr(\"Продукт\"),\n\t\tTitle: Ptr(\"CIO\"),\n\t\tRole: Ptr(UserRoleUser),\n\t\tSuspended: Ptr(false),\n\t\tListTags: []string{\"example\"},\n\t\tCustomProperties: []UserCreateRequestCustomProperty{UserCreateRequestCustomProperty{\n\t\t\tID: int32(1678),\n\t\t\tValue: \"Санкт-Петербург\",\n\t\t}},\n\t},\n\tSkipEmailNotify: Ptr(true),\n}\nresponse, err := client.Users.CreateUser(ctx, request)",
     "output": "User{ID: int32, FirstName: string, LastName: string, Nickname: string, Email: string, PhoneNumber: string, Department: string, Title: string, Role: UserRole, Suspended: bool, InviteStatus: InviteStatus, ListTags: []string, CustomProperties: []CustomProperty{ID: int32, Name: string, DataType: CustomPropertyDataType, Value: string}, UserStatus: *UserStatus{Emoji: string, Title: string, ExpiresAt: *string, IsAway: bool, AwayMessage: *UserStatusAwayMessage{Text: string}}, Bot: bool, Sso: bool, CreatedAt: string, LastActivityAt: string, TimeZone: string, ImageURL: *string}",
     "imports": [
       "UserCreateRequest",
@@ -359,7 +359,7 @@
     ]
   },
   "UserOperations_updateUser": {
-    "usage": "request := UserUpdateRequest{\n\tUser: UserUpdateRequestUser{\n\t\tFirstName: Ptr(\"example\"),\n\t\tLastName: Ptr(\"example\"),\n\t\tEmail: Ptr(\"example\"),\n\t\tPhoneNumber: Ptr(\"example\"),\n\t\tNickname: Ptr(\"example\"),\n\t\tDepartment: Ptr(\"example\"),\n\t\tTitle: Ptr(\"example\"),\n\t\tRole: Ptr(UserRoleAdmin),\n\t\tSuspended: Ptr(true),\n\t\tListTags: []string{\"example\"},\n\t\tCustomProperties: []UserUpdateRequestCustomProperty{UserUpdateRequestCustomProperty{\n\t\t\tID: int32(123),\n\t\t\tValue: \"example\",\n\t\t}},\n\t},\n}\nresponse, err := client.Users.UpdateUser(ctx, int32(123), request)",
+    "usage": "request := UserUpdateRequest{\n\tUser: UserUpdateRequestUser{\n\t\tFirstName: Ptr(\"Олег\"),\n\t\tLastName: Ptr(\"Петров\"),\n\t\tEmail: Ptr(\"olegpetrov@example.com\"),\n\t\tPhoneNumber: Ptr(\"+79001234567\"),\n\t\tNickname: Ptr(\"olegpetrov\"),\n\t\tDepartment: Ptr(\"Отдел разработки\"),\n\t\tTitle: Ptr(\"Старший разработчик\"),\n\t\tRole: Ptr(UserRoleUser),\n\t\tSuspended: Ptr(false),\n\t\tListTags: []string{\"example\"},\n\t\tCustomProperties: []UserUpdateRequestCustomProperty{UserUpdateRequestCustomProperty{\n\t\t\tID: int32(1678),\n\t\t\tValue: \"Санкт-Петербург\",\n\t\t}},\n\t},\n}\nresponse, err := client.Users.UpdateUser(ctx, int32(12), request)",
     "output": "User{ID: int32, FirstName: string, LastName: string, Nickname: string, Email: string, PhoneNumber: string, Department: string, Title: string, Role: UserRole, Suspended: bool, InviteStatus: InviteStatus, ListTags: []string, CustomProperties: []CustomProperty{ID: int32, Name: string, DataType: CustomPropertyDataType, Value: string}, UserStatus: *UserStatus{Emoji: string, Title: string, ExpiresAt: *string, IsAway: bool, AwayMessage: *UserStatusAwayMessage{Text: string}}, Bot: bool, Sso: bool, CreatedAt: string, LastActivityAt: string, TimeZone: string, ImageURL: *string}",
     "imports": [
       "UserRole",
@@ -369,7 +369,7 @@
     ]
   },
   "UserStatusOperations_updateUserStatus": {
-    "usage": "request := StatusUpdateRequest{\n\tStatus: StatusUpdateRequestStatus{\n\t\tEmoji: \"example\",\n\t\tTitle: \"example\",\n\t\tExpiresAt: Ptr(\"2024-01-01T00:00:00Z\"),\n\t\tIsAway: Ptr(true),\n\t\tAwayMessage: Ptr(\"example\"),\n\t},\n}\nresponse, err := client.Users.UpdateUserStatus(ctx, int32(123), request)",
+    "usage": "request := StatusUpdateRequest{\n\tStatus: StatusUpdateRequestStatus{\n\t\tEmoji: \"🎮\",\n\t\tTitle: \"Очень занят\",\n\t\tExpiresAt: Ptr(\"2024-04-08T10:00:00.000Z\"),\n\t\tIsAway: Ptr(true),\n\t\tAwayMessage: Ptr(\"Вернусь после 15:00\"),\n\t},\n}\nresponse, err := client.Users.UpdateUserStatus(ctx, int32(12), request)",
     "output": "UserStatus{Emoji: string, Title: string, ExpiresAt: *string, IsAway: bool, AwayMessage: *UserStatusAwayMessage{Text: string}}",
     "imports": [
       "StatusUpdateRequest",
@@ -377,13 +377,13 @@
     ]
   },
   "UserOperations_deleteUser": {
-    "usage": "client.Users.DeleteUser(ctx, int32(123))"
+    "usage": "client.Users.DeleteUser(ctx, int32(12))"
   },
   "UserStatusOperations_deleteUserStatus": {
-    "usage": "client.Users.DeleteUserStatus(ctx, int32(123))"
+    "usage": "client.Users.DeleteUserStatus(ctx, int32(12))"
   },
   "FormOperations_openView": {
-    "usage": "request := OpenViewRequest{\n\tType: \"modal\",\n\tTriggerID: \"example\",\n\tPrivateMetadata: Ptr(\"example\"),\n\tCallbackID: Ptr(\"example\"),\n\tView: OpenViewRequestView{\n\t\tTitle: \"example\",\n\t\tCloseText: Ptr(\"example\"),\n\t\tSubmitText: Ptr(\"example\"),\n\t\tBlocks: []ViewBlockUnion{ViewBlockHeader{\n\t\t\tType: \"header\",\n\t\t\tText: \"example\",\n\t\t}},\n\t},\n}\nclient.Views.OpenView(ctx, request)",
+    "usage": "request := OpenViewRequest{\n\tType: \"modal\",\n\tTriggerID: \"791a056b-006c-49dd-834b-c633fde52fe8\",\n\tPrivateMetadata: Ptr(\"{\\\"timeoff_id\\\":4378}\"),\n\tCallbackID: Ptr(\"timeoff_reguest_form\"),\n\tView: OpenViewRequestView{\n\t\tTitle: \"Уведомление об отпуске\",\n\t\tCloseText: Ptr(\"Закрыть\"),\n\t\tSubmitText: Ptr(\"Отправить заявку\"),\n\t\tBlocks: []ViewBlockUnion{ViewBlockHeader{\n\t\t\tType: \"header\",\n\t\t\tText: \"Основная информация\",\n\t\t}},\n\t},\n}\nclient.Views.OpenView(ctx, request)",
     "imports": [
       "OpenViewRequest",
       "OpenViewRequestView",

--- a/sdk/kotlin/generated/src/main/kotlin/com/pachca/examples.json
+++ b/sdk/kotlin/generated/src/main/kotlin/com/pachca/examples.json
@@ -3,18 +3,18 @@
     "usage": "import com.pachca.PachcaClient\n\nval client = PachcaClient(\"YOUR_TOKEN\")"
   },
   "SecurityOperations_getAuditEvents": {
-    "usage": "val response = client.security.getAuditEvents(startTime = \"2024-01-01T00:00:00Z\", endTime = \"2024-01-01T00:00:00Z\", eventKey = AuditEventKey.USER_LOGIN, actorId = \"example\", actorType = \"example\", entityId = \"example\", entityType = \"example\", limit = 123, cursor = \"example\")",
+    "usage": "val response = client.security.getAuditEvents(startTime = \"2025-05-01T09:11:00Z\", endTime = \"2025-05-02T09:11:00Z\", eventKey = AuditEventKey.USER_LOGIN, actorId = \"98765\", actorType = \"User\", entityId = \"98765\", entityType = \"User\", limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "GetAuditEventsResponse(data: List<AuditEvent>, meta: PaginationMeta?)",
     "imports": [
       "AuditEventKey"
     ]
   },
   "BotOperations_getWebhookEvents": {
-    "usage": "val response = client.bots.getWebhookEvents(limit = 123, cursor = \"example\")",
+    "usage": "val response = client.bots.getWebhookEvents(limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "GetWebhookEventsResponse(data: List<WebhookEvent>, meta: PaginationMeta?)"
   },
   "BotOperations_updateBot": {
-    "usage": "val request = BotUpdateRequest(bot = BotUpdateRequestBot(webhook = BotUpdateRequestBotWebhook(outgoingUrl = \"example\")))\nval response = client.bots.updateBot(id = 123, request = request)",
+    "usage": "val request = BotUpdateRequest(bot = BotUpdateRequestBot(webhook = BotUpdateRequestBotWebhook(outgoingUrl = \"https://www.website.com/tasks/new\")))\nval response = client.bots.updateBot(id = 1738816, request = request)",
     "output": "BotResponse(id: Int, webhook: BotResponseWebhook(outgoingUrl: String))",
     "imports": [
       "BotUpdateRequest",
@@ -23,10 +23,10 @@
     ]
   },
   "BotOperations_deleteWebhookEvent": {
-    "usage": "client.bots.deleteWebhookEvent(id = \"example\")"
+    "usage": "client.bots.deleteWebhookEvent(id = \"01KAJZ2XDSS2S3DSW9EXJZ0TBV\")"
   },
   "ChatOperations_listChats": {
-    "usage": "val response = client.chats.listChats(sortId = SortOrder.ASC, availability = ChatAvailability.IS_MEMBER, lastMessageAtAfter = \"2024-01-01T00:00:00Z\", lastMessageAtBefore = \"2024-01-01T00:00:00Z\", personal = true, limit = 123, cursor = \"example\")",
+    "usage": "val response = client.chats.listChats(sortId = SortOrder.DESC, availability = ChatAvailability.IS_MEMBER, lastMessageAtAfter = \"2025-01-01T00:00:00.000Z\", lastMessageAtBefore = \"2025-02-01T00:00:00.000Z\", personal = false, limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListChatsResponse(data: List<Chat>, meta: PaginationMeta?)",
     "imports": [
       "ChatAvailability",
@@ -34,11 +34,11 @@
     ]
   },
   "ChatOperations_getChat": {
-    "usage": "val response = client.chats.getChat(id = 123)",
+    "usage": "val response = client.chats.getChat(id = 334)",
     "output": "Chat(id: Int, name: String, createdAt: String, ownerId: Int, memberIds: List<Int>, groupTagIds: List<Int>, channel: Boolean, personal: Boolean, public: Boolean, lastMessageAt: String, meetRoomUrl: String)"
   },
   "ChatOperations_createChat": {
-    "usage": "val request = ChatCreateRequest(\n    chat = ChatCreateRequestChat(\n        name = \"example\",\n        memberIds = listOf(123),\n        groupTagIds = listOf(123),\n        channel = true,\n        public = true\n    )\n)\nval response = client.chats.createChat(request = request)",
+    "usage": "val request = ChatCreateRequest(\n    chat = ChatCreateRequestChat(\n        name = \"🤿 aqua\",\n        memberIds = listOf(123),\n        groupTagIds = listOf(123),\n        channel = true,\n        public = false\n    )\n)\nval response = client.chats.createChat(request = request)",
     "output": "Chat(id: Int, name: String, createdAt: String, ownerId: Int, memberIds: List<Int>, groupTagIds: List<Int>, channel: Boolean, personal: Boolean, public: Boolean, lastMessageAt: String, meetRoomUrl: String)",
     "imports": [
       "ChatCreateRequest",
@@ -46,7 +46,7 @@
     ]
   },
   "ChatOperations_updateChat": {
-    "usage": "val request = ChatUpdateRequest(chat = ChatUpdateRequestChat(name = \"example\", public = true))\nval response = client.chats.updateChat(id = 123, request = request)",
+    "usage": "val request = ChatUpdateRequest(chat = ChatUpdateRequestChat(name = \"Бассейн\", public = true))\nval response = client.chats.updateChat(id = 334, request = request)",
     "output": "Chat(id: Int, name: String, createdAt: String, ownerId: Int, memberIds: List<Int>, groupTagIds: List<Int>, channel: Boolean, personal: Boolean, public: Boolean, lastMessageAt: String, meetRoomUrl: String)",
     "imports": [
       "ChatUpdateRequest",
@@ -54,13 +54,13 @@
     ]
   },
   "ChatOperations_archiveChat": {
-    "usage": "client.chats.archiveChat(id = 123)"
+    "usage": "client.chats.archiveChat(id = 334)"
   },
   "ChatOperations_unarchiveChat": {
-    "usage": "client.chats.unarchiveChat(id = 123)"
+    "usage": "client.chats.unarchiveChat(id = 334)"
   },
   "ExportOperations_downloadExport": {
-    "usage": "val response = client.common.downloadExport(id = 123)",
+    "usage": "val response = client.common.downloadExport(id = 22322)",
     "output": "String"
   },
   "CommonOperations_listProperties": {
@@ -71,7 +71,7 @@
     ]
   },
   "ExportOperations_requestExport": {
-    "usage": "val request = ExportRequest(\n    startAt = \"2024-01-01\",\n    endAt = \"2024-01-01\",\n    webhookUrl = \"example\",\n    chatIds = listOf(123),\n    skipChatsFile = true\n)\nclient.common.requestExport(request = request)",
+    "usage": "val request = ExportRequest(\n    startAt = \"2025-03-20\",\n    endAt = \"2025-03-20\",\n    webhookUrl = \"https://webhook.site/9227d3b8-6e82-4e64-bf5d-ad972ad270f2\",\n    chatIds = listOf(123),\n    skipChatsFile = false\n)\nclient.common.requestExport(request = request)",
     "imports": [
       "ExportRequest"
     ]
@@ -87,53 +87,53 @@
     "output": "UploadParams(contentDisposition: String, acl: String, policy: String, xAmzCredential: String, xAmzAlgorithm: String, xAmzDate: String, xAmzSignature: String, key: String, directUrl: String)"
   },
   "ChatMemberOperations_listMembers": {
-    "usage": "val response = client.members.listMembers(id = 123, role = ChatMemberRoleFilter.ALL, limit = 123, cursor = \"example\")",
+    "usage": "val response = client.members.listMembers(id = 334, role = ChatMemberRoleFilter.ALL, limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListMembersResponse(data: List<User>, meta: PaginationMeta?)",
     "imports": [
       "ChatMemberRoleFilter"
     ]
   },
   "ChatMemberOperations_addTags": {
-    "usage": "val groupTagIds = listOf(123)\nclient.members.addTags(id = 123, groupTagIds = groupTagIds)"
+    "usage": "val groupTagIds = listOf(123)\nclient.members.addTags(id = 334, groupTagIds = groupTagIds)"
   },
   "ChatMemberOperations_addMembers": {
-    "usage": "val request = AddMembersRequest(memberIds = listOf(123), silent = true)\nclient.members.addMembers(id = 123, request = request)",
+    "usage": "val request = AddMembersRequest(memberIds = listOf(123), silent = true)\nclient.members.addMembers(id = 334, request = request)",
     "imports": [
       "AddMembersRequest"
     ]
   },
   "ChatMemberOperations_updateMemberRole": {
-    "usage": "client.members.updateMemberRole(id = 123, userId = 123, role = ChatMemberRole.ADMIN)",
+    "usage": "client.members.updateMemberRole(id = 334, userId = 186, role = ChatMemberRole.ADMIN)",
     "imports": [
       "ChatMemberRole"
     ]
   },
   "ChatMemberOperations_removeTag": {
-    "usage": "client.members.removeTag(id = 123, tagId = 123)"
+    "usage": "client.members.removeTag(id = 334, tagId = 86)"
   },
   "ChatMemberOperations_leaveChat": {
-    "usage": "client.members.leaveChat(id = 123)"
+    "usage": "client.members.leaveChat(id = 334)"
   },
   "ChatMemberOperations_removeMember": {
-    "usage": "client.members.removeMember(id = 123, userId = 123)"
+    "usage": "client.members.removeMember(id = 334, userId = 186)"
   },
   "GroupTagOperations_listTags": {
-    "usage": "val names = TagNamesFilter()\nval response = client.groupTags.listTags(names = names, limit = 123, cursor = \"example\")",
+    "usage": "val names = TagNamesFilter()\nval response = client.groupTags.listTags(names = names, limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListTagsResponse(data: List<GroupTag>, meta: PaginationMeta?)",
     "imports": [
       "TagNamesFilter"
     ]
   },
   "GroupTagOperations_getTag": {
-    "usage": "val response = client.groupTags.getTag(id = 123)",
+    "usage": "val response = client.groupTags.getTag(id = 9111)",
     "output": "GroupTag(id: Int, name: String, usersCount: Int)"
   },
   "GroupTagOperations_getTagUsers": {
-    "usage": "val response = client.groupTags.getTagUsers(id = 123, limit = 123, cursor = \"example\")",
+    "usage": "val response = client.groupTags.getTagUsers(id = 9111, limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "GetTagUsersResponse(data: List<User>, meta: PaginationMeta?)"
   },
   "GroupTagOperations_createTag": {
-    "usage": "val request = GroupTagRequest(groupTag = GroupTagRequestGroupTag(name = \"example\"))\nval response = client.groupTags.createTag(request = request)",
+    "usage": "val request = GroupTagRequest(groupTag = GroupTagRequestGroupTag(name = \"Новое название тега\"))\nval response = client.groupTags.createTag(request = request)",
     "output": "GroupTag(id: Int, name: String, usersCount: Int)",
     "imports": [
       "GroupTagRequest",
@@ -141,7 +141,7 @@
     ]
   },
   "GroupTagOperations_updateTag": {
-    "usage": "val request = GroupTagRequest(groupTag = GroupTagRequestGroupTag(name = \"example\"))\nval response = client.groupTags.updateTag(id = 123, request = request)",
+    "usage": "val request = GroupTagRequest(groupTag = GroupTagRequestGroupTag(name = \"Новое название тега\"))\nval response = client.groupTags.updateTag(id = 9111, request = request)",
     "output": "GroupTag(id: Int, name: String, usersCount: Int)",
     "imports": [
       "GroupTagRequest",
@@ -149,21 +149,21 @@
     ]
   },
   "GroupTagOperations_deleteTag": {
-    "usage": "client.groupTags.deleteTag(id = 123)"
+    "usage": "client.groupTags.deleteTag(id = 9111)"
   },
   "ChatMessageOperations_listChatMessages": {
-    "usage": "val response = client.messages.listChatMessages(chatId = 123, sortId = SortOrder.ASC, limit = 123, cursor = \"example\")",
+    "usage": "val response = client.messages.listChatMessages(chatId = 198, sortId = SortOrder.DESC, limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListChatMessagesResponse(data: List<Message>, meta: PaginationMeta?)",
     "imports": [
       "SortOrder"
     ]
   },
   "MessageOperations_getMessage": {
-    "usage": "val response = client.messages.getMessage(id = 123)",
+    "usage": "val response = client.messages.getMessage(id = 194275)",
     "output": "Message(id: Int, entityType: MessageEntityType, entityId: Int, chatId: Int, rootChatId: Int, content: String, userId: Int, createdAt: String, url: String, files: List<File(id: Int, key: String, name: String, fileType: FileType, url: String, width: Int?, height: Int?)>, buttons: List<List<Button(text: String, url: String?, data: String?)>>?, thread: Thread(id: Long, chatId: Long, messageId: Long, messageChatId: Long, updatedAt: String)?, forwarding: Forwarding(originalMessageId: Int, originalChatId: Int, authorId: Int, originalCreatedAt: String, originalThreadId: Int?, originalThreadMessageId: Int?, originalThreadParentChatId: Int?)?, parentMessageId: Int?, displayAvatarUrl: String?, displayName: String?, changedAt: String?, deletedAt: String?)"
   },
   "MessageOperations_createMessage": {
-    "usage": "val request = MessageCreateRequest(\n    message = MessageCreateRequestMessage(\n        entityType = MessageEntityType.DISCUSSION,\n        entityId = 123,\n        content = \"example\",\n        files = listOf(MessageCreateRequestFile(\n            key = \"example\",\n            name = \"example\",\n            fileType = FileType.FILE,\n            size = 123,\n            width = 123,\n            height = 123\n        )),\n        buttons = listOf(listOf(Button(\n            text = \"example\",\n            url = \"example\",\n            data = \"example\"\n        ))),\n        parentMessageId = 123,\n        displayAvatarUrl = \"example\",\n        displayName = \"example\",\n        skipInviteMentions = true,\n        linkPreview = true\n    )\n)\nval response = client.messages.createMessage(request = request)",
+    "usage": "val request = MessageCreateRequest(\n    message = MessageCreateRequestMessage(\n        entityType = MessageEntityType.DISCUSSION,\n        entityId = 334,\n        content = \"Вчера мы продали 756 футболок (что на 10% больше, чем в прошлое воскресенье)\",\n        files = listOf(MessageCreateRequestFile(\n            key = \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n            name = \"logo.png\",\n            fileType = FileType.IMAGE,\n            size = 12345,\n            width = 800,\n            height = 600\n        )),\n        buttons = listOf(listOf(Button(\n            text = \"Подробнее\",\n            url = \"https://example.com/details\",\n            data = \"awesome\"\n        ))),\n        parentMessageId = 194270,\n        displayAvatarUrl = \"https://example.com/avatar.png\",\n        displayName = \"Бот Поддержки\",\n        skipInviteMentions = false,\n        linkPreview = false\n    )\n)\nval response = client.messages.createMessage(request = request)",
     "output": "Message(id: Int, entityType: MessageEntityType, entityId: Int, chatId: Int, rootChatId: Int, content: String, userId: Int, createdAt: String, url: String, files: List<File(id: Int, key: String, name: String, fileType: FileType, url: String, width: Int?, height: Int?)>, buttons: List<List<Button(text: String, url: String?, data: String?)>>?, thread: Thread(id: Long, chatId: Long, messageId: Long, messageChatId: Long, updatedAt: String)?, forwarding: Forwarding(originalMessageId: Int, originalChatId: Int, authorId: Int, originalCreatedAt: String, originalThreadId: Int?, originalThreadMessageId: Int?, originalThreadParentChatId: Int?)?, parentMessageId: Int?, displayAvatarUrl: String?, displayName: String?, changedAt: String?, deletedAt: String?)",
     "imports": [
       "Button",
@@ -175,10 +175,10 @@
     ]
   },
   "MessageOperations_pinMessage": {
-    "usage": "client.messages.pinMessage(id = 123)"
+    "usage": "client.messages.pinMessage(id = 194275)"
   },
   "MessageOperations_updateMessage": {
-    "usage": "val request = MessageUpdateRequest(\n    message = MessageUpdateRequestMessage(\n        content = \"example\",\n        files = listOf(MessageUpdateRequestFile(\n            key = \"example\",\n            name = \"example\",\n            fileType = \"example\",\n            size = 123,\n            width = 123,\n            height = 123\n        )),\n        buttons = listOf(listOf(Button(\n            text = \"example\",\n            url = \"example\",\n            data = \"example\"\n        ))),\n        displayAvatarUrl = \"example\",\n        displayName = \"example\"\n    )\n)\nval response = client.messages.updateMessage(id = 123, request = request)",
+    "usage": "val request = MessageUpdateRequest(\n    message = MessageUpdateRequestMessage(\n        content = \"Вот попробуйте написать правильно это с первого раза: Будущий, Полощи, Прийти, Грейпфрут, Мозаика, Бюллетень, Дуршлаг, Винегрет.\",\n        files = listOf(MessageUpdateRequestFile(\n            key = \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n            name = \"logo.png\",\n            fileType = \"image\",\n            size = 12345,\n            width = 800,\n            height = 600\n        )),\n        buttons = listOf(listOf(Button(\n            text = \"Подробнее\",\n            url = \"https://example.com/details\",\n            data = \"awesome\"\n        ))),\n        displayAvatarUrl = \"https://example.com/avatar.png\",\n        displayName = \"Бот Поддержки\"\n    )\n)\nval response = client.messages.updateMessage(id = 194275, request = request)",
     "output": "Message(id: Int, entityType: MessageEntityType, entityId: Int, chatId: Int, rootChatId: Int, content: String, userId: Int, createdAt: String, url: String, files: List<File(id: Int, key: String, name: String, fileType: FileType, url: String, width: Int?, height: Int?)>, buttons: List<List<Button(text: String, url: String?, data: String?)>>?, thread: Thread(id: Long, chatId: Long, messageId: Long, messageChatId: Long, updatedAt: String)?, forwarding: Forwarding(originalMessageId: Int, originalChatId: Int, authorId: Int, originalCreatedAt: String, originalThreadId: Int?, originalThreadMessageId: Int?, originalThreadParentChatId: Int?)?, parentMessageId: Int?, displayAvatarUrl: String?, displayName: String?, changedAt: String?, deletedAt: String?)",
     "imports": [
       "Button",
@@ -188,13 +188,13 @@
     ]
   },
   "MessageOperations_deleteMessage": {
-    "usage": "client.messages.deleteMessage(id = 123)"
+    "usage": "client.messages.deleteMessage(id = 194275)"
   },
   "MessageOperations_unpinMessage": {
-    "usage": "client.messages.unpinMessage(id = 123)"
+    "usage": "client.messages.unpinMessage(id = 194275)"
   },
   "LinkPreviewOperations_createLinkPreviews": {
-    "usage": "val request = LinkPreviewsRequest(\n    linkPreviews = mapOf(\"key\" to LinkPreview(\n        title = \"example\",\n        description = \"example\",\n        imageUrl = \"example\",\n        image = LinkPreviewImage(\n            key = \"example\",\n            name = \"example\",\n            size = 123\n        )\n    ))\n)\nclient.linkPreviews.createLinkPreviews(id = 123, request = request)",
+    "usage": "val request = LinkPreviewsRequest(\n    linkPreviews = mapOf(\"key\" to LinkPreview(\n        title = \"Статья: Отправка файлов\",\n        description = \"Пример отправки файлов на удаленный сервер\",\n        imageUrl = \"https://website.com/img/landing.png\",\n        image = LinkPreviewImage(\n            key = \"attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/${filename}\",\n            name = \"files-to-server.jpg\",\n            size = 695604\n        )\n    ))\n)\nclient.linkPreviews.createLinkPreviews(id = 194275, request = request)",
     "imports": [
       "LinkPreview",
       "LinkPreviewImage",
@@ -202,29 +202,29 @@
     ]
   },
   "ReactionOperations_listReactions": {
-    "usage": "val response = client.reactions.listReactions(id = 123, limit = 123, cursor = \"example\")",
+    "usage": "val response = client.reactions.listReactions(id = 194275, limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListReactionsResponse(data: List<Reaction>, meta: PaginationMeta?)"
   },
   "ReactionOperations_addReaction": {
-    "usage": "val request = ReactionRequest(code = \"example\", name = \"example\")\nval response = client.reactions.addReaction(id = 123, request = request)",
+    "usage": "val request = ReactionRequest(code = \"👍\", name = \":+1:\")\nval response = client.reactions.addReaction(id = 7231942, request = request)",
     "output": "Reaction(userId: Int, createdAt: String, code: String, name: String?)",
     "imports": [
       "ReactionRequest"
     ]
   },
   "ReactionOperations_removeReaction": {
-    "usage": "client.reactions.removeReaction(id = 123, code = \"example\", name = \"example\")"
+    "usage": "client.reactions.removeReaction(id = 7231942, code = \"👍\", name = \":+1:\")"
   },
   "ReadMemberOperations_listReadMembers": {
-    "usage": "val response = client.readMembers.listReadMembers(id = 123, limit = 123, cursor = \"example\")",
+    "usage": "val response = client.readMembers.listReadMembers(id = 194275, limit = 300, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "Any"
   },
   "ThreadOperations_getThread": {
-    "usage": "val response = client.threads.getThread(id = 123)",
+    "usage": "val response = client.threads.getThread(id = 265142)",
     "output": "Thread(id: Long, chatId: Long, messageId: Long, messageChatId: Long, updatedAt: String)"
   },
   "ThreadOperations_createThread": {
-    "usage": "val response = client.threads.createThread(id = 123)",
+    "usage": "val response = client.threads.createThread(id = 154332686)",
     "output": "Thread(id: Long, chatId: Long, messageId: Long, messageChatId: Long, updatedAt: String)"
   },
   "OAuthOperations_getTokenInfo": {
@@ -240,7 +240,7 @@
     "output": "Any"
   },
   "ProfileOperations_updateStatus": {
-    "usage": "val request = StatusUpdateRequest(\n    status = StatusUpdateRequestStatus(\n        emoji = \"example\",\n        title = \"example\",\n        expiresAt = \"2024-01-01T00:00:00Z\",\n        isAway = true,\n        awayMessage = \"example\"\n    )\n)\nval response = client.profile.updateStatus(request = request)",
+    "usage": "val request = StatusUpdateRequest(\n    status = StatusUpdateRequestStatus(\n        emoji = \"🎮\",\n        title = \"Очень занят\",\n        expiresAt = \"2024-04-08T10:00:00.000Z\",\n        isAway = true,\n        awayMessage = \"Вернусь после 15:00\"\n    )\n)\nval response = client.profile.updateStatus(request = request)",
     "output": "UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Boolean, awayMessage: UserStatusAwayMessage(text: String)?)",
     "imports": [
       "StatusUpdateRequest",
@@ -251,7 +251,7 @@
     "usage": "client.profile.deleteStatus()"
   },
   "SearchOperations_searchChats": {
-    "usage": "val response = client.search.searchChats(query = \"example\", limit = 123, cursor = \"example\", order = SortOrder.ASC, createdFrom = \"2024-01-01T00:00:00Z\", createdTo = \"2024-01-01T00:00:00Z\", active = true, chatSubtype = ChatSubtype.DISCUSSION, personal = true)",
+    "usage": "val response = client.search.searchChats(query = \"Разработка\", limit = 10, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\", order = SortOrder.DESC, createdFrom = \"2025-01-01T00:00:00.000Z\", createdTo = \"2025-02-01T00:00:00.000Z\", active = true, chatSubtype = ChatSubtype.DISCUSSION, personal = false)",
     "output": "SearchChatsResponse(data: List<Chat>, meta: SearchPaginationMeta)",
     "imports": [
       "ChatSubtype",
@@ -259,14 +259,14 @@
     ]
   },
   "SearchOperations_searchMessages": {
-    "usage": "val chatIds = listOf(123)\nval userIds = listOf(123)\nval response = client.search.searchMessages(query = \"example\", limit = 123, cursor = \"example\", order = SortOrder.ASC, createdFrom = \"2024-01-01T00:00:00Z\", createdTo = \"2024-01-01T00:00:00Z\", chatIds = chatIds, userIds = userIds, active = true)",
+    "usage": "val chatIds = listOf(123)\nval userIds = listOf(123)\nval response = client.search.searchMessages(query = \"футболки\", limit = 10, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\", order = SortOrder.DESC, createdFrom = \"2025-01-01T00:00:00.000Z\", createdTo = \"2025-02-01T00:00:00.000Z\", chatIds = chatIds, userIds = userIds, active = true)",
     "output": "SearchMessagesResponse(data: List<Message>, meta: SearchPaginationMeta)",
     "imports": [
       "SortOrder"
     ]
   },
   "SearchOperations_searchUsers": {
-    "usage": "val companyRoles = listOf(UserRole.ADMIN)\nval response = client.search.searchUsers(query = \"example\", limit = 123, cursor = \"example\", sort = SearchSortOrder.BY_SCORE, order = SortOrder.ASC, createdFrom = \"2024-01-01T00:00:00Z\", createdTo = \"2024-01-01T00:00:00Z\", companyRoles = companyRoles)",
+    "usage": "val companyRoles = listOf(UserRole.ADMIN)\nval response = client.search.searchUsers(query = \"Олег\", limit = 10, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\", sort = SearchSortOrder.BY_SCORE, order = SortOrder.DESC, createdFrom = \"2025-01-01T00:00:00.000Z\", createdTo = \"2025-02-01T00:00:00.000Z\", companyRoles = companyRoles)",
     "output": "SearchUsersResponse(data: List<User>, meta: SearchPaginationMeta)",
     "imports": [
       "SearchSortOrder",
@@ -275,15 +275,15 @@
     ]
   },
   "TaskOperations_listTasks": {
-    "usage": "val response = client.tasks.listTasks(limit = 123, cursor = \"example\")",
+    "usage": "val response = client.tasks.listTasks(limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListTasksResponse(data: List<Task>, meta: PaginationMeta?)"
   },
   "TaskOperations_getTask": {
-    "usage": "val response = client.tasks.getTask(id = 123)",
+    "usage": "val response = client.tasks.getTask(id = 22283)",
     "output": "Task(id: Int, kind: TaskKind, content: String, dueAt: String?, priority: Int, userId: Int, chatId: Int?, status: TaskStatus, createdAt: String, performerIds: List<Int>, allDay: Boolean, customProperties: List<CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)>)"
   },
   "TaskOperations_createTask": {
-    "usage": "val request = TaskCreateRequest(\n    task = TaskCreateRequestTask(\n        kind = TaskKind.CALL,\n        content = \"example\",\n        dueAt = \"2024-01-01T00:00:00Z\",\n        priority = 123,\n        performerIds = listOf(123),\n        chatId = 123,\n        allDay = true,\n        customProperties = listOf(TaskCreateRequestCustomProperty(id = 123, value = \"example\"))\n    )\n)\nval response = client.tasks.createTask(request = request)",
+    "usage": "val request = TaskCreateRequest(\n    task = TaskCreateRequestTask(\n        kind = TaskKind.REMINDER,\n        content = \"Забрать со склада 21 заказ\",\n        dueAt = \"2020-06-05T12:00:00.000+03:00\",\n        priority = 2,\n        performerIds = listOf(123),\n        chatId = 456,\n        allDay = false,\n        customProperties = listOf(TaskCreateRequestCustomProperty(id = 78, value = \"Синий склад\"))\n    )\n)\nval response = client.tasks.createTask(request = request)",
     "output": "Task(id: Int, kind: TaskKind, content: String, dueAt: String?, priority: Int, userId: Int, chatId: Int?, status: TaskStatus, createdAt: String, performerIds: List<Int>, allDay: Boolean, customProperties: List<CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)>)",
     "imports": [
       "TaskCreateRequest",
@@ -293,7 +293,7 @@
     ]
   },
   "TaskOperations_updateTask": {
-    "usage": "val request = TaskUpdateRequest(\n    task = TaskUpdateRequestTask(\n        kind = TaskKind.CALL,\n        content = \"example\",\n        dueAt = \"2024-01-01T00:00:00Z\",\n        priority = 123,\n        performerIds = listOf(123),\n        status = TaskStatus.DONE,\n        allDay = true,\n        doneAt = \"2024-01-01T00:00:00Z\",\n        customProperties = listOf(TaskUpdateRequestCustomProperty(id = 123, value = \"example\"))\n    )\n)\nval response = client.tasks.updateTask(id = 123, request = request)",
+    "usage": "val request = TaskUpdateRequest(\n    task = TaskUpdateRequestTask(\n        kind = TaskKind.REMINDER,\n        content = \"Забрать со склада 21 заказ\",\n        dueAt = \"2020-06-05T12:00:00.000+03:00\",\n        priority = 2,\n        performerIds = listOf(123),\n        status = TaskStatus.DONE,\n        allDay = false,\n        doneAt = \"2020-06-05T12:00:00.000Z\",\n        customProperties = listOf(TaskUpdateRequestCustomProperty(id = 78, value = \"Синий склад\"))\n    )\n)\nval response = client.tasks.updateTask(id = 22283, request = request)",
     "output": "Task(id: Int, kind: TaskKind, content: String, dueAt: String?, priority: Int, userId: Int, chatId: Int?, status: TaskStatus, createdAt: String, performerIds: List<Int>, allDay: Boolean, customProperties: List<CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)>)",
     "imports": [
       "TaskKind",
@@ -304,22 +304,22 @@
     ]
   },
   "TaskOperations_deleteTask": {
-    "usage": "client.tasks.deleteTask(id = 123)"
+    "usage": "client.tasks.deleteTask(id = 22283)"
   },
   "UserOperations_listUsers": {
-    "usage": "val response = client.users.listUsers(query = \"example\", limit = 123, cursor = \"example\")",
+    "usage": "val response = client.users.listUsers(query = \"Олег\", limit = 1, cursor = \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListUsersResponse(data: List<User>, meta: PaginationMeta?)"
   },
   "UserOperations_getUser": {
-    "usage": "val response = client.users.getUser(id = 123)",
+    "usage": "val response = client.users.getUser(id = 12)",
     "output": "User(id: Int, firstName: String, lastName: String, nickname: String, email: String, phoneNumber: String, department: String, title: String, role: UserRole, suspended: Boolean, inviteStatus: InviteStatus, listTags: List<String>, customProperties: List<CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)>, userStatus: UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Boolean, awayMessage: UserStatusAwayMessage(text: String)?)?, bot: Boolean, sso: Boolean, createdAt: String, lastActivityAt: String, timeZone: String, imageUrl: String?)"
   },
   "UserStatusOperations_getUserStatus": {
-    "usage": "val response = client.users.getUserStatus(userId = 123)",
+    "usage": "val response = client.users.getUserStatus(userId = 12)",
     "output": "Any"
   },
   "UserOperations_createUser": {
-    "usage": "val request = UserCreateRequest(\n    user = UserCreateRequestUser(\n        firstName = \"example\",\n        lastName = \"example\",\n        email = \"example\",\n        phoneNumber = \"example\",\n        nickname = \"example\",\n        department = \"example\",\n        title = \"example\",\n        role = UserRole.ADMIN,\n        suspended = true,\n        listTags = listOf(\"example\"),\n        customProperties = listOf(UserCreateRequestCustomProperty(id = 123, value = \"example\"))\n    ),\n    skipEmailNotify = true\n)\nval response = client.users.createUser(request = request)",
+    "usage": "val request = UserCreateRequest(\n    user = UserCreateRequestUser(\n        firstName = \"Олег\",\n        lastName = \"Петров\",\n        email = \"olegp@example.com\",\n        phoneNumber = \"+79001234567\",\n        nickname = \"olegpetrov\",\n        department = \"Продукт\",\n        title = \"CIO\",\n        role = UserRole.USER,\n        suspended = false,\n        listTags = listOf(\"example\"),\n        customProperties = listOf(UserCreateRequestCustomProperty(id = 1678, value = \"Санкт-Петербург\"))\n    ),\n    skipEmailNotify = true\n)\nval response = client.users.createUser(request = request)",
     "output": "User(id: Int, firstName: String, lastName: String, nickname: String, email: String, phoneNumber: String, department: String, title: String, role: UserRole, suspended: Boolean, inviteStatus: InviteStatus, listTags: List<String>, customProperties: List<CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)>, userStatus: UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Boolean, awayMessage: UserStatusAwayMessage(text: String)?)?, bot: Boolean, sso: Boolean, createdAt: String, lastActivityAt: String, timeZone: String, imageUrl: String?)",
     "imports": [
       "UserCreateRequest",
@@ -329,7 +329,7 @@
     ]
   },
   "UserOperations_updateUser": {
-    "usage": "val request = UserUpdateRequest(\n    user = UserUpdateRequestUser(\n        firstName = \"example\",\n        lastName = \"example\",\n        email = \"example\",\n        phoneNumber = \"example\",\n        nickname = \"example\",\n        department = \"example\",\n        title = \"example\",\n        role = UserRole.ADMIN,\n        suspended = true,\n        listTags = listOf(\"example\"),\n        customProperties = listOf(UserUpdateRequestCustomProperty(id = 123, value = \"example\"))\n    )\n)\nval response = client.users.updateUser(id = 123, request = request)",
+    "usage": "val request = UserUpdateRequest(\n    user = UserUpdateRequestUser(\n        firstName = \"Олег\",\n        lastName = \"Петров\",\n        email = \"olegpetrov@example.com\",\n        phoneNumber = \"+79001234567\",\n        nickname = \"olegpetrov\",\n        department = \"Отдел разработки\",\n        title = \"Старший разработчик\",\n        role = UserRole.USER,\n        suspended = false,\n        listTags = listOf(\"example\"),\n        customProperties = listOf(UserUpdateRequestCustomProperty(id = 1678, value = \"Санкт-Петербург\"))\n    )\n)\nval response = client.users.updateUser(id = 12, request = request)",
     "output": "User(id: Int, firstName: String, lastName: String, nickname: String, email: String, phoneNumber: String, department: String, title: String, role: UserRole, suspended: Boolean, inviteStatus: InviteStatus, listTags: List<String>, customProperties: List<CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)>, userStatus: UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Boolean, awayMessage: UserStatusAwayMessage(text: String)?)?, bot: Boolean, sso: Boolean, createdAt: String, lastActivityAt: String, timeZone: String, imageUrl: String?)",
     "imports": [
       "UserRole",
@@ -339,7 +339,7 @@
     ]
   },
   "UserStatusOperations_updateUserStatus": {
-    "usage": "val request = StatusUpdateRequest(\n    status = StatusUpdateRequestStatus(\n        emoji = \"example\",\n        title = \"example\",\n        expiresAt = \"2024-01-01T00:00:00Z\",\n        isAway = true,\n        awayMessage = \"example\"\n    )\n)\nval response = client.users.updateUserStatus(userId = 123, request = request)",
+    "usage": "val request = StatusUpdateRequest(\n    status = StatusUpdateRequestStatus(\n        emoji = \"🎮\",\n        title = \"Очень занят\",\n        expiresAt = \"2024-04-08T10:00:00.000Z\",\n        isAway = true,\n        awayMessage = \"Вернусь после 15:00\"\n    )\n)\nval response = client.users.updateUserStatus(userId = 12, request = request)",
     "output": "UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Boolean, awayMessage: UserStatusAwayMessage(text: String)?)",
     "imports": [
       "StatusUpdateRequest",
@@ -347,13 +347,13 @@
     ]
   },
   "UserOperations_deleteUser": {
-    "usage": "client.users.deleteUser(id = 123)"
+    "usage": "client.users.deleteUser(id = 12)"
   },
   "UserStatusOperations_deleteUserStatus": {
-    "usage": "client.users.deleteUserStatus(userId = 123)"
+    "usage": "client.users.deleteUserStatus(userId = 12)"
   },
   "FormOperations_openView": {
-    "usage": "val request = OpenViewRequest(\n    type = \"modal\",\n    triggerId = \"example\",\n    privateMetadata = \"example\",\n    callbackId = \"example\",\n    view = OpenViewRequestView(\n        title = \"example\",\n        closeText = \"example\",\n        submitText = \"example\",\n        blocks = listOf(ViewBlockHeader(type = \"header\", text = \"example\"))\n    )\n)\nclient.views.openView(request = request)",
+    "usage": "val request = OpenViewRequest(\n    type = \"modal\",\n    triggerId = \"791a056b-006c-49dd-834b-c633fde52fe8\",\n    privateMetadata = \"{\\\"timeoff_id\\\":4378}\",\n    callbackId = \"timeoff_reguest_form\",\n    view = OpenViewRequestView(\n        title = \"Уведомление об отпуске\",\n        closeText = \"Закрыть\",\n        submitText = \"Отправить заявку\",\n        blocks = listOf(ViewBlockHeader(type = \"header\", text = \"Основная информация\"))\n    )\n)\nclient.views.openView(request = request)",
     "imports": [
       "OpenViewRequest",
       "OpenViewRequestView",

--- a/sdk/python/generated/pachca/examples.json
+++ b/sdk/python/generated/pachca/examples.json
@@ -3,7 +3,7 @@
     "usage": "from pachca import PachcaClient\n\nclient = PachcaClient(\"YOUR_TOKEN\")"
   },
   "SecurityOperations_getAuditEvents": {
-    "usage": "params = GetAuditEventsParams(\n    start_time=\"2024-01-01T00:00:00Z\",\n    end_time=\"2024-01-01T00:00:00Z\",\n    event_key=AuditEventKey.USER_LOGIN,\n    actor_id=\"example\",\n    actor_type=\"example\",\n    entity_id=\"example\",\n    entity_type=\"example\",\n    limit=123,\n    cursor=\"example\"\n)\nresponse = await client.security.get_audit_events(params=params)",
+    "usage": "params = GetAuditEventsParams(\n    start_time=\"2025-05-01T09:11:00Z\",\n    end_time=\"2025-05-02T09:11:00Z\",\n    event_key=AuditEventKey.USER_LOGIN,\n    actor_id=\"98765\",\n    actor_type=\"User\",\n    entity_id=\"98765\",\n    entity_type=\"User\",\n    limit=1,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n)\nresponse = await client.security.get_audit_events(params=params)",
     "output": "GetAuditEventsResponse(data: list[AuditEvent], meta: PaginationMeta | None)",
     "imports": [
       "AuditEventKey",
@@ -11,14 +11,14 @@
     ]
   },
   "BotOperations_getWebhookEvents": {
-    "usage": "params = GetWebhookEventsParams(limit=123, cursor=\"example\")\nresponse = await client.bots.get_webhook_events(params=params)",
+    "usage": "params = GetWebhookEventsParams(limit=1, cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")\nresponse = await client.bots.get_webhook_events(params=params)",
     "output": "GetWebhookEventsResponse(data: list[WebhookEvent], meta: PaginationMeta | None)",
     "imports": [
       "GetWebhookEventsParams"
     ]
   },
   "BotOperations_updateBot": {
-    "usage": "request = BotUpdateRequest(bot=BotUpdateRequestBot(webhook=BotUpdateRequestBotWebhook(outgoing_url=\"example\")))\nresponse = await client.bots.update_bot(id=123, request=request)",
+    "usage": "request = BotUpdateRequest(bot=BotUpdateRequestBot(webhook=BotUpdateRequestBotWebhook(outgoing_url=\"https://www.website.com/tasks/new\")))\nresponse = await client.bots.update_bot(id=1738816, request=request)",
     "output": "BotResponse(id: int, webhook: BotResponseWebhook(outgoing_url: str))",
     "imports": [
       "BotUpdateRequest",
@@ -27,10 +27,10 @@
     ]
   },
   "BotOperations_deleteWebhookEvent": {
-    "usage": "await client.bots.delete_webhook_event(id=\"example\")"
+    "usage": "await client.bots.delete_webhook_event(id=\"01KAJZ2XDSS2S3DSW9EXJZ0TBV\")"
   },
   "ChatOperations_listChats": {
-    "usage": "params = ListChatsParams(\n    sort_id=SortOrder.ASC,\n    availability=ChatAvailability.IS_MEMBER,\n    last_message_at_after=\"2024-01-01T00:00:00Z\",\n    last_message_at_before=\"2024-01-01T00:00:00Z\",\n    personal=True,\n    limit=123,\n    cursor=\"example\"\n)\nresponse = await client.chats.list_chats(params=params)",
+    "usage": "params = ListChatsParams(\n    sort_id=SortOrder.DESC,\n    availability=ChatAvailability.IS_MEMBER,\n    last_message_at_after=\"2025-01-01T00:00:00.000Z\",\n    last_message_at_before=\"2025-02-01T00:00:00.000Z\",\n    personal=False,\n    limit=1,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n)\nresponse = await client.chats.list_chats(params=params)",
     "output": "ListChatsResponse(data: list[Chat], meta: PaginationMeta | None)",
     "imports": [
       "ChatAvailability",
@@ -39,11 +39,11 @@
     ]
   },
   "ChatOperations_getChat": {
-    "usage": "response = await client.chats.get_chat(id=123)",
+    "usage": "response = await client.chats.get_chat(id=334)",
     "output": "Chat(id: int, name: str, created_at: str, owner_id: int, member_ids: list[int], group_tag_ids: list[int], channel: bool, personal: bool, public: bool, last_message_at: str, meet_room_url: str)"
   },
   "ChatOperations_createChat": {
-    "usage": "request = ChatCreateRequest(\n    chat=ChatCreateRequestChat(\n        name=\"example\",\n        member_ids=[123],\n        group_tag_ids=[123],\n        channel=True,\n        public=True\n    )\n)\nresponse = await client.chats.create_chat(request=request)",
+    "usage": "request = ChatCreateRequest(\n    chat=ChatCreateRequestChat(\n        name=\"🤿 aqua\",\n        member_ids=[123],\n        group_tag_ids=[123],\n        channel=True,\n        public=False\n    )\n)\nresponse = await client.chats.create_chat(request=request)",
     "output": "Chat(id: int, name: str, created_at: str, owner_id: int, member_ids: list[int], group_tag_ids: list[int], channel: bool, personal: bool, public: bool, last_message_at: str, meet_room_url: str)",
     "imports": [
       "ChatCreateRequest",
@@ -51,7 +51,7 @@
     ]
   },
   "ChatOperations_updateChat": {
-    "usage": "request = ChatUpdateRequest(chat=ChatUpdateRequestChat(name=\"example\", public=True))\nresponse = await client.chats.update_chat(id=123, request=request)",
+    "usage": "request = ChatUpdateRequest(chat=ChatUpdateRequestChat(name=\"Бассейн\", public=True))\nresponse = await client.chats.update_chat(id=334, request=request)",
     "output": "Chat(id: int, name: str, created_at: str, owner_id: int, member_ids: list[int], group_tag_ids: list[int], channel: bool, personal: bool, public: bool, last_message_at: str, meet_room_url: str)",
     "imports": [
       "ChatUpdateRequest",
@@ -59,13 +59,13 @@
     ]
   },
   "ChatOperations_archiveChat": {
-    "usage": "await client.chats.archive_chat(id=123)"
+    "usage": "await client.chats.archive_chat(id=334)"
   },
   "ChatOperations_unarchiveChat": {
-    "usage": "await client.chats.unarchive_chat(id=123)"
+    "usage": "await client.chats.unarchive_chat(id=334)"
   },
   "ExportOperations_downloadExport": {
-    "usage": "response = await client.common.download_export(id=123)",
+    "usage": "response = await client.common.download_export(id=22322)",
     "output": "str"
   },
   "CommonOperations_listProperties": {
@@ -77,7 +77,7 @@
     ]
   },
   "ExportOperations_requestExport": {
-    "usage": "request = ExportRequest(\n    start_at=\"2024-01-01\",\n    end_at=\"2024-01-01\",\n    webhook_url=\"example\",\n    chat_ids=[123],\n    skip_chats_file=True\n)\nawait client.common.request_export(request=request)",
+    "usage": "request = ExportRequest(\n    start_at=\"2025-03-20\",\n    end_at=\"2025-03-20\",\n    webhook_url=\"https://webhook.site/9227d3b8-6e82-4e64-bf5d-ad972ad270f2\",\n    chat_ids=[123],\n    skip_chats_file=False\n)\nawait client.common.request_export(request=request)",
     "imports": [
       "ExportRequest"
     ]
@@ -93,7 +93,7 @@
     "output": "UploadParams(content_disposition: str, acl: str, policy: str, x_amz_credential: str, x_amz_algorithm: str, x_amz_date: str, x_amz_signature: str, key: str, direct_url: str)"
   },
   "ChatMemberOperations_listMembers": {
-    "usage": "params = ListMembersParams(\n    role=ChatMemberRoleFilter.ALL,\n    limit=123,\n    cursor=\"example\"\n)\nresponse = await client.members.list_members(id=123, params=params)",
+    "usage": "params = ListMembersParams(\n    role=ChatMemberRoleFilter.ALL,\n    limit=1,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n)\nresponse = await client.members.list_members(id=334, params=params)",
     "output": "ListMembersResponse(data: list[User], meta: PaginationMeta | None)",
     "imports": [
       "ChatMemberRoleFilter",
@@ -101,31 +101,31 @@
     ]
   },
   "ChatMemberOperations_addTags": {
-    "usage": "group_tag_ids = [123]\nawait client.members.add_tags(id=123, group_tag_ids=group_tag_ids)"
+    "usage": "group_tag_ids = [123]\nawait client.members.add_tags(id=334, group_tag_ids=group_tag_ids)"
   },
   "ChatMemberOperations_addMembers": {
-    "usage": "request = AddMembersRequest(member_ids=[123], silent=True)\nawait client.members.add_members(id=123, request=request)",
+    "usage": "request = AddMembersRequest(member_ids=[123], silent=True)\nawait client.members.add_members(id=334, request=request)",
     "imports": [
       "AddMembersRequest"
     ]
   },
   "ChatMemberOperations_updateMemberRole": {
-    "usage": "await client.members.update_member_role(id=123, user_id=123, role=ChatMemberRole.ADMIN)",
+    "usage": "await client.members.update_member_role(id=334, user_id=186, role=ChatMemberRole.ADMIN)",
     "imports": [
       "ChatMemberRole"
     ]
   },
   "ChatMemberOperations_removeTag": {
-    "usage": "await client.members.remove_tag(id=123, tag_id=123)"
+    "usage": "await client.members.remove_tag(id=334, tag_id=86)"
   },
   "ChatMemberOperations_leaveChat": {
-    "usage": "await client.members.leave_chat(id=123)"
+    "usage": "await client.members.leave_chat(id=334)"
   },
   "ChatMemberOperations_removeMember": {
-    "usage": "await client.members.remove_member(id=123, user_id=123)"
+    "usage": "await client.members.remove_member(id=334, user_id=186)"
   },
   "GroupTagOperations_listTags": {
-    "usage": "params = ListTagsParams(\n    names=TagNamesFilter(),\n    limit=123,\n    cursor=\"example\"\n)\nresponse = await client.group_tags.list_tags(params=params)",
+    "usage": "params = ListTagsParams(\n    names=TagNamesFilter(),\n    limit=1,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n)\nresponse = await client.group_tags.list_tags(params=params)",
     "output": "ListTagsResponse(data: list[GroupTag], meta: PaginationMeta | None)",
     "imports": [
       "ListTagsParams",
@@ -133,18 +133,18 @@
     ]
   },
   "GroupTagOperations_getTag": {
-    "usage": "response = await client.group_tags.get_tag(id=123)",
+    "usage": "response = await client.group_tags.get_tag(id=9111)",
     "output": "GroupTag(id: int, name: str, users_count: int)"
   },
   "GroupTagOperations_getTagUsers": {
-    "usage": "params = GetTagUsersParams(limit=123, cursor=\"example\")\nresponse = await client.group_tags.get_tag_users(id=123, params=params)",
+    "usage": "params = GetTagUsersParams(limit=1, cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")\nresponse = await client.group_tags.get_tag_users(id=9111, params=params)",
     "output": "GetTagUsersResponse(data: list[User], meta: PaginationMeta | None)",
     "imports": [
       "GetTagUsersParams"
     ]
   },
   "GroupTagOperations_createTag": {
-    "usage": "request = GroupTagRequest(group_tag=GroupTagRequestGroupTag(name=\"example\"))\nresponse = await client.group_tags.create_tag(request=request)",
+    "usage": "request = GroupTagRequest(group_tag=GroupTagRequestGroupTag(name=\"Новое название тега\"))\nresponse = await client.group_tags.create_tag(request=request)",
     "output": "GroupTag(id: int, name: str, users_count: int)",
     "imports": [
       "GroupTagRequest",
@@ -152,7 +152,7 @@
     ]
   },
   "GroupTagOperations_updateTag": {
-    "usage": "request = GroupTagRequest(group_tag=GroupTagRequestGroupTag(name=\"example\"))\nresponse = await client.group_tags.update_tag(id=123, request=request)",
+    "usage": "request = GroupTagRequest(group_tag=GroupTagRequestGroupTag(name=\"Новое название тега\"))\nresponse = await client.group_tags.update_tag(id=9111, request=request)",
     "output": "GroupTag(id: int, name: str, users_count: int)",
     "imports": [
       "GroupTagRequest",
@@ -160,10 +160,10 @@
     ]
   },
   "GroupTagOperations_deleteTag": {
-    "usage": "await client.group_tags.delete_tag(id=123)"
+    "usage": "await client.group_tags.delete_tag(id=9111)"
   },
   "ChatMessageOperations_listChatMessages": {
-    "usage": "params = ListChatMessagesParams(\n    chat_id=123,\n    sort_id=SortOrder.ASC,\n    limit=123,\n    cursor=\"example\"\n)\nresponse = await client.messages.list_chat_messages(params=params)",
+    "usage": "params = ListChatMessagesParams(\n    chat_id=198,\n    sort_id=SortOrder.DESC,\n    limit=1,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n)\nresponse = await client.messages.list_chat_messages(params=params)",
     "output": "ListChatMessagesResponse(data: list[Message], meta: PaginationMeta | None)",
     "imports": [
       "ListChatMessagesParams",
@@ -171,11 +171,11 @@
     ]
   },
   "MessageOperations_getMessage": {
-    "usage": "response = await client.messages.get_message(id=123)",
+    "usage": "response = await client.messages.get_message(id=194275)",
     "output": "Message(id: int, entity_type: MessageEntityType, entity_id: int, chat_id: int, root_chat_id: int, content: str, user_id: int, created_at: str, url: str, files: list[File(id: int, key: str, name: str, file_type: FileType, url: str, width: int | None, height: int | None)], buttons: list[list[Button(text: str, url: str | None, data: str | None)]] | None, thread: Thread(id: int, chat_id: int, message_id: int, message_chat_id: int, updated_at: str) | None, forwarding: Forwarding(original_message_id: int, original_chat_id: int, author_id: int, original_created_at: str, original_thread_id: int | None, original_thread_message_id: int | None, original_thread_parent_chat_id: int | None) | None, parent_message_id: int | None, display_avatar_url: str | None, display_name: str | None, changed_at: str | None, deleted_at: str | None)"
   },
   "MessageOperations_createMessage": {
-    "usage": "request = MessageCreateRequest(\n    message=MessageCreateRequestMessage(\n        entity_type=MessageEntityType.DISCUSSION,\n        entity_id=123,\n        content=\"example\",\n        files=[MessageCreateRequestFile(\n            key=\"example\",\n            name=\"example\",\n            file_type=FileType.FILE,\n            size=123,\n            width=123,\n            height=123\n        )],\n        buttons=[[Button(\n            text=\"example\",\n            url=\"example\",\n            data=\"example\"\n        )]],\n        parent_message_id=123,\n        display_avatar_url=\"example\",\n        display_name=\"example\",\n        skip_invite_mentions=True,\n        link_preview=True\n    )\n)\nresponse = await client.messages.create_message(request=request)",
+    "usage": "request = MessageCreateRequest(\n    message=MessageCreateRequestMessage(\n        entity_type=MessageEntityType.DISCUSSION,\n        entity_id=334,\n        content=\"Вчера мы продали 756 футболок (что на 10% больше, чем в прошлое воскресенье)\",\n        files=[MessageCreateRequestFile(\n            key=\"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n            name=\"logo.png\",\n            file_type=FileType.IMAGE,\n            size=12345,\n            width=800,\n            height=600\n        )],\n        buttons=[[Button(\n            text=\"Подробнее\",\n            url=\"https://example.com/details\",\n            data=\"awesome\"\n        )]],\n        parent_message_id=194270,\n        display_avatar_url=\"https://example.com/avatar.png\",\n        display_name=\"Бот Поддержки\",\n        skip_invite_mentions=False,\n        link_preview=False\n    )\n)\nresponse = await client.messages.create_message(request=request)",
     "output": "Message(id: int, entity_type: MessageEntityType, entity_id: int, chat_id: int, root_chat_id: int, content: str, user_id: int, created_at: str, url: str, files: list[File(id: int, key: str, name: str, file_type: FileType, url: str, width: int | None, height: int | None)], buttons: list[list[Button(text: str, url: str | None, data: str | None)]] | None, thread: Thread(id: int, chat_id: int, message_id: int, message_chat_id: int, updated_at: str) | None, forwarding: Forwarding(original_message_id: int, original_chat_id: int, author_id: int, original_created_at: str, original_thread_id: int | None, original_thread_message_id: int | None, original_thread_parent_chat_id: int | None) | None, parent_message_id: int | None, display_avatar_url: str | None, display_name: str | None, changed_at: str | None, deleted_at: str | None)",
     "imports": [
       "Button",
@@ -187,10 +187,10 @@
     ]
   },
   "MessageOperations_pinMessage": {
-    "usage": "await client.messages.pin_message(id=123)"
+    "usage": "await client.messages.pin_message(id=194275)"
   },
   "MessageOperations_updateMessage": {
-    "usage": "request = MessageUpdateRequest(\n    message=MessageUpdateRequestMessage(\n        content=\"example\",\n        files=[MessageUpdateRequestFile(\n            key=\"example\",\n            name=\"example\",\n            file_type=\"example\",\n            size=123,\n            width=123,\n            height=123\n        )],\n        buttons=[[Button(\n            text=\"example\",\n            url=\"example\",\n            data=\"example\"\n        )]],\n        display_avatar_url=\"example\",\n        display_name=\"example\"\n    )\n)\nresponse = await client.messages.update_message(id=123, request=request)",
+    "usage": "request = MessageUpdateRequest(\n    message=MessageUpdateRequestMessage(\n        content=\"Вот попробуйте написать правильно это с первого раза: Будущий, Полощи, Прийти, Грейпфрут, Мозаика, Бюллетень, Дуршлаг, Винегрет.\",\n        files=[MessageUpdateRequestFile(\n            key=\"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n            name=\"logo.png\",\n            file_type=\"image\",\n            size=12345,\n            width=800,\n            height=600\n        )],\n        buttons=[[Button(\n            text=\"Подробнее\",\n            url=\"https://example.com/details\",\n            data=\"awesome\"\n        )]],\n        display_avatar_url=\"https://example.com/avatar.png\",\n        display_name=\"Бот Поддержки\"\n    )\n)\nresponse = await client.messages.update_message(id=194275, request=request)",
     "output": "Message(id: int, entity_type: MessageEntityType, entity_id: int, chat_id: int, root_chat_id: int, content: str, user_id: int, created_at: str, url: str, files: list[File(id: int, key: str, name: str, file_type: FileType, url: str, width: int | None, height: int | None)], buttons: list[list[Button(text: str, url: str | None, data: str | None)]] | None, thread: Thread(id: int, chat_id: int, message_id: int, message_chat_id: int, updated_at: str) | None, forwarding: Forwarding(original_message_id: int, original_chat_id: int, author_id: int, original_created_at: str, original_thread_id: int | None, original_thread_message_id: int | None, original_thread_parent_chat_id: int | None) | None, parent_message_id: int | None, display_avatar_url: str | None, display_name: str | None, changed_at: str | None, deleted_at: str | None)",
     "imports": [
       "Button",
@@ -200,13 +200,13 @@
     ]
   },
   "MessageOperations_deleteMessage": {
-    "usage": "await client.messages.delete_message(id=123)"
+    "usage": "await client.messages.delete_message(id=194275)"
   },
   "MessageOperations_unpinMessage": {
-    "usage": "await client.messages.unpin_message(id=123)"
+    "usage": "await client.messages.unpin_message(id=194275)"
   },
   "LinkPreviewOperations_createLinkPreviews": {
-    "usage": "request = LinkPreviewsRequest(\n    link_previews={\"key\": LinkPreview(\n        title=\"example\",\n        description=\"example\",\n        image_url=\"example\",\n        image=LinkPreviewImage(\n            key=\"example\",\n            name=\"example\",\n            size=123\n        )\n    )}\n)\nawait client.link_previews.create_link_previews(id=123, request=request)",
+    "usage": "request = LinkPreviewsRequest(\n    link_previews={\"key\": LinkPreview(\n        title=\"Статья: Отправка файлов\",\n        description=\"Пример отправки файлов на удаленный сервер\",\n        image_url=\"https://website.com/img/landing.png\",\n        image=LinkPreviewImage(\n            key=\"attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/${filename}\",\n            name=\"files-to-server.jpg\",\n            size=695604\n        )\n    )}\n)\nawait client.link_previews.create_link_previews(id=194275, request=request)",
     "imports": [
       "LinkPreview",
       "LinkPreviewImage",
@@ -214,38 +214,38 @@
     ]
   },
   "ReactionOperations_listReactions": {
-    "usage": "params = ListReactionsParams(limit=123, cursor=\"example\")\nresponse = await client.reactions.list_reactions(id=123, params=params)",
+    "usage": "params = ListReactionsParams(limit=1, cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")\nresponse = await client.reactions.list_reactions(id=194275, params=params)",
     "output": "ListReactionsResponse(data: list[Reaction], meta: PaginationMeta | None)",
     "imports": [
       "ListReactionsParams"
     ]
   },
   "ReactionOperations_addReaction": {
-    "usage": "request = ReactionRequest(code=\"example\", name=\"example\")\nresponse = await client.reactions.add_reaction(id=123, request=request)",
+    "usage": "request = ReactionRequest(code=\"👍\", name=\":+1:\")\nresponse = await client.reactions.add_reaction(id=7231942, request=request)",
     "output": "Reaction(user_id: int, created_at: str, code: str, name: str | None)",
     "imports": [
       "ReactionRequest"
     ]
   },
   "ReactionOperations_removeReaction": {
-    "usage": "params = RemoveReactionParams(code=\"example\", name=\"example\")\nawait client.reactions.remove_reaction(id=123, params=params)",
+    "usage": "params = RemoveReactionParams(code=\"👍\", name=\":+1:\")\nawait client.reactions.remove_reaction(id=7231942, params=params)",
     "imports": [
       "RemoveReactionParams"
     ]
   },
   "ReadMemberOperations_listReadMembers": {
-    "usage": "params = ListReadMembersParams(limit=123, cursor=\"example\")\nresponse = await client.read_members.list_read_members(id=123, params=params)",
+    "usage": "params = ListReadMembersParams(limit=300, cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")\nresponse = await client.read_members.list_read_members(id=194275, params=params)",
     "output": "object",
     "imports": [
       "ListReadMembersParams"
     ]
   },
   "ThreadOperations_getThread": {
-    "usage": "response = await client.threads.get_thread(id=123)",
+    "usage": "response = await client.threads.get_thread(id=265142)",
     "output": "Thread(id: int, chat_id: int, message_id: int, message_chat_id: int, updated_at: str)"
   },
   "ThreadOperations_createThread": {
-    "usage": "response = await client.threads.create_thread(id=123)",
+    "usage": "response = await client.threads.create_thread(id=154332686)",
     "output": "Thread(id: int, chat_id: int, message_id: int, message_chat_id: int, updated_at: str)"
   },
   "OAuthOperations_getTokenInfo": {
@@ -261,7 +261,7 @@
     "output": "object"
   },
   "ProfileOperations_updateStatus": {
-    "usage": "request = StatusUpdateRequest(\n    status=StatusUpdateRequestStatus(\n        emoji=\"example\",\n        title=\"example\",\n        expires_at=\"2024-01-01T00:00:00Z\",\n        is_away=True,\n        away_message=\"example\"\n    )\n)\nresponse = await client.profile.update_status(request=request)",
+    "usage": "request = StatusUpdateRequest(\n    status=StatusUpdateRequestStatus(\n        emoji=\"🎮\",\n        title=\"Очень занят\",\n        expires_at=\"2024-04-08T10:00:00.000Z\",\n        is_away=True,\n        away_message=\"Вернусь после 15:00\"\n    )\n)\nresponse = await client.profile.update_status(request=request)",
     "output": "UserStatus(emoji: str, title: str, expires_at: str | None, is_away: bool, away_message: UserStatusAwayMessage(text: str) | None)",
     "imports": [
       "StatusUpdateRequest",
@@ -272,7 +272,7 @@
     "usage": "await client.profile.delete_status()"
   },
   "SearchOperations_searchChats": {
-    "usage": "params = SearchChatsParams(\n    query=\"example\",\n    limit=123,\n    cursor=\"example\",\n    order=SortOrder.ASC,\n    created_from=\"2024-01-01T00:00:00Z\",\n    created_to=\"2024-01-01T00:00:00Z\",\n    active=True,\n    chat_subtype=ChatSubtype.DISCUSSION,\n    personal=True\n)\nresponse = await client.search.search_chats(params=params)",
+    "usage": "params = SearchChatsParams(\n    query=\"Разработка\",\n    limit=10,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\",\n    order=SortOrder.DESC,\n    created_from=\"2025-01-01T00:00:00.000Z\",\n    created_to=\"2025-02-01T00:00:00.000Z\",\n    active=True,\n    chat_subtype=ChatSubtype.DISCUSSION,\n    personal=False\n)\nresponse = await client.search.search_chats(params=params)",
     "output": "SearchChatsResponse(data: list[Chat], meta: SearchPaginationMeta)",
     "imports": [
       "ChatSubtype",
@@ -281,7 +281,7 @@
     ]
   },
   "SearchOperations_searchMessages": {
-    "usage": "params = SearchMessagesParams(\n    query=\"example\",\n    limit=123,\n    cursor=\"example\",\n    order=SortOrder.ASC,\n    created_from=\"2024-01-01T00:00:00Z\",\n    created_to=\"2024-01-01T00:00:00Z\",\n    chat_ids=[123],\n    user_ids=[123],\n    active=True\n)\nresponse = await client.search.search_messages(params=params)",
+    "usage": "params = SearchMessagesParams(\n    query=\"футболки\",\n    limit=10,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\",\n    order=SortOrder.DESC,\n    created_from=\"2025-01-01T00:00:00.000Z\",\n    created_to=\"2025-02-01T00:00:00.000Z\",\n    chat_ids=[123],\n    user_ids=[123],\n    active=True\n)\nresponse = await client.search.search_messages(params=params)",
     "output": "SearchMessagesResponse(data: list[Message], meta: SearchPaginationMeta)",
     "imports": [
       "SearchMessagesParams",
@@ -289,7 +289,7 @@
     ]
   },
   "SearchOperations_searchUsers": {
-    "usage": "params = SearchUsersParams(\n    query=\"example\",\n    limit=123,\n    cursor=\"example\",\n    sort=SearchSortOrder.BY_SCORE,\n    order=SortOrder.ASC,\n    created_from=\"2024-01-01T00:00:00Z\",\n    created_to=\"2024-01-01T00:00:00Z\",\n    company_roles=[UserRole.ADMIN]\n)\nresponse = await client.search.search_users(params=params)",
+    "usage": "params = SearchUsersParams(\n    query=\"Олег\",\n    limit=10,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\",\n    sort=SearchSortOrder.BY_SCORE,\n    order=SortOrder.DESC,\n    created_from=\"2025-01-01T00:00:00.000Z\",\n    created_to=\"2025-02-01T00:00:00.000Z\",\n    company_roles=[UserRole.ADMIN]\n)\nresponse = await client.search.search_users(params=params)",
     "output": "SearchUsersResponse(data: list[User], meta: SearchPaginationMeta)",
     "imports": [
       "SearchSortOrder",
@@ -299,18 +299,18 @@
     ]
   },
   "TaskOperations_listTasks": {
-    "usage": "params = ListTasksParams(limit=123, cursor=\"example\")\nresponse = await client.tasks.list_tasks(params=params)",
+    "usage": "params = ListTasksParams(limit=1, cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")\nresponse = await client.tasks.list_tasks(params=params)",
     "output": "ListTasksResponse(data: list[Task], meta: PaginationMeta | None)",
     "imports": [
       "ListTasksParams"
     ]
   },
   "TaskOperations_getTask": {
-    "usage": "response = await client.tasks.get_task(id=123)",
+    "usage": "response = await client.tasks.get_task(id=22283)",
     "output": "Task(id: int, kind: TaskKind, content: str, due_at: str | None, priority: int, user_id: int, chat_id: int | None, status: TaskStatus, created_at: str, performer_ids: list[int], all_day: bool, custom_properties: list[CustomProperty(id: int, name: str, data_type: CustomPropertyDataType, value: str)])"
   },
   "TaskOperations_createTask": {
-    "usage": "request = TaskCreateRequest(\n    task=TaskCreateRequestTask(\n        kind=TaskKind.CALL,\n        content=\"example\",\n        due_at=\"2024-01-01T00:00:00Z\",\n        priority=123,\n        performer_ids=[123],\n        chat_id=123,\n        all_day=True,\n        custom_properties=[TaskCreateRequestCustomProperty(id=123, value=\"example\")]\n    )\n)\nresponse = await client.tasks.create_task(request=request)",
+    "usage": "request = TaskCreateRequest(\n    task=TaskCreateRequestTask(\n        kind=TaskKind.REMINDER,\n        content=\"Забрать со склада 21 заказ\",\n        due_at=\"2020-06-05T12:00:00.000+03:00\",\n        priority=2,\n        performer_ids=[123],\n        chat_id=456,\n        all_day=False,\n        custom_properties=[TaskCreateRequestCustomProperty(id=78, value=\"Синий склад\")]\n    )\n)\nresponse = await client.tasks.create_task(request=request)",
     "output": "Task(id: int, kind: TaskKind, content: str, due_at: str | None, priority: int, user_id: int, chat_id: int | None, status: TaskStatus, created_at: str, performer_ids: list[int], all_day: bool, custom_properties: list[CustomProperty(id: int, name: str, data_type: CustomPropertyDataType, value: str)])",
     "imports": [
       "TaskCreateRequest",
@@ -320,7 +320,7 @@
     ]
   },
   "TaskOperations_updateTask": {
-    "usage": "request = TaskUpdateRequest(\n    task=TaskUpdateRequestTask(\n        kind=TaskKind.CALL,\n        content=\"example\",\n        due_at=\"2024-01-01T00:00:00Z\",\n        priority=123,\n        performer_ids=[123],\n        status=TaskStatus.DONE,\n        all_day=True,\n        done_at=\"2024-01-01T00:00:00Z\",\n        custom_properties=[TaskUpdateRequestCustomProperty(id=123, value=\"example\")]\n    )\n)\nresponse = await client.tasks.update_task(id=123, request=request)",
+    "usage": "request = TaskUpdateRequest(\n    task=TaskUpdateRequestTask(\n        kind=TaskKind.REMINDER,\n        content=\"Забрать со склада 21 заказ\",\n        due_at=\"2020-06-05T12:00:00.000+03:00\",\n        priority=2,\n        performer_ids=[123],\n        status=TaskStatus.DONE,\n        all_day=False,\n        done_at=\"2020-06-05T12:00:00.000Z\",\n        custom_properties=[TaskUpdateRequestCustomProperty(id=78, value=\"Синий склад\")]\n    )\n)\nresponse = await client.tasks.update_task(id=22283, request=request)",
     "output": "Task(id: int, kind: TaskKind, content: str, due_at: str | None, priority: int, user_id: int, chat_id: int | None, status: TaskStatus, created_at: str, performer_ids: list[int], all_day: bool, custom_properties: list[CustomProperty(id: int, name: str, data_type: CustomPropertyDataType, value: str)])",
     "imports": [
       "TaskKind",
@@ -331,25 +331,25 @@
     ]
   },
   "TaskOperations_deleteTask": {
-    "usage": "await client.tasks.delete_task(id=123)"
+    "usage": "await client.tasks.delete_task(id=22283)"
   },
   "UserOperations_listUsers": {
-    "usage": "params = ListUsersParams(\n    query=\"example\",\n    limit=123,\n    cursor=\"example\"\n)\nresponse = await client.users.list_users(params=params)",
+    "usage": "params = ListUsersParams(\n    query=\"Олег\",\n    limit=1,\n    cursor=\"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n)\nresponse = await client.users.list_users(params=params)",
     "output": "ListUsersResponse(data: list[User], meta: PaginationMeta | None)",
     "imports": [
       "ListUsersParams"
     ]
   },
   "UserOperations_getUser": {
-    "usage": "response = await client.users.get_user(id=123)",
+    "usage": "response = await client.users.get_user(id=12)",
     "output": "User(id: int, first_name: str, last_name: str, nickname: str, email: str, phone_number: str, department: str, title: str, role: UserRole, suspended: bool, invite_status: InviteStatus, list_tags: list[str], custom_properties: list[CustomProperty(id: int, name: str, data_type: CustomPropertyDataType, value: str)], user_status: UserStatus(emoji: str, title: str, expires_at: str | None, is_away: bool, away_message: UserStatusAwayMessage(text: str) | None) | None, bot: bool, sso: bool, created_at: str, last_activity_at: str, time_zone: str, image_url: str | None)"
   },
   "UserStatusOperations_getUserStatus": {
-    "usage": "response = await client.users.get_user_status(user_id=123)",
+    "usage": "response = await client.users.get_user_status(user_id=12)",
     "output": "object"
   },
   "UserOperations_createUser": {
-    "usage": "request = UserCreateRequest(\n    user=UserCreateRequestUser(\n        first_name=\"example\",\n        last_name=\"example\",\n        email=\"example\",\n        phone_number=\"example\",\n        nickname=\"example\",\n        department=\"example\",\n        title=\"example\",\n        role=UserRole.ADMIN,\n        suspended=True,\n        list_tags=[\"example\"],\n        custom_properties=[UserCreateRequestCustomProperty(id=123, value=\"example\")]\n    ),\n    skip_email_notify=True\n)\nresponse = await client.users.create_user(request=request)",
+    "usage": "request = UserCreateRequest(\n    user=UserCreateRequestUser(\n        first_name=\"Олег\",\n        last_name=\"Петров\",\n        email=\"olegp@example.com\",\n        phone_number=\"+79001234567\",\n        nickname=\"olegpetrov\",\n        department=\"Продукт\",\n        title=\"CIO\",\n        role=UserRole.USER,\n        suspended=False,\n        list_tags=[\"example\"],\n        custom_properties=[UserCreateRequestCustomProperty(id=1678, value=\"Санкт-Петербург\")]\n    ),\n    skip_email_notify=True\n)\nresponse = await client.users.create_user(request=request)",
     "output": "User(id: int, first_name: str, last_name: str, nickname: str, email: str, phone_number: str, department: str, title: str, role: UserRole, suspended: bool, invite_status: InviteStatus, list_tags: list[str], custom_properties: list[CustomProperty(id: int, name: str, data_type: CustomPropertyDataType, value: str)], user_status: UserStatus(emoji: str, title: str, expires_at: str | None, is_away: bool, away_message: UserStatusAwayMessage(text: str) | None) | None, bot: bool, sso: bool, created_at: str, last_activity_at: str, time_zone: str, image_url: str | None)",
     "imports": [
       "UserCreateRequest",
@@ -359,7 +359,7 @@
     ]
   },
   "UserOperations_updateUser": {
-    "usage": "request = UserUpdateRequest(\n    user=UserUpdateRequestUser(\n        first_name=\"example\",\n        last_name=\"example\",\n        email=\"example\",\n        phone_number=\"example\",\n        nickname=\"example\",\n        department=\"example\",\n        title=\"example\",\n        role=UserRole.ADMIN,\n        suspended=True,\n        list_tags=[\"example\"],\n        custom_properties=[UserUpdateRequestCustomProperty(id=123, value=\"example\")]\n    )\n)\nresponse = await client.users.update_user(id=123, request=request)",
+    "usage": "request = UserUpdateRequest(\n    user=UserUpdateRequestUser(\n        first_name=\"Олег\",\n        last_name=\"Петров\",\n        email=\"olegpetrov@example.com\",\n        phone_number=\"+79001234567\",\n        nickname=\"olegpetrov\",\n        department=\"Отдел разработки\",\n        title=\"Старший разработчик\",\n        role=UserRole.USER,\n        suspended=False,\n        list_tags=[\"example\"],\n        custom_properties=[UserUpdateRequestCustomProperty(id=1678, value=\"Санкт-Петербург\")]\n    )\n)\nresponse = await client.users.update_user(id=12, request=request)",
     "output": "User(id: int, first_name: str, last_name: str, nickname: str, email: str, phone_number: str, department: str, title: str, role: UserRole, suspended: bool, invite_status: InviteStatus, list_tags: list[str], custom_properties: list[CustomProperty(id: int, name: str, data_type: CustomPropertyDataType, value: str)], user_status: UserStatus(emoji: str, title: str, expires_at: str | None, is_away: bool, away_message: UserStatusAwayMessage(text: str) | None) | None, bot: bool, sso: bool, created_at: str, last_activity_at: str, time_zone: str, image_url: str | None)",
     "imports": [
       "UserRole",
@@ -369,7 +369,7 @@
     ]
   },
   "UserStatusOperations_updateUserStatus": {
-    "usage": "request = StatusUpdateRequest(\n    status=StatusUpdateRequestStatus(\n        emoji=\"example\",\n        title=\"example\",\n        expires_at=\"2024-01-01T00:00:00Z\",\n        is_away=True,\n        away_message=\"example\"\n    )\n)\nresponse = await client.users.update_user_status(user_id=123, request=request)",
+    "usage": "request = StatusUpdateRequest(\n    status=StatusUpdateRequestStatus(\n        emoji=\"🎮\",\n        title=\"Очень занят\",\n        expires_at=\"2024-04-08T10:00:00.000Z\",\n        is_away=True,\n        away_message=\"Вернусь после 15:00\"\n    )\n)\nresponse = await client.users.update_user_status(user_id=12, request=request)",
     "output": "UserStatus(emoji: str, title: str, expires_at: str | None, is_away: bool, away_message: UserStatusAwayMessage(text: str) | None)",
     "imports": [
       "StatusUpdateRequest",
@@ -377,13 +377,13 @@
     ]
   },
   "UserOperations_deleteUser": {
-    "usage": "await client.users.delete_user(id=123)"
+    "usage": "await client.users.delete_user(id=12)"
   },
   "UserStatusOperations_deleteUserStatus": {
-    "usage": "await client.users.delete_user_status(user_id=123)"
+    "usage": "await client.users.delete_user_status(user_id=12)"
   },
   "FormOperations_openView": {
-    "usage": "request = OpenViewRequest(\n    type=\"modal\",\n    trigger_id=\"example\",\n    private_metadata=\"example\",\n    callback_id=\"example\",\n    view=OpenViewRequestView(\n        title=\"example\",\n        close_text=\"example\",\n        submit_text=\"example\",\n        blocks=[ViewBlockHeader(type=\"header\", text=\"example\")]\n    )\n)\nawait client.views.open_view(request=request)",
+    "usage": "request = OpenViewRequest(\n    type=\"modal\",\n    trigger_id=\"791a056b-006c-49dd-834b-c633fde52fe8\",\n    private_metadata=\"{\\\"timeoff_id\\\":4378}\",\n    callback_id=\"timeoff_reguest_form\",\n    view=OpenViewRequestView(\n        title=\"Уведомление об отпуске\",\n        close_text=\"Закрыть\",\n        submit_text=\"Отправить заявку\",\n        blocks=[ViewBlockHeader(type=\"header\", text=\"Основная информация\")]\n    )\n)\nawait client.views.open_view(request=request)",
     "imports": [
       "OpenViewRequest",
       "OpenViewRequestView",

--- a/sdk/swift/generated/Sources/Pachca/GeneratedSources/examples.json
+++ b/sdk/swift/generated/Sources/Pachca/GeneratedSources/examples.json
@@ -3,18 +3,18 @@
     "usage": "import PachcaSDK\n\nlet client = PachcaClient(token: \"YOUR_TOKEN\")"
   },
   "SecurityOperations_getAuditEvents": {
-    "usage": "let response = try await client.security.getAuditEvents(startTime: \"2024-01-01T00:00:00Z\", endTime: \"2024-01-01T00:00:00Z\", eventKey: .userLogin, actorId: \"example\", actorType: \"example\", entityId: \"example\", entityType: \"example\", limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.security.getAuditEvents(startTime: \"2025-05-01T09:11:00Z\", endTime: \"2025-05-02T09:11:00Z\", eventKey: .userLogin, actorId: \"98765\", actorType: \"User\", entityId: \"98765\", entityType: \"User\", limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "GetAuditEventsResponse(data: [AuditEvent], meta: PaginationMeta?)",
     "imports": [
       "AuditEventKey"
     ]
   },
   "BotOperations_getWebhookEvents": {
-    "usage": "let response = try await client.bots.getWebhookEvents(limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.bots.getWebhookEvents(limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "GetWebhookEventsResponse(data: [WebhookEvent], meta: PaginationMeta?)"
   },
   "BotOperations_updateBot": {
-    "usage": "let body = BotUpdateRequest(bot: BotUpdateRequestBot(webhook: BotUpdateRequestBotWebhook(outgoingUrl: \"example\")))\nlet response = try await client.bots.updateBot(id: 123, body: body)",
+    "usage": "let body = BotUpdateRequest(bot: BotUpdateRequestBot(webhook: BotUpdateRequestBotWebhook(outgoingUrl: \"https://www.website.com/tasks/new\")))\nlet response = try await client.bots.updateBot(id: 1738816, body: body)",
     "output": "BotResponse(id: Int, webhook: BotResponseWebhook(outgoingUrl: String))",
     "imports": [
       "BotUpdateRequest",
@@ -23,10 +23,10 @@
     ]
   },
   "BotOperations_deleteWebhookEvent": {
-    "usage": "try await client.bots.deleteWebhookEvent(id: \"example\")"
+    "usage": "try await client.bots.deleteWebhookEvent(id: \"01KAJZ2XDSS2S3DSW9EXJZ0TBV\")"
   },
   "ChatOperations_listChats": {
-    "usage": "let response = try await client.chats.listChats(sortId: .asc, availability: .isMember, lastMessageAtAfter: \"2024-01-01T00:00:00Z\", lastMessageAtBefore: \"2024-01-01T00:00:00Z\", personal: true, limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.chats.listChats(sortId: .desc, availability: .isMember, lastMessageAtAfter: \"2025-01-01T00:00:00.000Z\", lastMessageAtBefore: \"2025-02-01T00:00:00.000Z\", personal: false, limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListChatsResponse(data: [Chat], meta: PaginationMeta?)",
     "imports": [
       "ChatAvailability",
@@ -34,11 +34,11 @@
     ]
   },
   "ChatOperations_getChat": {
-    "usage": "let response = try await client.chats.getChat(id: 123)",
+    "usage": "let response = try await client.chats.getChat(id: 334)",
     "output": "Chat(id: Int, name: String, createdAt: String, ownerId: Int, memberIds: [Int], groupTagIds: [Int], channel: Bool, personal: Bool, `public`: Bool, lastMessageAt: String, meetRoomUrl: String)"
   },
   "ChatOperations_createChat": {
-    "usage": "let body = ChatCreateRequest(\n    chat: ChatCreateRequestChat(\n        name: \"example\",\n        memberIds: [123],\n        groupTagIds: [123],\n        channel: true,\n        `public`: true\n    )\n)\nlet response = try await client.chats.createChat(body: body)",
+    "usage": "let body = ChatCreateRequest(\n    chat: ChatCreateRequestChat(\n        name: \"🤿 aqua\",\n        memberIds: [123],\n        groupTagIds: [123],\n        channel: true,\n        `public`: false\n    )\n)\nlet response = try await client.chats.createChat(body: body)",
     "output": "Chat(id: Int, name: String, createdAt: String, ownerId: Int, memberIds: [Int], groupTagIds: [Int], channel: Bool, personal: Bool, `public`: Bool, lastMessageAt: String, meetRoomUrl: String)",
     "imports": [
       "ChatCreateRequest",
@@ -46,7 +46,7 @@
     ]
   },
   "ChatOperations_updateChat": {
-    "usage": "let body = ChatUpdateRequest(chat: ChatUpdateRequestChat(name: \"example\", `public`: true))\nlet response = try await client.chats.updateChat(id: 123, body: body)",
+    "usage": "let body = ChatUpdateRequest(chat: ChatUpdateRequestChat(name: \"Бассейн\", `public`: true))\nlet response = try await client.chats.updateChat(id: 334, body: body)",
     "output": "Chat(id: Int, name: String, createdAt: String, ownerId: Int, memberIds: [Int], groupTagIds: [Int], channel: Bool, personal: Bool, `public`: Bool, lastMessageAt: String, meetRoomUrl: String)",
     "imports": [
       "ChatUpdateRequest",
@@ -54,13 +54,13 @@
     ]
   },
   "ChatOperations_archiveChat": {
-    "usage": "try await client.chats.archiveChat(id: 123)"
+    "usage": "try await client.chats.archiveChat(id: 334)"
   },
   "ChatOperations_unarchiveChat": {
-    "usage": "try await client.chats.unarchiveChat(id: 123)"
+    "usage": "try await client.chats.unarchiveChat(id: 334)"
   },
   "ExportOperations_downloadExport": {
-    "usage": "let response = try await client.common.downloadExport(id: 123)",
+    "usage": "let response = try await client.common.downloadExport(id: 22322)",
     "output": "String"
   },
   "CommonOperations_listProperties": {
@@ -71,7 +71,7 @@
     ]
   },
   "ExportOperations_requestExport": {
-    "usage": "let body = ExportRequest(\n    startAt: \"2024-01-01\",\n    endAt: \"2024-01-01\",\n    webhookUrl: \"example\",\n    chatIds: [123],\n    skipChatsFile: true\n)\ntry await client.common.requestExport(body: body)",
+    "usage": "let body = ExportRequest(\n    startAt: \"2025-03-20\",\n    endAt: \"2025-03-20\",\n    webhookUrl: \"https://webhook.site/9227d3b8-6e82-4e64-bf5d-ad972ad270f2\",\n    chatIds: [123],\n    skipChatsFile: false\n)\ntry await client.common.requestExport(body: body)",
     "imports": [
       "ExportRequest"
     ]
@@ -87,53 +87,53 @@
     "output": "UploadParams(ContentDisposition: String, acl: String, policy: String, xAmzCredential: String, xAmzAlgorithm: String, xAmzDate: String, xAmzSignature: String, key: String, directUrl: String)"
   },
   "ChatMemberOperations_listMembers": {
-    "usage": "let response = try await client.members.listMembers(id: 123, role: .all, limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.members.listMembers(id: 334, role: .all, limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListMembersResponse(data: [User], meta: PaginationMeta?)",
     "imports": [
       "ChatMemberRoleFilter"
     ]
   },
   "ChatMemberOperations_addTags": {
-    "usage": "let groupTagIds = [123]\ntry await client.members.addTags(id: 123, groupTagIds: groupTagIds)"
+    "usage": "let groupTagIds = [123]\ntry await client.members.addTags(id: 334, groupTagIds: groupTagIds)"
   },
   "ChatMemberOperations_addMembers": {
-    "usage": "let body = AddMembersRequest(memberIds: [123], silent: true)\ntry await client.members.addMembers(id: 123, body: body)",
+    "usage": "let body = AddMembersRequest(memberIds: [123], silent: true)\ntry await client.members.addMembers(id: 334, body: body)",
     "imports": [
       "AddMembersRequest"
     ]
   },
   "ChatMemberOperations_updateMemberRole": {
-    "usage": "try await client.members.updateMemberRole(id: 123, userId: 123, role: .admin)",
+    "usage": "try await client.members.updateMemberRole(id: 334, userId: 186, role: .admin)",
     "imports": [
       "ChatMemberRole"
     ]
   },
   "ChatMemberOperations_removeTag": {
-    "usage": "try await client.members.removeTag(id: 123, tagId: 123)"
+    "usage": "try await client.members.removeTag(id: 334, tagId: 86)"
   },
   "ChatMemberOperations_leaveChat": {
-    "usage": "try await client.members.leaveChat(id: 123)"
+    "usage": "try await client.members.leaveChat(id: 334)"
   },
   "ChatMemberOperations_removeMember": {
-    "usage": "try await client.members.removeMember(id: 123, userId: 123)"
+    "usage": "try await client.members.removeMember(id: 334, userId: 186)"
   },
   "GroupTagOperations_listTags": {
-    "usage": "let names = TagNamesFilter()\nlet response = try await client.groupTags.listTags(names: names, limit: 123, cursor: \"example\")",
+    "usage": "let names = TagNamesFilter()\nlet response = try await client.groupTags.listTags(names: names, limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListTagsResponse(data: [GroupTag], meta: PaginationMeta?)",
     "imports": [
       "TagNamesFilter"
     ]
   },
   "GroupTagOperations_getTag": {
-    "usage": "let response = try await client.groupTags.getTag(id: 123)",
+    "usage": "let response = try await client.groupTags.getTag(id: 9111)",
     "output": "GroupTag(id: Int, name: String, usersCount: Int)"
   },
   "GroupTagOperations_getTagUsers": {
-    "usage": "let response = try await client.groupTags.getTagUsers(id: 123, limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.groupTags.getTagUsers(id: 9111, limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "GetTagUsersResponse(data: [User], meta: PaginationMeta?)"
   },
   "GroupTagOperations_createTag": {
-    "usage": "let body = GroupTagRequest(groupTag: GroupTagRequestGroupTag(name: \"example\"))\nlet response = try await client.groupTags.createTag(body: body)",
+    "usage": "let body = GroupTagRequest(groupTag: GroupTagRequestGroupTag(name: \"Новое название тега\"))\nlet response = try await client.groupTags.createTag(body: body)",
     "output": "GroupTag(id: Int, name: String, usersCount: Int)",
     "imports": [
       "GroupTagRequest",
@@ -141,7 +141,7 @@
     ]
   },
   "GroupTagOperations_updateTag": {
-    "usage": "let body = GroupTagRequest(groupTag: GroupTagRequestGroupTag(name: \"example\"))\nlet response = try await client.groupTags.updateTag(id: 123, body: body)",
+    "usage": "let body = GroupTagRequest(groupTag: GroupTagRequestGroupTag(name: \"Новое название тега\"))\nlet response = try await client.groupTags.updateTag(id: 9111, body: body)",
     "output": "GroupTag(id: Int, name: String, usersCount: Int)",
     "imports": [
       "GroupTagRequest",
@@ -149,21 +149,21 @@
     ]
   },
   "GroupTagOperations_deleteTag": {
-    "usage": "try await client.groupTags.deleteTag(id: 123)"
+    "usage": "try await client.groupTags.deleteTag(id: 9111)"
   },
   "ChatMessageOperations_listChatMessages": {
-    "usage": "let response = try await client.messages.listChatMessages(chatId: 123, sortId: .asc, limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.messages.listChatMessages(chatId: 198, sortId: .desc, limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListChatMessagesResponse(data: [Message], meta: PaginationMeta?)",
     "imports": [
       "SortOrder"
     ]
   },
   "MessageOperations_getMessage": {
-    "usage": "let response = try await client.messages.getMessage(id: 123)",
+    "usage": "let response = try await client.messages.getMessage(id: 194275)",
     "output": "Message(id: Int, entityType: MessageEntityType, entityId: Int, chatId: Int, rootChatId: Int, content: String, userId: Int, createdAt: String, url: String, files: [File(id: Int, key: String, name: String, fileType: FileType, url: String, width: Int?, height: Int?)], buttons: [[Button(text: String, url: String?, data: String?)]]?, thread: Thread(id: Int64, chatId: Int64, messageId: Int64, messageChatId: Int64, updatedAt: String)?, forwarding: Forwarding(originalMessageId: Int, originalChatId: Int, authorId: Int, originalCreatedAt: String, originalThreadId: Int?, originalThreadMessageId: Int?, originalThreadParentChatId: Int?)?, parentMessageId: Int?, displayAvatarUrl: String?, displayName: String?, changedAt: String?, deletedAt: String?)"
   },
   "MessageOperations_createMessage": {
-    "usage": "let body = MessageCreateRequest(\n    message: MessageCreateRequestMessage(\n        entityType: .discussion,\n        entityId: 123,\n        content: \"example\",\n        files: [MessageCreateRequestFile(\n            key: \"example\",\n            name: \"example\",\n            fileType: .file,\n            size: 123,\n            width: 123,\n            height: 123\n        )],\n        buttons: [[Button(\n            text: \"example\",\n            url: \"example\",\n            data: \"example\"\n        )]],\n        parentMessageId: 123,\n        displayAvatarUrl: \"example\",\n        displayName: \"example\",\n        skipInviteMentions: true,\n        linkPreview: true\n    )\n)\nlet response = try await client.messages.createMessage(body: body)",
+    "usage": "let body = MessageCreateRequest(\n    message: MessageCreateRequestMessage(\n        entityType: .discussion,\n        entityId: 334,\n        content: \"Вчера мы продали 756 футболок (что на 10% больше, чем в прошлое воскресенье)\",\n        files: [MessageCreateRequestFile(\n            key: \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n            name: \"logo.png\",\n            fileType: .image,\n            size: 12345,\n            width: 800,\n            height: 600\n        )],\n        buttons: [[Button(\n            text: \"Подробнее\",\n            url: \"https://example.com/details\",\n            data: \"awesome\"\n        )]],\n        parentMessageId: 194270,\n        displayAvatarUrl: \"https://example.com/avatar.png\",\n        displayName: \"Бот Поддержки\",\n        skipInviteMentions: false,\n        linkPreview: false\n    )\n)\nlet response = try await client.messages.createMessage(body: body)",
     "output": "Message(id: Int, entityType: MessageEntityType, entityId: Int, chatId: Int, rootChatId: Int, content: String, userId: Int, createdAt: String, url: String, files: [File(id: Int, key: String, name: String, fileType: FileType, url: String, width: Int?, height: Int?)], buttons: [[Button(text: String, url: String?, data: String?)]]?, thread: Thread(id: Int64, chatId: Int64, messageId: Int64, messageChatId: Int64, updatedAt: String)?, forwarding: Forwarding(originalMessageId: Int, originalChatId: Int, authorId: Int, originalCreatedAt: String, originalThreadId: Int?, originalThreadMessageId: Int?, originalThreadParentChatId: Int?)?, parentMessageId: Int?, displayAvatarUrl: String?, displayName: String?, changedAt: String?, deletedAt: String?)",
     "imports": [
       "Button",
@@ -175,10 +175,10 @@
     ]
   },
   "MessageOperations_pinMessage": {
-    "usage": "try await client.messages.pinMessage(id: 123)"
+    "usage": "try await client.messages.pinMessage(id: 194275)"
   },
   "MessageOperations_updateMessage": {
-    "usage": "let body = MessageUpdateRequest(\n    message: MessageUpdateRequestMessage(\n        content: \"example\",\n        files: [MessageUpdateRequestFile(\n            key: \"example\",\n            name: \"example\",\n            fileType: \"example\",\n            size: 123,\n            width: 123,\n            height: 123\n        )],\n        buttons: [[Button(\n            text: \"example\",\n            url: \"example\",\n            data: \"example\"\n        )]],\n        displayAvatarUrl: \"example\",\n        displayName: \"example\"\n    )\n)\nlet response = try await client.messages.updateMessage(id: 123, body: body)",
+    "usage": "let body = MessageUpdateRequest(\n    message: MessageUpdateRequestMessage(\n        content: \"Вот попробуйте написать правильно это с первого раза: Будущий, Полощи, Прийти, Грейпфрут, Мозаика, Бюллетень, Дуршлаг, Винегрет.\",\n        files: [MessageUpdateRequestFile(\n            key: \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n            name: \"logo.png\",\n            fileType: \"image\",\n            size: 12345,\n            width: 800,\n            height: 600\n        )],\n        buttons: [[Button(\n            text: \"Подробнее\",\n            url: \"https://example.com/details\",\n            data: \"awesome\"\n        )]],\n        displayAvatarUrl: \"https://example.com/avatar.png\",\n        displayName: \"Бот Поддержки\"\n    )\n)\nlet response = try await client.messages.updateMessage(id: 194275, body: body)",
     "output": "Message(id: Int, entityType: MessageEntityType, entityId: Int, chatId: Int, rootChatId: Int, content: String, userId: Int, createdAt: String, url: String, files: [File(id: Int, key: String, name: String, fileType: FileType, url: String, width: Int?, height: Int?)], buttons: [[Button(text: String, url: String?, data: String?)]]?, thread: Thread(id: Int64, chatId: Int64, messageId: Int64, messageChatId: Int64, updatedAt: String)?, forwarding: Forwarding(originalMessageId: Int, originalChatId: Int, authorId: Int, originalCreatedAt: String, originalThreadId: Int?, originalThreadMessageId: Int?, originalThreadParentChatId: Int?)?, parentMessageId: Int?, displayAvatarUrl: String?, displayName: String?, changedAt: String?, deletedAt: String?)",
     "imports": [
       "Button",
@@ -188,13 +188,13 @@
     ]
   },
   "MessageOperations_deleteMessage": {
-    "usage": "try await client.messages.deleteMessage(id: 123)"
+    "usage": "try await client.messages.deleteMessage(id: 194275)"
   },
   "MessageOperations_unpinMessage": {
-    "usage": "try await client.messages.unpinMessage(id: 123)"
+    "usage": "try await client.messages.unpinMessage(id: 194275)"
   },
   "LinkPreviewOperations_createLinkPreviews": {
-    "usage": "let body = LinkPreviewsRequest(\n    linkPreviews: [\"key\": LinkPreview(\n        title: \"example\",\n        description: \"example\",\n        imageUrl: \"example\",\n        image: LinkPreviewImage(\n            key: \"example\",\n            name: \"example\",\n            size: 123\n        )\n    )]\n)\ntry await client.linkPreviews.createLinkPreviews(id: 123, body: body)",
+    "usage": "let body = LinkPreviewsRequest(\n    linkPreviews: [\"key\": LinkPreview(\n        title: \"Статья: Отправка файлов\",\n        description: \"Пример отправки файлов на удаленный сервер\",\n        imageUrl: \"https://website.com/img/landing.png\",\n        image: LinkPreviewImage(\n            key: \"attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/${filename}\",\n            name: \"files-to-server.jpg\",\n            size: 695604\n        )\n    )]\n)\ntry await client.linkPreviews.createLinkPreviews(id: 194275, body: body)",
     "imports": [
       "LinkPreview",
       "LinkPreviewImage",
@@ -202,29 +202,29 @@
     ]
   },
   "ReactionOperations_listReactions": {
-    "usage": "let response = try await client.reactions.listReactions(id: 123, limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.reactions.listReactions(id: 194275, limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListReactionsResponse(data: [Reaction], meta: PaginationMeta?)"
   },
   "ReactionOperations_addReaction": {
-    "usage": "let body = ReactionRequest(code: \"example\", name: \"example\")\nlet response = try await client.reactions.addReaction(id: 123, body: body)",
+    "usage": "let body = ReactionRequest(code: \"👍\", name: \":+1:\")\nlet response = try await client.reactions.addReaction(id: 7231942, body: body)",
     "output": "Reaction(userId: Int, createdAt: String, code: String, name: String?)",
     "imports": [
       "ReactionRequest"
     ]
   },
   "ReactionOperations_removeReaction": {
-    "usage": "try await client.reactions.removeReaction(id: 123, code: \"example\", name: \"example\")"
+    "usage": "try await client.reactions.removeReaction(id: 7231942, code: \"👍\", name: \":+1:\")"
   },
   "ReadMemberOperations_listReadMembers": {
-    "usage": "let response = try await client.readMembers.listReadMembers(id: 123, limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.readMembers.listReadMembers(id: 194275, limit: 300, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "String"
   },
   "ThreadOperations_getThread": {
-    "usage": "let response = try await client.threads.getThread(id: 123)",
+    "usage": "let response = try await client.threads.getThread(id: 265142)",
     "output": "Thread(id: Int64, chatId: Int64, messageId: Int64, messageChatId: Int64, updatedAt: String)"
   },
   "ThreadOperations_createThread": {
-    "usage": "let response = try await client.threads.createThread(id: 123)",
+    "usage": "let response = try await client.threads.createThread(id: 154332686)",
     "output": "Thread(id: Int64, chatId: Int64, messageId: Int64, messageChatId: Int64, updatedAt: String)"
   },
   "OAuthOperations_getTokenInfo": {
@@ -240,7 +240,7 @@
     "output": "String"
   },
   "ProfileOperations_updateStatus": {
-    "usage": "let body = StatusUpdateRequest(\n    status: StatusUpdateRequestStatus(\n        emoji: \"example\",\n        title: \"example\",\n        expiresAt: \"2024-01-01T00:00:00Z\",\n        isAway: true,\n        awayMessage: \"example\"\n    )\n)\nlet response = try await client.profile.updateStatus(body: body)",
+    "usage": "let body = StatusUpdateRequest(\n    status: StatusUpdateRequestStatus(\n        emoji: \"🎮\",\n        title: \"Очень занят\",\n        expiresAt: \"2024-04-08T10:00:00.000Z\",\n        isAway: true,\n        awayMessage: \"Вернусь после 15:00\"\n    )\n)\nlet response = try await client.profile.updateStatus(body: body)",
     "output": "UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Bool, awayMessage: UserStatusAwayMessage(text: String)?)",
     "imports": [
       "StatusUpdateRequest",
@@ -251,7 +251,7 @@
     "usage": "try await client.profile.deleteStatus()"
   },
   "SearchOperations_searchChats": {
-    "usage": "let response = try await client.search.searchChats(query: \"example\", limit: 123, cursor: \"example\", order: .asc, createdFrom: \"2024-01-01T00:00:00Z\", createdTo: \"2024-01-01T00:00:00Z\", active: true, chatSubtype: .discussion, personal: true)",
+    "usage": "let response = try await client.search.searchChats(query: \"Разработка\", limit: 10, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\", order: .desc, createdFrom: \"2025-01-01T00:00:00.000Z\", createdTo: \"2025-02-01T00:00:00.000Z\", active: true, chatSubtype: .discussion, personal: false)",
     "output": "SearchChatsResponse(data: [Chat], meta: SearchPaginationMeta)",
     "imports": [
       "ChatSubtype",
@@ -259,14 +259,14 @@
     ]
   },
   "SearchOperations_searchMessages": {
-    "usage": "let chatIds = [123]\nlet userIds = [123]\nlet response = try await client.search.searchMessages(query: \"example\", limit: 123, cursor: \"example\", order: .asc, createdFrom: \"2024-01-01T00:00:00Z\", createdTo: \"2024-01-01T00:00:00Z\", chatIds: chatIds, userIds: userIds, active: true)",
+    "usage": "let chatIds = [123]\nlet userIds = [123]\nlet response = try await client.search.searchMessages(query: \"футболки\", limit: 10, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\", order: .desc, createdFrom: \"2025-01-01T00:00:00.000Z\", createdTo: \"2025-02-01T00:00:00.000Z\", chatIds: chatIds, userIds: userIds, active: true)",
     "output": "SearchMessagesResponse(data: [Message], meta: SearchPaginationMeta)",
     "imports": [
       "SortOrder"
     ]
   },
   "SearchOperations_searchUsers": {
-    "usage": "let companyRoles = [.admin]\nlet response = try await client.search.searchUsers(query: \"example\", limit: 123, cursor: \"example\", sort: .byScore, order: .asc, createdFrom: \"2024-01-01T00:00:00Z\", createdTo: \"2024-01-01T00:00:00Z\", companyRoles: companyRoles)",
+    "usage": "let companyRoles = [.admin]\nlet response = try await client.search.searchUsers(query: \"Олег\", limit: 10, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\", sort: .byScore, order: .desc, createdFrom: \"2025-01-01T00:00:00.000Z\", createdTo: \"2025-02-01T00:00:00.000Z\", companyRoles: companyRoles)",
     "output": "SearchUsersResponse(data: [User], meta: SearchPaginationMeta)",
     "imports": [
       "SearchSortOrder",
@@ -275,15 +275,15 @@
     ]
   },
   "TaskOperations_listTasks": {
-    "usage": "let response = try await client.tasks.listTasks(limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.tasks.listTasks(limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListTasksResponse(data: [Task], meta: PaginationMeta?)"
   },
   "TaskOperations_getTask": {
-    "usage": "let response = try await client.tasks.getTask(id: 123)",
+    "usage": "let response = try await client.tasks.getTask(id: 22283)",
     "output": "Task(id: Int, kind: TaskKind, content: String, dueAt: String?, priority: Int, userId: Int, chatId: Int?, status: TaskStatus, createdAt: String, performerIds: [Int], allDay: Bool, customProperties: [CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)])"
   },
   "TaskOperations_createTask": {
-    "usage": "let body = TaskCreateRequest(\n    task: TaskCreateRequestTask(\n        kind: .call,\n        content: \"example\",\n        dueAt: \"2024-01-01T00:00:00Z\",\n        priority: 123,\n        performerIds: [123],\n        chatId: 123,\n        allDay: true,\n        customProperties: [TaskCreateRequestCustomProperty(id: 123, value: \"example\")]\n    )\n)\nlet response = try await client.tasks.createTask(body: body)",
+    "usage": "let body = TaskCreateRequest(\n    task: TaskCreateRequestTask(\n        kind: .reminder,\n        content: \"Забрать со склада 21 заказ\",\n        dueAt: \"2020-06-05T12:00:00.000+03:00\",\n        priority: 2,\n        performerIds: [123],\n        chatId: 456,\n        allDay: false,\n        customProperties: [TaskCreateRequestCustomProperty(id: 78, value: \"Синий склад\")]\n    )\n)\nlet response = try await client.tasks.createTask(body: body)",
     "output": "Task(id: Int, kind: TaskKind, content: String, dueAt: String?, priority: Int, userId: Int, chatId: Int?, status: TaskStatus, createdAt: String, performerIds: [Int], allDay: Bool, customProperties: [CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)])",
     "imports": [
       "TaskCreateRequest",
@@ -293,7 +293,7 @@
     ]
   },
   "TaskOperations_updateTask": {
-    "usage": "let body = TaskUpdateRequest(\n    task: TaskUpdateRequestTask(\n        kind: .call,\n        content: \"example\",\n        dueAt: \"2024-01-01T00:00:00Z\",\n        priority: 123,\n        performerIds: [123],\n        status: .done,\n        allDay: true,\n        doneAt: \"2024-01-01T00:00:00Z\",\n        customProperties: [TaskUpdateRequestCustomProperty(id: 123, value: \"example\")]\n    )\n)\nlet response = try await client.tasks.updateTask(id: 123, body: body)",
+    "usage": "let body = TaskUpdateRequest(\n    task: TaskUpdateRequestTask(\n        kind: .reminder,\n        content: \"Забрать со склада 21 заказ\",\n        dueAt: \"2020-06-05T12:00:00.000+03:00\",\n        priority: 2,\n        performerIds: [123],\n        status: .done,\n        allDay: false,\n        doneAt: \"2020-06-05T12:00:00.000Z\",\n        customProperties: [TaskUpdateRequestCustomProperty(id: 78, value: \"Синий склад\")]\n    )\n)\nlet response = try await client.tasks.updateTask(id: 22283, body: body)",
     "output": "Task(id: Int, kind: TaskKind, content: String, dueAt: String?, priority: Int, userId: Int, chatId: Int?, status: TaskStatus, createdAt: String, performerIds: [Int], allDay: Bool, customProperties: [CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)])",
     "imports": [
       "TaskKind",
@@ -304,22 +304,22 @@
     ]
   },
   "TaskOperations_deleteTask": {
-    "usage": "try await client.tasks.deleteTask(id: 123)"
+    "usage": "try await client.tasks.deleteTask(id: 22283)"
   },
   "UserOperations_listUsers": {
-    "usage": "let response = try await client.users.listUsers(query: \"example\", limit: 123, cursor: \"example\")",
+    "usage": "let response = try await client.users.listUsers(query: \"Олег\", limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\")",
     "output": "ListUsersResponse(data: [User], meta: PaginationMeta?)"
   },
   "UserOperations_getUser": {
-    "usage": "let response = try await client.users.getUser(id: 123)",
+    "usage": "let response = try await client.users.getUser(id: 12)",
     "output": "User(id: Int, firstName: String, lastName: String, nickname: String, email: String, phoneNumber: String, department: String, title: String, role: UserRole, suspended: Bool, inviteStatus: InviteStatus, listTags: [String], customProperties: [CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)], userStatus: UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Bool, awayMessage: UserStatusAwayMessage(text: String)?)?, bot: Bool, sso: Bool, createdAt: String, lastActivityAt: String, timeZone: String, imageUrl: String?)"
   },
   "UserStatusOperations_getUserStatus": {
-    "usage": "let response = try await client.users.getUserStatus(userId: 123)",
+    "usage": "let response = try await client.users.getUserStatus(userId: 12)",
     "output": "String"
   },
   "UserOperations_createUser": {
-    "usage": "let body = UserCreateRequest(\n    user: UserCreateRequestUser(\n        firstName: \"example\",\n        lastName: \"example\",\n        email: \"example\",\n        phoneNumber: \"example\",\n        nickname: \"example\",\n        department: \"example\",\n        title: \"example\",\n        role: .admin,\n        suspended: true,\n        listTags: [\"example\"],\n        customProperties: [UserCreateRequestCustomProperty(id: 123, value: \"example\")]\n    ),\n    skipEmailNotify: true\n)\nlet response = try await client.users.createUser(body: body)",
+    "usage": "let body = UserCreateRequest(\n    user: UserCreateRequestUser(\n        firstName: \"Олег\",\n        lastName: \"Петров\",\n        email: \"olegp@example.com\",\n        phoneNumber: \"+79001234567\",\n        nickname: \"olegpetrov\",\n        department: \"Продукт\",\n        title: \"CIO\",\n        role: .user,\n        suspended: false,\n        listTags: [\"example\"],\n        customProperties: [UserCreateRequestCustomProperty(id: 1678, value: \"Санкт-Петербург\")]\n    ),\n    skipEmailNotify: true\n)\nlet response = try await client.users.createUser(body: body)",
     "output": "User(id: Int, firstName: String, lastName: String, nickname: String, email: String, phoneNumber: String, department: String, title: String, role: UserRole, suspended: Bool, inviteStatus: InviteStatus, listTags: [String], customProperties: [CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)], userStatus: UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Bool, awayMessage: UserStatusAwayMessage(text: String)?)?, bot: Bool, sso: Bool, createdAt: String, lastActivityAt: String, timeZone: String, imageUrl: String?)",
     "imports": [
       "UserCreateRequest",
@@ -329,7 +329,7 @@
     ]
   },
   "UserOperations_updateUser": {
-    "usage": "let body = UserUpdateRequest(\n    user: UserUpdateRequestUser(\n        firstName: \"example\",\n        lastName: \"example\",\n        email: \"example\",\n        phoneNumber: \"example\",\n        nickname: \"example\",\n        department: \"example\",\n        title: \"example\",\n        role: .admin,\n        suspended: true,\n        listTags: [\"example\"],\n        customProperties: [UserUpdateRequestCustomProperty(id: 123, value: \"example\")]\n    )\n)\nlet response = try await client.users.updateUser(id: 123, body: body)",
+    "usage": "let body = UserUpdateRequest(\n    user: UserUpdateRequestUser(\n        firstName: \"Олег\",\n        lastName: \"Петров\",\n        email: \"olegpetrov@example.com\",\n        phoneNumber: \"+79001234567\",\n        nickname: \"olegpetrov\",\n        department: \"Отдел разработки\",\n        title: \"Старший разработчик\",\n        role: .user,\n        suspended: false,\n        listTags: [\"example\"],\n        customProperties: [UserUpdateRequestCustomProperty(id: 1678, value: \"Санкт-Петербург\")]\n    )\n)\nlet response = try await client.users.updateUser(id: 12, body: body)",
     "output": "User(id: Int, firstName: String, lastName: String, nickname: String, email: String, phoneNumber: String, department: String, title: String, role: UserRole, suspended: Bool, inviteStatus: InviteStatus, listTags: [String], customProperties: [CustomProperty(id: Int, name: String, dataType: CustomPropertyDataType, value: String)], userStatus: UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Bool, awayMessage: UserStatusAwayMessage(text: String)?)?, bot: Bool, sso: Bool, createdAt: String, lastActivityAt: String, timeZone: String, imageUrl: String?)",
     "imports": [
       "UserRole",
@@ -339,7 +339,7 @@
     ]
   },
   "UserStatusOperations_updateUserStatus": {
-    "usage": "let body = StatusUpdateRequest(\n    status: StatusUpdateRequestStatus(\n        emoji: \"example\",\n        title: \"example\",\n        expiresAt: \"2024-01-01T00:00:00Z\",\n        isAway: true,\n        awayMessage: \"example\"\n    )\n)\nlet response = try await client.users.updateUserStatus(userId: 123, body: body)",
+    "usage": "let body = StatusUpdateRequest(\n    status: StatusUpdateRequestStatus(\n        emoji: \"🎮\",\n        title: \"Очень занят\",\n        expiresAt: \"2024-04-08T10:00:00.000Z\",\n        isAway: true,\n        awayMessage: \"Вернусь после 15:00\"\n    )\n)\nlet response = try await client.users.updateUserStatus(userId: 12, body: body)",
     "output": "UserStatus(emoji: String, title: String, expiresAt: String?, isAway: Bool, awayMessage: UserStatusAwayMessage(text: String)?)",
     "imports": [
       "StatusUpdateRequest",
@@ -347,13 +347,13 @@
     ]
   },
   "UserOperations_deleteUser": {
-    "usage": "try await client.users.deleteUser(id: 123)"
+    "usage": "try await client.users.deleteUser(id: 12)"
   },
   "UserStatusOperations_deleteUserStatus": {
-    "usage": "try await client.users.deleteUserStatus(userId: 123)"
+    "usage": "try await client.users.deleteUserStatus(userId: 12)"
   },
   "FormOperations_openView": {
-    "usage": "let body = OpenViewRequest(\n    type: \"modal\",\n    triggerId: \"example\",\n    privateMetadata: \"example\",\n    callbackId: \"example\",\n    view: OpenViewRequestView(\n        title: \"example\",\n        closeText: \"example\",\n        submitText: \"example\",\n        blocks: [ViewBlockHeader(type: \"header\", text: \"example\")]\n    )\n)\ntry await client.views.openView(body: body)",
+    "usage": "let body = OpenViewRequest(\n    type: \"modal\",\n    triggerId: \"791a056b-006c-49dd-834b-c633fde52fe8\",\n    privateMetadata: \"{\\\"timeoff_id\\\":4378}\",\n    callbackId: \"timeoff_reguest_form\",\n    view: OpenViewRequestView(\n        title: \"Уведомление об отпуске\",\n        closeText: \"Закрыть\",\n        submitText: \"Отправить заявку\",\n        blocks: [ViewBlockHeader(type: \"header\", text: \"Основная информация\")]\n    )\n)\ntry await client.views.openView(body: body)",
     "imports": [
       "OpenViewRequest",
       "OpenViewRequestView",

--- a/sdk/typescript/src/generated/examples.json
+++ b/sdk/typescript/src/generated/examples.json
@@ -3,18 +3,18 @@
     "usage": "import { PachcaClient } from \"@pachca/sdk\"\n\nconst client = new PachcaClient(\"YOUR_TOKEN\")"
   },
   "SecurityOperations_getAuditEvents": {
-    "usage": "const response = client.security.getAuditEvents({\n  startTime: \"2024-01-01T00:00:00Z\",\n  endTime: \"2024-01-01T00:00:00Z\",\n  eventKey: AuditEventKey.UserLogin,\n  actorId: \"example\",\n  actorType: \"example\",\n  entityId: \"example\",\n  entityType: \"example\",\n  limit: 123,\n  cursor: \"example\"\n})",
+    "usage": "const response = client.security.getAuditEvents({\n  startTime: \"2025-05-01T09:11:00Z\",\n  endTime: \"2025-05-02T09:11:00Z\",\n  eventKey: AuditEventKey.UserLogin,\n  actorId: \"98765\",\n  actorType: \"User\",\n  entityId: \"98765\",\n  entityType: \"User\",\n  limit: 1,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n})",
     "output": "GetAuditEventsResponse({ data: AuditEvent[], meta?: PaginationMeta })",
     "imports": [
       "AuditEventKey"
     ]
   },
   "BotOperations_getWebhookEvents": {
-    "usage": "const response = client.bots.getWebhookEvents({ limit: 123, cursor: \"example\" })",
+    "usage": "const response = client.bots.getWebhookEvents({ limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\" })",
     "output": "GetWebhookEventsResponse({ data: WebhookEvent[], meta?: PaginationMeta })"
   },
   "BotOperations_updateBot": {
-    "usage": "const request: BotUpdateRequest = { bot: { webhook: { outgoingUrl: \"example\" } } }\nconst response = client.bots.updateBot(123, request)",
+    "usage": "const request: BotUpdateRequest = { bot: { webhook: { outgoingUrl: \"https://www.website.com/tasks/new\" } } }\nconst response = client.bots.updateBot(1738816, request)",
     "output": "BotResponse({ id: number, webhook: BotResponseWebhook({ outgoingUrl: string }) })",
     "imports": [
       "BotUpdateRequest",
@@ -23,10 +23,10 @@
     ]
   },
   "BotOperations_deleteWebhookEvent": {
-    "usage": "client.bots.deleteWebhookEvent(\"example\")"
+    "usage": "client.bots.deleteWebhookEvent(\"01KAJZ2XDSS2S3DSW9EXJZ0TBV\")"
   },
   "ChatOperations_listChats": {
-    "usage": "const response = client.chats.listChats({\n  sortId: SortOrder.Asc,\n  availability: ChatAvailability.IsMember,\n  lastMessageAtAfter: \"2024-01-01T00:00:00Z\",\n  lastMessageAtBefore: \"2024-01-01T00:00:00Z\",\n  personal: true,\n  limit: 123,\n  cursor: \"example\"\n})",
+    "usage": "const response = client.chats.listChats({\n  sortId: SortOrder.Desc,\n  availability: ChatAvailability.IsMember,\n  lastMessageAtAfter: \"2025-01-01T00:00:00.000Z\",\n  lastMessageAtBefore: \"2025-02-01T00:00:00.000Z\",\n  personal: false,\n  limit: 1,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n})",
     "output": "ListChatsResponse({ data: Chat[], meta?: PaginationMeta })",
     "imports": [
       "ChatAvailability",
@@ -34,11 +34,11 @@
     ]
   },
   "ChatOperations_getChat": {
-    "usage": "const response = client.chats.getChat(123)",
+    "usage": "const response = client.chats.getChat(334)",
     "output": "Chat({ id: number, name: string, createdAt: string, ownerId: number, memberIds: number[], groupTagIds: number[], channel: boolean, personal: boolean, public: boolean, lastMessageAt: string, meetRoomUrl: string })"
   },
   "ChatOperations_createChat": {
-    "usage": "const request: ChatCreateRequest = {\n  chat: {\n    name: \"example\",\n    memberIds: [123],\n    groupTagIds: [123],\n    channel: true,\n    public: true\n  }\n}\nconst response = client.chats.createChat(request)",
+    "usage": "const request: ChatCreateRequest = {\n  chat: {\n    name: \"🤿 aqua\",\n    memberIds: [123],\n    groupTagIds: [123],\n    channel: true,\n    public: false\n  }\n}\nconst response = client.chats.createChat(request)",
     "output": "Chat({ id: number, name: string, createdAt: string, ownerId: number, memberIds: number[], groupTagIds: number[], channel: boolean, personal: boolean, public: boolean, lastMessageAt: string, meetRoomUrl: string })",
     "imports": [
       "ChatCreateRequest",
@@ -46,7 +46,7 @@
     ]
   },
   "ChatOperations_updateChat": {
-    "usage": "const request: ChatUpdateRequest = { chat: { name: \"example\", public: true } }\nconst response = client.chats.updateChat(123, request)",
+    "usage": "const request: ChatUpdateRequest = { chat: { name: \"Бассейн\", public: true } }\nconst response = client.chats.updateChat(334, request)",
     "output": "Chat({ id: number, name: string, createdAt: string, ownerId: number, memberIds: number[], groupTagIds: number[], channel: boolean, personal: boolean, public: boolean, lastMessageAt: string, meetRoomUrl: string })",
     "imports": [
       "ChatUpdateRequest",
@@ -54,13 +54,13 @@
     ]
   },
   "ChatOperations_archiveChat": {
-    "usage": "client.chats.archiveChat(123)"
+    "usage": "client.chats.archiveChat(334)"
   },
   "ChatOperations_unarchiveChat": {
-    "usage": "client.chats.unarchiveChat(123)"
+    "usage": "client.chats.unarchiveChat(334)"
   },
   "ExportOperations_downloadExport": {
-    "usage": "const response = client.common.downloadExport(123)",
+    "usage": "const response = client.common.downloadExport(22322)",
     "output": "string"
   },
   "CommonOperations_listProperties": {
@@ -71,7 +71,7 @@
     ]
   },
   "ExportOperations_requestExport": {
-    "usage": "const request: ExportRequest = {\n  startAt: \"2024-01-01\",\n  endAt: \"2024-01-01\",\n  webhookUrl: \"example\",\n  chatIds: [123],\n  skipChatsFile: true\n}\nclient.common.requestExport(request)",
+    "usage": "const request: ExportRequest = {\n  startAt: \"2025-03-20\",\n  endAt: \"2025-03-20\",\n  webhookUrl: \"https://webhook.site/9227d3b8-6e82-4e64-bf5d-ad972ad270f2\",\n  chatIds: [123],\n  skipChatsFile: false\n}\nclient.common.requestExport(request)",
     "imports": [
       "ExportRequest"
     ]
@@ -87,53 +87,53 @@
     "output": "UploadParams({ contentDisposition: string, acl: string, policy: string, xAmzCredential: string, xAmzAlgorithm: string, xAmzDate: string, xAmzSignature: string, key: string, directUrl: string })"
   },
   "ChatMemberOperations_listMembers": {
-    "usage": "const response = client.members.listMembers(123, {\n  role: ChatMemberRoleFilter.All,\n  limit: 123,\n  cursor: \"example\"\n})",
+    "usage": "const response = client.members.listMembers(334, {\n  role: ChatMemberRoleFilter.All,\n  limit: 1,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n})",
     "output": "ListMembersResponse({ data: User[], meta?: PaginationMeta })",
     "imports": [
       "ChatMemberRoleFilter"
     ]
   },
   "ChatMemberOperations_addTags": {
-    "usage": "const groupTagIds = [123]\nclient.members.addTags(123, groupTagIds)"
+    "usage": "const groupTagIds = [123]\nclient.members.addTags(334, groupTagIds)"
   },
   "ChatMemberOperations_addMembers": {
-    "usage": "const request: AddMembersRequest = { memberIds: [123], silent: true }\nclient.members.addMembers(123, request)",
+    "usage": "const request: AddMembersRequest = { memberIds: [123], silent: true }\nclient.members.addMembers(334, request)",
     "imports": [
       "AddMembersRequest"
     ]
   },
   "ChatMemberOperations_updateMemberRole": {
-    "usage": "client.members.updateMemberRole(123, 123, ChatMemberRole.Admin)",
+    "usage": "client.members.updateMemberRole(334, 186, ChatMemberRole.Admin)",
     "imports": [
       "ChatMemberRole"
     ]
   },
   "ChatMemberOperations_removeTag": {
-    "usage": "client.members.removeTag(123, 123)"
+    "usage": "client.members.removeTag(334, 86)"
   },
   "ChatMemberOperations_leaveChat": {
-    "usage": "client.members.leaveChat(123)"
+    "usage": "client.members.leaveChat(334)"
   },
   "ChatMemberOperations_removeMember": {
-    "usage": "client.members.removeMember(123, 123)"
+    "usage": "client.members.removeMember(334, 186)"
   },
   "GroupTagOperations_listTags": {
-    "usage": "const response = client.groupTags.listTags({\n  names: {},\n  limit: 123,\n  cursor: \"example\"\n})",
+    "usage": "const response = client.groupTags.listTags({\n  names: {},\n  limit: 1,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n})",
     "output": "ListTagsResponse({ data: GroupTag[], meta?: PaginationMeta })",
     "imports": [
       "TagNamesFilter"
     ]
   },
   "GroupTagOperations_getTag": {
-    "usage": "const response = client.groupTags.getTag(123)",
+    "usage": "const response = client.groupTags.getTag(9111)",
     "output": "GroupTag({ id: number, name: string, usersCount: number })"
   },
   "GroupTagOperations_getTagUsers": {
-    "usage": "const response = client.groupTags.getTagUsers(123, { limit: 123, cursor: \"example\" })",
+    "usage": "const response = client.groupTags.getTagUsers(9111, { limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\" })",
     "output": "GetTagUsersResponse({ data: User[], meta?: PaginationMeta })"
   },
   "GroupTagOperations_createTag": {
-    "usage": "const request: GroupTagRequest = { groupTag: { name: \"example\" } }\nconst response = client.groupTags.createTag(request)",
+    "usage": "const request: GroupTagRequest = { groupTag: { name: \"Новое название тега\" } }\nconst response = client.groupTags.createTag(request)",
     "output": "GroupTag({ id: number, name: string, usersCount: number })",
     "imports": [
       "GroupTagRequest",
@@ -141,7 +141,7 @@
     ]
   },
   "GroupTagOperations_updateTag": {
-    "usage": "const request: GroupTagRequest = { groupTag: { name: \"example\" } }\nconst response = client.groupTags.updateTag(123, request)",
+    "usage": "const request: GroupTagRequest = { groupTag: { name: \"Новое название тега\" } }\nconst response = client.groupTags.updateTag(9111, request)",
     "output": "GroupTag({ id: number, name: string, usersCount: number })",
     "imports": [
       "GroupTagRequest",
@@ -149,21 +149,21 @@
     ]
   },
   "GroupTagOperations_deleteTag": {
-    "usage": "client.groupTags.deleteTag(123)"
+    "usage": "client.groupTags.deleteTag(9111)"
   },
   "ChatMessageOperations_listChatMessages": {
-    "usage": "const response = client.messages.listChatMessages({\n  chatId: 123,\n  sortId: SortOrder.Asc,\n  limit: 123,\n  cursor: \"example\"\n})",
+    "usage": "const response = client.messages.listChatMessages({\n  chatId: 198,\n  sortId: SortOrder.Desc,\n  limit: 1,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n})",
     "output": "ListChatMessagesResponse({ data: Message[], meta?: PaginationMeta })",
     "imports": [
       "SortOrder"
     ]
   },
   "MessageOperations_getMessage": {
-    "usage": "const response = client.messages.getMessage(123)",
+    "usage": "const response = client.messages.getMessage(194275)",
     "output": "Message({ id: number, entityType: MessageEntityType, entityId: number, chatId: number, rootChatId: number, content: string, userId: number, createdAt: string, url: string, files: File({ id: number, key: string, name: string, fileType: FileType, url: string, width?: number | null, height?: number | null })[], buttons: Button({ text: string, url?: string, data?: string })[][] | null, thread: Thread({ id: number, chatId: number, messageId: number, messageChatId: number, updatedAt: string }) | null, forwarding: Forwarding({ originalMessageId: number, originalChatId: number, authorId: number, originalCreatedAt: string, originalThreadId: number | null, originalThreadMessageId: number | null, originalThreadParentChatId: number | null }) | null, parentMessageId: number | null, displayAvatarUrl: string | null, displayName: string | null, changedAt: string | null, deletedAt: string | null })"
   },
   "MessageOperations_createMessage": {
-    "usage": "const request: MessageCreateRequest = {\n  message: {\n    entityType: MessageEntityType.Discussion,\n    entityId: 123,\n    content: \"example\",\n    files: [{\n      key: \"example\",\n      name: \"example\",\n      fileType: FileType.File,\n      size: 123,\n      width: 123,\n      height: 123\n    }],\n    buttons: [[{\n      text: \"example\",\n      url: \"example\",\n      data: \"example\"\n    }]],\n    parentMessageId: 123,\n    displayAvatarUrl: \"example\",\n    displayName: \"example\",\n    skipInviteMentions: true,\n    linkPreview: true\n  }\n}\nconst response = client.messages.createMessage(request)",
+    "usage": "const request: MessageCreateRequest = {\n  message: {\n    entityType: MessageEntityType.Discussion,\n    entityId: 334,\n    content: \"Вчера мы продали 756 футболок (что на 10% больше, чем в прошлое воскресенье)\",\n    files: [{\n      key: \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n      name: \"logo.png\",\n      fileType: FileType.Image,\n      size: 12345,\n      width: 800,\n      height: 600\n    }],\n    buttons: [[{\n      text: \"Подробнее\",\n      url: \"https://example.com/details\",\n      data: \"awesome\"\n    }]],\n    parentMessageId: 194270,\n    displayAvatarUrl: \"https://example.com/avatar.png\",\n    displayName: \"Бот Поддержки\",\n    skipInviteMentions: false,\n    linkPreview: false\n  }\n}\nconst response = client.messages.createMessage(request)",
     "output": "Message({ id: number, entityType: MessageEntityType, entityId: number, chatId: number, rootChatId: number, content: string, userId: number, createdAt: string, url: string, files: File({ id: number, key: string, name: string, fileType: FileType, url: string, width?: number | null, height?: number | null })[], buttons: Button({ text: string, url?: string, data?: string })[][] | null, thread: Thread({ id: number, chatId: number, messageId: number, messageChatId: number, updatedAt: string }) | null, forwarding: Forwarding({ originalMessageId: number, originalChatId: number, authorId: number, originalCreatedAt: string, originalThreadId: number | null, originalThreadMessageId: number | null, originalThreadParentChatId: number | null }) | null, parentMessageId: number | null, displayAvatarUrl: string | null, displayName: string | null, changedAt: string | null, deletedAt: string | null })",
     "imports": [
       "Button",
@@ -175,10 +175,10 @@
     ]
   },
   "MessageOperations_pinMessage": {
-    "usage": "client.messages.pinMessage(123)"
+    "usage": "client.messages.pinMessage(194275)"
   },
   "MessageOperations_updateMessage": {
-    "usage": "const request: MessageUpdateRequest = {\n  message: {\n    content: \"example\",\n    files: [{\n      key: \"example\",\n      name: \"example\",\n      fileType: \"example\",\n      size: 123,\n      width: 123,\n      height: 123\n    }],\n    buttons: [[{\n      text: \"example\",\n      url: \"example\",\n      data: \"example\"\n    }]],\n    displayAvatarUrl: \"example\",\n    displayName: \"example\"\n  }\n}\nconst response = client.messages.updateMessage(123, request)",
+    "usage": "const request: MessageUpdateRequest = {\n  message: {\n    content: \"Вот попробуйте написать правильно это с первого раза: Будущий, Полощи, Прийти, Грейпфрут, Мозаика, Бюллетень, Дуршлаг, Винегрет.\",\n    files: [{\n      key: \"attaches/files/93746/e354fd79-4f3e-4b5a-9c8d-1a2b3c4d5e6f/logo.png\",\n      name: \"logo.png\",\n      fileType: \"image\",\n      size: 12345,\n      width: 800,\n      height: 600\n    }],\n    buttons: [[{\n      text: \"Подробнее\",\n      url: \"https://example.com/details\",\n      data: \"awesome\"\n    }]],\n    displayAvatarUrl: \"https://example.com/avatar.png\",\n    displayName: \"Бот Поддержки\"\n  }\n}\nconst response = client.messages.updateMessage(194275, request)",
     "output": "Message({ id: number, entityType: MessageEntityType, entityId: number, chatId: number, rootChatId: number, content: string, userId: number, createdAt: string, url: string, files: File({ id: number, key: string, name: string, fileType: FileType, url: string, width?: number | null, height?: number | null })[], buttons: Button({ text: string, url?: string, data?: string })[][] | null, thread: Thread({ id: number, chatId: number, messageId: number, messageChatId: number, updatedAt: string }) | null, forwarding: Forwarding({ originalMessageId: number, originalChatId: number, authorId: number, originalCreatedAt: string, originalThreadId: number | null, originalThreadMessageId: number | null, originalThreadParentChatId: number | null }) | null, parentMessageId: number | null, displayAvatarUrl: string | null, displayName: string | null, changedAt: string | null, deletedAt: string | null })",
     "imports": [
       "Button",
@@ -188,13 +188,13 @@
     ]
   },
   "MessageOperations_deleteMessage": {
-    "usage": "client.messages.deleteMessage(123)"
+    "usage": "client.messages.deleteMessage(194275)"
   },
   "MessageOperations_unpinMessage": {
-    "usage": "client.messages.unpinMessage(123)"
+    "usage": "client.messages.unpinMessage(194275)"
   },
   "LinkPreviewOperations_createLinkPreviews": {
-    "usage": "const request: LinkPreviewsRequest = {\n  linkPreviews: { key: {\n    title: \"example\",\n    description: \"example\",\n    imageUrl: \"example\",\n    image: {\n      key: \"example\",\n      name: \"example\",\n      size: 123\n    }\n  } }\n}\nclient.linkPreviews.createLinkPreviews(123, request)",
+    "usage": "const request: LinkPreviewsRequest = {\n  linkPreviews: { key: {\n    title: \"Статья: Отправка файлов\",\n    description: \"Пример отправки файлов на удаленный сервер\",\n    imageUrl: \"https://website.com/img/landing.png\",\n    image: {\n      key: \"attaches/files/93746/e354fd79-9jh6-f2hd-fj83-709dae24c763/${filename}\",\n      name: \"files-to-server.jpg\",\n      size: 695604\n    }\n  } }\n}\nclient.linkPreviews.createLinkPreviews(194275, request)",
     "imports": [
       "LinkPreview",
       "LinkPreviewImage",
@@ -202,29 +202,29 @@
     ]
   },
   "ReactionOperations_listReactions": {
-    "usage": "const response = client.reactions.listReactions(123, { limit: 123, cursor: \"example\" })",
+    "usage": "const response = client.reactions.listReactions(194275, { limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\" })",
     "output": "ListReactionsResponse({ data: Reaction[], meta?: PaginationMeta })"
   },
   "ReactionOperations_addReaction": {
-    "usage": "const request: ReactionRequest = { code: \"example\", name: \"example\" }\nconst response = client.reactions.addReaction(123, request)",
+    "usage": "const request: ReactionRequest = { code: \"👍\", name: \":+1:\" }\nconst response = client.reactions.addReaction(7231942, request)",
     "output": "Reaction({ userId: number, createdAt: string, code: string, name?: string })",
     "imports": [
       "ReactionRequest"
     ]
   },
   "ReactionOperations_removeReaction": {
-    "usage": "client.reactions.removeReaction(123, { code: \"example\", name: \"example\" })"
+    "usage": "client.reactions.removeReaction(7231942, { code: \"👍\", name: \":+1:\" })"
   },
   "ReadMemberOperations_listReadMembers": {
-    "usage": "const response = client.readMembers.listReadMembers(123, { limit: 123, cursor: \"example\" })",
+    "usage": "const response = client.readMembers.listReadMembers(194275, { limit: 300, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\" })",
     "output": "unknown"
   },
   "ThreadOperations_getThread": {
-    "usage": "const response = client.threads.getThread(123)",
+    "usage": "const response = client.threads.getThread(265142)",
     "output": "Thread({ id: number, chatId: number, messageId: number, messageChatId: number, updatedAt: string })"
   },
   "ThreadOperations_createThread": {
-    "usage": "const response = client.threads.createThread(123)",
+    "usage": "const response = client.threads.createThread(154332686)",
     "output": "Thread({ id: number, chatId: number, messageId: number, messageChatId: number, updatedAt: string })"
   },
   "OAuthOperations_getTokenInfo": {
@@ -240,7 +240,7 @@
     "output": "unknown"
   },
   "ProfileOperations_updateStatus": {
-    "usage": "const request: StatusUpdateRequest = {\n  status: {\n    emoji: \"example\",\n    title: \"example\",\n    expiresAt: \"2024-01-01T00:00:00Z\",\n    isAway: true,\n    awayMessage: \"example\"\n  }\n}\nconst response = client.profile.updateStatus(request)",
+    "usage": "const request: StatusUpdateRequest = {\n  status: {\n    emoji: \"🎮\",\n    title: \"Очень занят\",\n    expiresAt: \"2024-04-08T10:00:00.000Z\",\n    isAway: true,\n    awayMessage: \"Вернусь после 15:00\"\n  }\n}\nconst response = client.profile.updateStatus(request)",
     "output": "UserStatus({ emoji: string, title: string, expiresAt: string | null, isAway: boolean, awayMessage: UserStatusAwayMessage({ text: string }) | null })",
     "imports": [
       "StatusUpdateRequest",
@@ -251,7 +251,7 @@
     "usage": "client.profile.deleteStatus()"
   },
   "SearchOperations_searchChats": {
-    "usage": "const response = client.search.searchChats({\n  query: \"example\",\n  limit: 123,\n  cursor: \"example\",\n  order: SortOrder.Asc,\n  createdFrom: \"2024-01-01T00:00:00Z\",\n  createdTo: \"2024-01-01T00:00:00Z\",\n  active: true,\n  chatSubtype: ChatSubtype.Discussion,\n  personal: true\n})",
+    "usage": "const response = client.search.searchChats({\n  query: \"Разработка\",\n  limit: 10,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\",\n  order: SortOrder.Desc,\n  createdFrom: \"2025-01-01T00:00:00.000Z\",\n  createdTo: \"2025-02-01T00:00:00.000Z\",\n  active: true,\n  chatSubtype: ChatSubtype.Discussion,\n  personal: false\n})",
     "output": "SearchChatsResponse({ data: Chat[], meta: SearchPaginationMeta })",
     "imports": [
       "ChatSubtype",
@@ -259,14 +259,14 @@
     ]
   },
   "SearchOperations_searchMessages": {
-    "usage": "const response = client.search.searchMessages({\n  query: \"example\",\n  limit: 123,\n  cursor: \"example\",\n  order: SortOrder.Asc,\n  createdFrom: \"2024-01-01T00:00:00Z\",\n  createdTo: \"2024-01-01T00:00:00Z\",\n  chatIds: [123],\n  userIds: [123],\n  active: true\n})",
+    "usage": "const response = client.search.searchMessages({\n  query: \"футболки\",\n  limit: 10,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\",\n  order: SortOrder.Desc,\n  createdFrom: \"2025-01-01T00:00:00.000Z\",\n  createdTo: \"2025-02-01T00:00:00.000Z\",\n  chatIds: [123],\n  userIds: [123],\n  active: true\n})",
     "output": "SearchMessagesResponse({ data: Message[], meta: SearchPaginationMeta })",
     "imports": [
       "SortOrder"
     ]
   },
   "SearchOperations_searchUsers": {
-    "usage": "const response = client.search.searchUsers({\n  query: \"example\",\n  limit: 123,\n  cursor: \"example\",\n  sort: SearchSortOrder.ByScore,\n  order: SortOrder.Asc,\n  createdFrom: \"2024-01-01T00:00:00Z\",\n  createdTo: \"2024-01-01T00:00:00Z\",\n  companyRoles: [UserRole.Admin]\n})",
+    "usage": "const response = client.search.searchUsers({\n  query: \"Олег\",\n  limit: 10,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\",\n  sort: SearchSortOrder.ByScore,\n  order: SortOrder.Desc,\n  createdFrom: \"2025-01-01T00:00:00.000Z\",\n  createdTo: \"2025-02-01T00:00:00.000Z\",\n  companyRoles: [UserRole.Admin]\n})",
     "output": "SearchUsersResponse({ data: User[], meta: SearchPaginationMeta })",
     "imports": [
       "SearchSortOrder",
@@ -275,15 +275,15 @@
     ]
   },
   "TaskOperations_listTasks": {
-    "usage": "const response = client.tasks.listTasks({ limit: 123, cursor: \"example\" })",
+    "usage": "const response = client.tasks.listTasks({ limit: 1, cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\" })",
     "output": "ListTasksResponse({ data: Task[], meta?: PaginationMeta })"
   },
   "TaskOperations_getTask": {
-    "usage": "const response = client.tasks.getTask(123)",
+    "usage": "const response = client.tasks.getTask(22283)",
     "output": "Task({ id: number, kind: TaskKind, content: string, dueAt: string | null, priority: number, userId: number, chatId: number | null, status: TaskStatus, createdAt: string, performerIds: number[], allDay: boolean, customProperties: CustomProperty({ id: number, name: string, dataType: CustomPropertyDataType, value: string })[] })"
   },
   "TaskOperations_createTask": {
-    "usage": "const request: TaskCreateRequest = {\n  task: {\n    kind: TaskKind.Call,\n    content: \"example\",\n    dueAt: \"2024-01-01T00:00:00Z\",\n    priority: 123,\n    performerIds: [123],\n    chatId: 123,\n    allDay: true,\n    customProperties: [{ id: 123, value: \"example\" }]\n  }\n}\nconst response = client.tasks.createTask(request)",
+    "usage": "const request: TaskCreateRequest = {\n  task: {\n    kind: TaskKind.Reminder,\n    content: \"Забрать со склада 21 заказ\",\n    dueAt: \"2020-06-05T12:00:00.000+03:00\",\n    priority: 2,\n    performerIds: [123],\n    chatId: 456,\n    allDay: false,\n    customProperties: [{ id: 78, value: \"Синий склад\" }]\n  }\n}\nconst response = client.tasks.createTask(request)",
     "output": "Task({ id: number, kind: TaskKind, content: string, dueAt: string | null, priority: number, userId: number, chatId: number | null, status: TaskStatus, createdAt: string, performerIds: number[], allDay: boolean, customProperties: CustomProperty({ id: number, name: string, dataType: CustomPropertyDataType, value: string })[] })",
     "imports": [
       "TaskCreateRequest",
@@ -293,7 +293,7 @@
     ]
   },
   "TaskOperations_updateTask": {
-    "usage": "const request: TaskUpdateRequest = {\n  task: {\n    kind: TaskKind.Call,\n    content: \"example\",\n    dueAt: \"2024-01-01T00:00:00Z\",\n    priority: 123,\n    performerIds: [123],\n    status: TaskStatus.Done,\n    allDay: true,\n    doneAt: \"2024-01-01T00:00:00Z\",\n    customProperties: [{ id: 123, value: \"example\" }]\n  }\n}\nconst response = client.tasks.updateTask(123, request)",
+    "usage": "const request: TaskUpdateRequest = {\n  task: {\n    kind: TaskKind.Reminder,\n    content: \"Забрать со склада 21 заказ\",\n    dueAt: \"2020-06-05T12:00:00.000+03:00\",\n    priority: 2,\n    performerIds: [123],\n    status: TaskStatus.Done,\n    allDay: false,\n    doneAt: \"2020-06-05T12:00:00.000Z\",\n    customProperties: [{ id: 78, value: \"Синий склад\" }]\n  }\n}\nconst response = client.tasks.updateTask(22283, request)",
     "output": "Task({ id: number, kind: TaskKind, content: string, dueAt: string | null, priority: number, userId: number, chatId: number | null, status: TaskStatus, createdAt: string, performerIds: number[], allDay: boolean, customProperties: CustomProperty({ id: number, name: string, dataType: CustomPropertyDataType, value: string })[] })",
     "imports": [
       "TaskKind",
@@ -304,22 +304,22 @@
     ]
   },
   "TaskOperations_deleteTask": {
-    "usage": "client.tasks.deleteTask(123)"
+    "usage": "client.tasks.deleteTask(22283)"
   },
   "UserOperations_listUsers": {
-    "usage": "const response = client.users.listUsers({\n  query: \"example\",\n  limit: 123,\n  cursor: \"example\"\n})",
+    "usage": "const response = client.users.listUsers({\n  query: \"Олег\",\n  limit: 1,\n  cursor: \"eyJpZCI6MTAsImRpciI6ImFzYyJ9\"\n})",
     "output": "ListUsersResponse({ data: User[], meta?: PaginationMeta })"
   },
   "UserOperations_getUser": {
-    "usage": "const response = client.users.getUser(123)",
+    "usage": "const response = client.users.getUser(12)",
     "output": "User({ id: number, firstName: string, lastName: string, nickname: string, email: string, phoneNumber: string, department: string, title: string, role: UserRole, suspended: boolean, inviteStatus: InviteStatus, listTags: string[], customProperties: CustomProperty({ id: number, name: string, dataType: CustomPropertyDataType, value: string })[], userStatus: UserStatus({ emoji: string, title: string, expiresAt: string | null, isAway: boolean, awayMessage: UserStatusAwayMessage({ text: string }) | null }) | null, bot: boolean, sso: boolean, createdAt: string, lastActivityAt: string, timeZone: string, imageUrl: string | null })"
   },
   "UserStatusOperations_getUserStatus": {
-    "usage": "const response = client.users.getUserStatus(123)",
+    "usage": "const response = client.users.getUserStatus(12)",
     "output": "unknown"
   },
   "UserOperations_createUser": {
-    "usage": "const request: UserCreateRequest = {\n  user: {\n    firstName: \"example\",\n    lastName: \"example\",\n    email: \"example\",\n    phoneNumber: \"example\",\n    nickname: \"example\",\n    department: \"example\",\n    title: \"example\",\n    role: UserRole.Admin,\n    suspended: true,\n    listTags: [\"example\"],\n    customProperties: [{ id: 123, value: \"example\" }]\n  },\n  skipEmailNotify: true\n}\nconst response = client.users.createUser(request)",
+    "usage": "const request: UserCreateRequest = {\n  user: {\n    firstName: \"Олег\",\n    lastName: \"Петров\",\n    email: \"olegp@example.com\",\n    phoneNumber: \"+79001234567\",\n    nickname: \"olegpetrov\",\n    department: \"Продукт\",\n    title: \"CIO\",\n    role: UserRole.User,\n    suspended: false,\n    listTags: [\"example\"],\n    customProperties: [{ id: 1678, value: \"Санкт-Петербург\" }]\n  },\n  skipEmailNotify: true\n}\nconst response = client.users.createUser(request)",
     "output": "User({ id: number, firstName: string, lastName: string, nickname: string, email: string, phoneNumber: string, department: string, title: string, role: UserRole, suspended: boolean, inviteStatus: InviteStatus, listTags: string[], customProperties: CustomProperty({ id: number, name: string, dataType: CustomPropertyDataType, value: string })[], userStatus: UserStatus({ emoji: string, title: string, expiresAt: string | null, isAway: boolean, awayMessage: UserStatusAwayMessage({ text: string }) | null }) | null, bot: boolean, sso: boolean, createdAt: string, lastActivityAt: string, timeZone: string, imageUrl: string | null })",
     "imports": [
       "UserCreateRequest",
@@ -329,7 +329,7 @@
     ]
   },
   "UserOperations_updateUser": {
-    "usage": "const request: UserUpdateRequest = {\n  user: {\n    firstName: \"example\",\n    lastName: \"example\",\n    email: \"example\",\n    phoneNumber: \"example\",\n    nickname: \"example\",\n    department: \"example\",\n    title: \"example\",\n    role: UserRole.Admin,\n    suspended: true,\n    listTags: [\"example\"],\n    customProperties: [{ id: 123, value: \"example\" }]\n  }\n}\nconst response = client.users.updateUser(123, request)",
+    "usage": "const request: UserUpdateRequest = {\n  user: {\n    firstName: \"Олег\",\n    lastName: \"Петров\",\n    email: \"olegpetrov@example.com\",\n    phoneNumber: \"+79001234567\",\n    nickname: \"olegpetrov\",\n    department: \"Отдел разработки\",\n    title: \"Старший разработчик\",\n    role: UserRole.User,\n    suspended: false,\n    listTags: [\"example\"],\n    customProperties: [{ id: 1678, value: \"Санкт-Петербург\" }]\n  }\n}\nconst response = client.users.updateUser(12, request)",
     "output": "User({ id: number, firstName: string, lastName: string, nickname: string, email: string, phoneNumber: string, department: string, title: string, role: UserRole, suspended: boolean, inviteStatus: InviteStatus, listTags: string[], customProperties: CustomProperty({ id: number, name: string, dataType: CustomPropertyDataType, value: string })[], userStatus: UserStatus({ emoji: string, title: string, expiresAt: string | null, isAway: boolean, awayMessage: UserStatusAwayMessage({ text: string }) | null }) | null, bot: boolean, sso: boolean, createdAt: string, lastActivityAt: string, timeZone: string, imageUrl: string | null })",
     "imports": [
       "UserRole",
@@ -339,7 +339,7 @@
     ]
   },
   "UserStatusOperations_updateUserStatus": {
-    "usage": "const request: StatusUpdateRequest = {\n  status: {\n    emoji: \"example\",\n    title: \"example\",\n    expiresAt: \"2024-01-01T00:00:00Z\",\n    isAway: true,\n    awayMessage: \"example\"\n  }\n}\nconst response = client.users.updateUserStatus(123, request)",
+    "usage": "const request: StatusUpdateRequest = {\n  status: {\n    emoji: \"🎮\",\n    title: \"Очень занят\",\n    expiresAt: \"2024-04-08T10:00:00.000Z\",\n    isAway: true,\n    awayMessage: \"Вернусь после 15:00\"\n  }\n}\nconst response = client.users.updateUserStatus(12, request)",
     "output": "UserStatus({ emoji: string, title: string, expiresAt: string | null, isAway: boolean, awayMessage: UserStatusAwayMessage({ text: string }) | null })",
     "imports": [
       "StatusUpdateRequest",
@@ -347,13 +347,13 @@
     ]
   },
   "UserOperations_deleteUser": {
-    "usage": "client.users.deleteUser(123)"
+    "usage": "client.users.deleteUser(12)"
   },
   "UserStatusOperations_deleteUserStatus": {
-    "usage": "client.users.deleteUserStatus(123)"
+    "usage": "client.users.deleteUserStatus(12)"
   },
   "FormOperations_openView": {
-    "usage": "const request: OpenViewRequest = {\n  type: \"modal\",\n  triggerId: \"example\",\n  privateMetadata: \"example\",\n  callbackId: \"example\",\n  view: {\n    title: \"example\",\n    closeText: \"example\",\n    submitText: \"example\",\n    blocks: [{ type: \"header\", text: \"example\" }]\n  }\n}\nclient.views.openView(request)",
+    "usage": "const request: OpenViewRequest = {\n  type: \"modal\",\n  triggerId: \"791a056b-006c-49dd-834b-c633fde52fe8\",\n  privateMetadata: \"{\\\"timeoff_id\\\":4378}\",\n  callbackId: \"timeoff_reguest_form\",\n  view: {\n    title: \"Уведомление об отпуске\",\n    closeText: \"Закрыть\",\n    submitText: \"Отправить заявку\",\n    blocks: [{ type: \"header\", text: \"Основная информация\" }]\n  }\n}\nclient.views.openView(request)",
     "imports": [
       "OpenViewRequest",
       "OpenViewRequestView",


### PR DESCRIPTION
## Summary

- Add `example` field to `IRFieldType` and populate it from OpenAPI spec in `transform.ts`
- All 5 language literal generators read `ft.example` for realistic values (e.g., `334` instead of `123`, `"🤿 aqua"` instead of `"example"`)
- Fix union ref resolution in example literals across all languages

## Test plan

- [x] All 19 snapshot tests pass
- [x] Type-check passes
- [x] Regenerated examples.json for all 5 SDKs with real spec values

🤖 Generated with [Claude Code](https://claude.com/claude-code)