### PR TITLE
fix(generator): add repository field for npm provenance

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -15,6 +15,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pachca/openapi"
+  },
   "scripts": {
     "build": "bun build src/index.ts bin/generator.ts --outdir dist --target node --format esm --splitting --packages=bundle",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Add `repository` field to generator package.json for npm provenance verification

Fixes npm publish error:
```
Error verifying sigstore provenance bundle: Failed to validate repository information: 
package.json: "repository.url" is "", expected to match "https://github.com/pachca/openapi"
```

## Test plan
- [ ] Verify publish-generator succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)