### PR TITLE
feat(generator): default spec URL and remote fetch support

### DIFF
--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -11,14 +11,21 @@ npm install -g @pachca/generator
 ## Использование
 
 ```bash
-npx @pachca/generator --spec openapi.yaml --output ./sdk --lang typescript,python,go,kotlin,swift
+# Генерация из Pachca API (по умолчанию)
+npx @pachca/generator --output ./sdk --lang typescript,python,go,kotlin,swift
+
+# Генерация из локального файла
+npx @pachca/generator --spec openapi.yaml --output ./sdk --lang typescript
+
+# Генерация из URL
+npx @pachca/generator --spec https://example.com/openapi.yaml --output ./sdk --lang go
 ```
 
 ### Параметры
 
 | Флаг | Описание |
 |------|----------|
-| `--spec` | Путь к OpenAPI 3.0 YAML спецификации |
+| `--spec` | Путь или URL к OpenAPI 3.0 YAML спецификации (по умолчанию: `https://dev.pachca.com/openapi.yaml`) |
 | `--output` | Директория для сгенерированных файлов |
 | `--lang` | Целевые языки через запятую: `typescript`, `python`, `go`, `kotlin`, `swift` |
 

--- a/packages/generator/bin/generator.ts
+++ b/packages/generator/bin/generator.ts
@@ -1,18 +1,35 @@
 #!/usr/bin/env node
 
 import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { generate, SUPPORTED_LANGS } from '../src/index.js';
 
+const DEFAULT_SPEC_URL = 'https://dev.pachca.com/openapi.yaml';
+
 function usage(): never {
-  console.error(`Usage: @pachca/generator --spec <path> --output <dir> --lang <langs> [--examples]`);
-  console.error(`  --spec      Path to OpenAPI YAML spec`);
+  console.error(`Usage: @pachca/generator [--spec <path|url>] --output <dir> --lang <langs> [--examples]`);
+  console.error(`  --spec      Path or URL to OpenAPI YAML spec (default: ${DEFAULT_SPEC_URL})`);
   console.error(`  --output    Output directory`);
   console.error(`  --lang      Comma-separated languages: ${SUPPORTED_LANGS.join(', ')}`);
   console.error(`  --examples  Generate examples.json with sample input/output`);
   process.exit(1);
 }
 
-function parseArgs(): { spec: string; output: string; langs: string[]; examples: boolean } {
+async function fetchSpec(url: string): Promise<string> {
+  console.error(`Fetching spec from ${url}...`);
+  const response = await fetch(url);
+  if (!response.ok) {
+    console.error(`Failed to fetch spec: ${response.status} ${response.statusText}`);
+    process.exit(1);
+  }
+  const content = await response.text();
+  const tempFile = path.join(os.tmpdir(), `openapi-${Date.now()}.yaml`);
+  fs.writeFileSync(tempFile, content);
+  return tempFile;
+}
+
+async function parseArgs(): Promise<{ spec: string; output: string; langs: string[]; examples: boolean }> {
   const args = process.argv.slice(2);
   let spec = '';
   let output = '';
@@ -39,9 +56,13 @@ function parseArgs(): { spec: string; output: string; langs: string[]; examples:
     }
   }
 
-  if (!spec || !output || !lang) usage();
+  if (!output || !lang) usage();
 
-  if (!fs.existsSync(spec)) {
+  if (!spec) {
+    spec = await fetchSpec(DEFAULT_SPEC_URL);
+  } else if (spec.startsWith('http://') || spec.startsWith('https://')) {
+    spec = await fetchSpec(spec);
+  } else if (!fs.existsSync(spec)) {
     console.error(`Spec file not found: ${spec}`);
     process.exit(1);
   }
@@ -57,5 +78,5 @@ function parseArgs(): { spec: string; output: string; langs: string[]; examples:
   return { spec, output, langs, examples };
 }
 
-const { spec, output, langs, examples } = parseArgs();
+const { spec, output, langs, examples } = await parseArgs();
 generate(spec, output, langs, { examples });

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pachca/generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bin": {
     "openapi-sdk-generator": "./dist/bin/generator.js"


### PR DESCRIPTION
## Summary
- `--spec` is now optional, defaults to `https://dev.pachca.com/openapi.yaml`
- Support fetching spec from remote URLs (http/https)
- Bump version to 1.1.0

## Usage
```bash
# Uses default Pachca API spec
npx @pachca/generator --output ./sdk --lang typescript

# From URL
npx @pachca/generator --spec https://example.com/openapi.yaml --output ./sdk --lang go

# From local file (as before)
npx @pachca/generator --spec ./openapi.yaml --output ./sdk --lang python
```

## Test plan
- [x] `bun test` passes
- [x] Manual test with default URL works
- [x] Snapshot regeneration works

🤖 Generated with [Claude Code](https://claude.com/claude-code)