### PR TITLE
fix(n8n): fix file upload 403 error (v2.0.4)

### DIFF
--- a/integrations/n8n/CHANGELOG.md
+++ b/integrations/n8n/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bug Fixes
 
-- Fix file upload 403 error — `Content-Type` was sent as an S3 form field but not included in the presigned policy, causing Selectel S3 to reject the upload with "Extra input fields: content-type"
+- Fix file upload 403 error
 
 ## 2.0.3 (2026-04-08)
 

--- a/integrations/n8n/CHANGELOG.md
+++ b/integrations/n8n/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## 2.0.4 (2026-04-08)
+
+### Bug Fixes
+
+- Fix file upload 403 error — `Content-Type` was sent as an S3 form field but not included in the presigned policy, causing Selectel S3 to reject the upload with "Extra input fields: content-type"
+
 ## 2.0.3 (2026-04-08)
 
 ### Improvements

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -24,7 +24,7 @@ Or install from archive (Docker, custom n8n images):
 # Download from GitHub Releases
 # Find the latest n8n-nodes-pachca.tgz at:
 # https://github.com/pachca/openapi/releases?q=n8n
-wget https://github.com/pachca/openapi/releases/download/n8n-v2.0.2/n8n-nodes-pachca.tgz
+wget https://github.com/pachca/openapi/releases/download/n8n-v2.0.4/n8n-nodes-pachca.tgz
 
 # Via npm (recommended)
 cd ~/.n8n/nodes && npm install ./n8n-nodes-pachca.tgz

--- a/integrations/n8n/nodes/Pachca/GenericFunctions.ts
+++ b/integrations/n8n/nodes/Pachca/GenericFunctions.ts
@@ -743,7 +743,6 @@ export async function uploadFileToS3(
   const MAX_RETRIES = 3;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     const s3Fields: Record<string, string> = {
-      'Content-Type': contentType,
       'Content-Disposition': String(presigned['Content-Disposition']),
       acl: String(presigned.acl),
       policy: String(presigned.policy),

--- a/integrations/n8n/package.json
+++ b/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-pachca",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Pachca node for n8n workflow automation",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
## Summary

- Fix file upload 403 error — `Content-Type` was sent as an S3 form field not covered by the presigned policy, Selectel S3 rejected with `"Extra input fields: content-type"`
- Bump version to 2.0.4, update CHANGELOG and README

## Test plan

- [x] Verified with curl: upload without `Content-Type` field → 204 (success)
- [x] Verified with curl: upload with `Content-Type` field → 403
- [x] All 409 unit tests pass
- [x] `turbo build` + `turbo check` pass