### PR TITLE
fix: correct Python SDK package name (pachca → pachca-sdk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/pachca/openapi/actions/workflows/check.yml/badge.svg)](https://github.com/pachca/openapi/actions/workflows/check.yml)
 [![npm](https://img.shields.io/npm/v/@pachca/sdk)](https://www.npmjs.com/package/@pachca/sdk)
 [![npm](https://img.shields.io/npm/v/@pachca/cli)](https://www.npmjs.com/package/@pachca/cli)
-[![PyPI](https://img.shields.io/pypi/v/pachca)](https://pypi.org/project/pachca/)
+[![PyPI](https://img.shields.io/pypi/v/pachca-sdk)](https://pypi.org/project/pachca-sdk/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Unified Developer Experience Platform для [Pachca API](https://dev.pachca.com) — API корпоративного мессенджера Пачка. Один источник (TypeSpec + workflows.ts) генерирует артефакты для всех каналов: web docs, CLI, SDK, agent skills, LLM context.

--- a/apps/docs/content/api/sdk.mdx
+++ b/apps/docs/content/api/sdk.mdx
@@ -33,12 +33,12 @@ const allUsers = await pachca.users.listUsersAll();
 
 ## Python
 
-<PackageBadge name="pachca" href="https://pypi.org/project/pachca/" />
+<PackageBadge name="pachca-sdk" href="https://pypi.org/project/pachca-sdk/" />
 
 Установите пакет из PyPI:
 
 ```bash
-pip install pachca
+pip install pachca-sdk
 ```
 
 ```python

--- a/apps/docs/public/api/sdk.md
+++ b/apps/docs/public/api/sdk.md
@@ -29,12 +29,12 @@ const allUsers = await pachca.users.listUsersAll();
 
 ## Python
 
-<PackageBadge name="pachca" href="https://pypi.org/project/pachca/" />
+<PackageBadge name="pachca-sdk" href="https://pypi.org/project/pachca-sdk/" />
 
 Установите пакет из PyPI:
 
 ```bash
-pip install pachca
+pip install pachca-sdk
 ```
 
 ```python

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -63,7 +63,7 @@
 | Язык | Пакет | Установка |
 |------|-------|----------|
 | TypeScript | `@pachca/sdk` | `npm install @pachca/sdk` |
-| Python | `pachca` | `pip install pachca` |
+| Python | `pachca-sdk` | `pip install pachca-sdk` |
 | Go | `github.com/pachca/go-sdk` | `go get github.com/pachca/openapi/sdk/go/generated` |
 | Kotlin | `com.pachca:sdk` | `implementation("com.pachca:pachca-sdk:1.0.0")` |
 | Swift | `PachcaSDK` | SPM: `https://github.com/pachca/openapi` |
@@ -4387,12 +4387,12 @@ const allUsers = await pachca.users.listUsersAll();
 
 ## Python
 
-<PackageBadge name="pachca" href="https://pypi.org/project/pachca/" />
+<PackageBadge name="pachca-sdk" href="https://pypi.org/project/pachca-sdk/" />
 
 Установите пакет из PyPI:
 
 ```bash
-pip install pachca
+pip install pachca-sdk
 ```
 
 ```python

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -147,7 +147,7 @@ pachca guide "отправить сообщение"  # CLI guide for humans
 | Язык | Пакет | Установка |
 |------|-------|----------|
 | TypeScript | `@pachca/sdk` | `npm install @pachca/sdk` |
-| Python | `pachca` | `pip install pachca` |
+| Python | `pachca-sdk` | `pip install pachca-sdk` |
 | Go | `github.com/pachca/go-sdk` | `go get github.com/pachca/openapi/sdk/go/generated` |
 | Kotlin | `com.pachca:sdk` | `implementation("com.pachca:pachca-sdk:1.0.0")` |
 | Swift | `PachcaSDK` | SPM: `https://github.com/pachca/openapi` |

--- a/apps/docs/scripts/generate-llms.ts
+++ b/apps/docs/scripts/generate-llms.ts
@@ -72,7 +72,7 @@ function generateLlmsTxt(api: Awaited<ReturnType<typeof parseOpenAPI>>) {
   content += '| Язык | Пакет | Установка |\n';
   content += '|------|-------|----------|\n';
   content += '| TypeScript | `@pachca/sdk` | `npm install @pachca/sdk` |\n';
-  content += '| Python | `pachca` | `pip install pachca` |\n';
+  content += '| Python | `pachca-sdk` | `pip install pachca-sdk` |\n';
   content +=
     '| Go | `github.com/pachca/go-sdk` | `go get github.com/pachca/openapi/sdk/go/generated` |\n';
   content += '| Kotlin | `com.pachca:sdk` | `implementation("com.pachca:pachca-sdk:1.0.0")` |\n';
@@ -150,7 +150,7 @@ async function generateLlmsFullTxt(api: Awaited<ReturnType<typeof parseOpenAPI>>
   content += '| Язык | Пакет | Установка |\n';
   content += '|------|-------|----------|\n';
   content += '| TypeScript | `@pachca/sdk` | `npm install @pachca/sdk` |\n';
-  content += '| Python | `pachca` | `pip install pachca` |\n';
+  content += '| Python | `pachca-sdk` | `pip install pachca-sdk` |\n';
   content +=
     '| Go | `github.com/pachca/go-sdk` | `go get github.com/pachca/openapi/sdk/go/generated` |\n';
   content += '| Kotlin | `com.pachca:sdk` | `implementation("com.pachca:pachca-sdk:1.0.0")` |\n';

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -5,7 +5,7 @@ Python клиент для [Pachca API](https://dev.pachca.com).
 ## Установка
 
 ```bash
-pip install pachca
+pip install pachca-sdk
 ```
 
 ## Использование


### PR DESCRIPTION
## Summary
- Python SDK публикуется на PyPI как `pachca-sdk`, но документация ссылалась на сторонний пакет `pachca` (v0.0.1, другой автор)
- Пользователи получали `ModuleNotFoundError: No module named 'pachca.client'` при `pip install pachca`
- Исправлены ссылки и команды установки во всех источниках: sdk.mdx, generate-llms.ts, README.md, sdk/python/README.md

## Test plan
- [ ] Проверить страницу /sdk — бейдж Python ведёт на pypi.org/project/pachca-sdk/
- [ ] `pip install pachca-sdk` устанавливает правильный пакет с `pachca.client.PachcaClient`

🤖 Generated with [Claude Code](https://claude.com/claude-code)