### PR TITLE
fix: update n8n GitHub URL to pachca org

### DIFF
--- a/apps/docs/content/guides/n8n.mdx
+++ b/apps/docs/content/guides/n8n.mdx
@@ -55,13 +55,13 @@ n8n автоматически выполняет каждое действие 
     <ImageCard src="/images/n8n/owner-account.avif" alt="Настройка аккаунта владельца n8n" caption="Настройка Owner Account" maxWidth={960} />
   </Step>
   <Step title="Установка расширения Пачки">
-    Расширение доступно на [GitHub](https://github.com/doesntneedname/n8n-nodes-pachca) и [npmjs](https://www.npmjs.com/package/n8n-nodes-pachca).
+    Расширение доступно на [GitHub](https://github.com/pachca/n8n-nodes-pachca) и [npmjs](https://www.npmjs.com/package/n8n-nodes-pachca).
 
     Три способа установки:
 
     1. Зайти в **Settings** > **Community nodes** и добавить `n8n-nodes-pachca` (рекомендуется)
     2. Выполнить команду `npm i n8n-nodes-pachca` в директории n8n
-    3. Следовать README-инструкции на [GitHub](https://github.com/doesntneedname/n8n-nodes-pachca)
+    3. Следовать README-инструкции на [GitHub](https://github.com/pachca/n8n-nodes-pachca)
 
     <ImageCard src="/images/n8n/community-nodes.avif" alt="Установка расширения Пачки через Community nodes" caption="Установка через Community nodes" maxWidth={960} />
   </Step>

--- a/apps/docs/public/guides/n8n.md
+++ b/apps/docs/public/guides/n8n.md
@@ -60,13 +60,13 @@ n8n автоматически выполняет каждое действие 
 
   ### Шаг 2. Установка расширения Пачки
 
-Расширение доступно на [GitHub](https://github.com/doesntneedname/n8n-nodes-pachca) и [npmjs](https://www.npmjs.com/package/n8n-nodes-pachca).
+Расширение доступно на [GitHub](https://github.com/pachca/n8n-nodes-pachca) и [npmjs](https://www.npmjs.com/package/n8n-nodes-pachca).
 
     Три способа установки:
 
     1. Зайти в **Settings** > **Community nodes** и добавить `n8n-nodes-pachca` (рекомендуется)
     2. Выполнить команду `npm i n8n-nodes-pachca` в директории n8n
-    3. Следовать README-инструкции на [GitHub](https://github.com/doesntneedname/n8n-nodes-pachca)
+    3. Следовать README-инструкции на [GitHub](https://github.com/pachca/n8n-nodes-pachca)
 
     ![Установка расширения Пачки через Community nodes](/images/n8n/community-nodes.avif)
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -5122,13 +5122,13 @@ n8n автоматически выполняет каждое действие 
 
   ### Шаг 2. Установка расширения Пачки
 
-Расширение доступно на [GitHub](https://github.com/doesntneedname/n8n-nodes-pachca) и [npmjs](https://www.npmjs.com/package/n8n-nodes-pachca).
+Расширение доступно на [GitHub](https://github.com/pachca/n8n-nodes-pachca) и [npmjs](https://www.npmjs.com/package/n8n-nodes-pachca).
 
     Три способа установки:
 
     1. Зайти в **Settings** > **Community nodes** и добавить `n8n-nodes-pachca` (рекомендуется)
     2. Выполнить команду `npm i n8n-nodes-pachca` в директории n8n
-    3. Следовать README-инструкции на [GitHub](https://github.com/doesntneedname/n8n-nodes-pachca)
+    3. Следовать README-инструкции на [GitHub](https://github.com/pachca/n8n-nodes-pachca)
 
     ![Установка расширения Пачки через Community nodes](/images/n8n/community-nodes.avif)
 


### PR DESCRIPTION
## Summary
- Fixed n8n-nodes-pachca GitHub links in docs guide — pointed to `doesntneedname/n8n-nodes-pachca` (old fork), now correctly points to `pachca/n8n-nodes-pachca` (official repo)

## Changed files
- `apps/docs/content/guides/n8n.mdx` — source (2 URLs)
- `apps/docs/public/guides/n8n.md` — regenerated
- `apps/docs/public/llms-full.txt` — regenerated