### PR TITLE
fix(n8n): narrow package files, fix scan-community-package

### DIFF
--- a/.github/workflows/n8n.yml
+++ b/.github/workflows/n8n.yml
@@ -171,11 +171,6 @@ jobs:
           bun run tsc
           find nodes icons credentials \( -name '*.png' -o -name '*.svg' \) | while read f; do mkdir -p "dist/$(dirname "$f")" && cp "$f" "dist/$f"; done
 
-      - name: Scan community package
-        if: steps.changes.outputs.changed == 'true'
-        working-directory: integrations/n8n
-        run: bun x @n8n/scan-community-package .
-
       - name: Publish to npm
         if: steps.changes.outputs.changed == 'true'
         working-directory: integrations/n8n
@@ -191,6 +186,10 @@ jobs:
               exit $CODE
             fi
           }
+
+      - name: Scan community package
+        if: steps.changes.outputs.changed == 'true'
+        run: npx @n8n/scan-community-package n8n-nodes-pachca@${{ steps.version.outputs.version }}
 
       - name: Create GitHub Release
         if: steps.changes.outputs.changed == 'true'

--- a/integrations/n8n/package.json
+++ b/integrations/n8n/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@n8n/node-cli": "^0.23.0",
     "eslint": "^9.0.0",
+    "@pachca/openapi-parser": "workspace:*",
     "n8n-workflow": "*",
     "typescript": "^5.9.0",
     "tsx": "^4.0.0",

--- a/integrations/n8n/package.json
+++ b/integrations/n8n/package.json
@@ -31,7 +31,9 @@
     "directory": "integrations/n8n"
   },
   "files": [
-    "dist/",
+    "dist/nodes/",
+    "dist/credentials/",
+    "dist/icons/",
     "index.js",
     "icons/",
     "docs/",
@@ -70,7 +72,6 @@
   "devDependencies": {
     "@n8n/node-cli": "^0.23.0",
     "eslint": "^9.0.0",
-    "@pachca/openapi-parser": "workspace:*",
     "n8n-workflow": "*",
     "typescript": "^5.9.0",
     "tsx": "^4.0.0",


### PR DESCRIPTION
## Summary

- **package.json files**: `dist/` → `dist/nodes/`, `dist/credentials/`, `dist/icons/` — исключает случайное попадание e2e screenshots в пакет (2MB → 85KB)
- **package.json devDeps**: убрали `@pachca/openapi-parser: workspace:*` — bun резолвит через workspace автоматически
- **n8n.yml scan**: перенесли `scan-community-package` после `npm publish` и вызываем по имени пакета (`n8n-nodes-pachca@version`) — сканер не поддерживает локальные пути, `.` давал ошибку `.@null`

## Test plan

- [ ] n8n build проходит (`turbo build --filter=n8n-nodes-pachca`)
- [ ] `npm pack --dry-run` показывает 128 файлов, ~85KB
- [ ] После мержа + workflow_dispatch — scan проходит чисто