### PR TITLE
feat(docs): English llms-en.txt for Context7 indexing

### DIFF
--- a/apps/docs/content/home.mdx
+++ b/apps/docs/content/home.mdx
@@ -93,4 +93,7 @@ hideTableOfContents: true
   <Card title="llms-full.txt" icon="Sparkles" href="/llms-full.txt" download>
     Полное описание API для LLM
   </Card>
+  <Card title="llms-en.txt" icon="Sparkles" href="/llms-en.txt" download>
+    English API documentation for LLM
+  </Card>
 </CardGroup>

--- a/apps/docs/public/index.md
+++ b/apps/docs/public/index.md
@@ -90,4 +90,5 @@ curl "https://api.pachca.com/api/shared/v1/messages" \
 - [Коллекция Postman](/pachca.postman_collection.json) — Все методы с примерами для Postman и Bruno
 - [llms.txt](/llms.txt) — Краткое описание API для LLM
 - [llms-full.txt](/llms-full.txt) — Полное описание API для LLM
+- [llms-en.txt](/llms-en.txt) — English API documentation for LLM
 

--- a/apps/docs/public/llms-en.txt
+++ b/apps/docs/public/llms-en.txt
@@ -1,0 +1,868 @@
+﻿# Pachca API — Complete English Documentation
+
+> REST API for Pachca corporate messenger. Manage messages, chats, users, tasks, bots, and webhooks.
+
+> Base URL: https://api.pachca.com/api/shared/v1
+
+# LIBRARY RULES
+
+## Authentication
+- All requests require Bearer token in Authorization header: `Authorization: Bearer <TOKEN>`
+- Token types: **admin** (full access — manage users, tags, delete messages), **bot** (send messages with custom name/avatar, receive webhooks), **user** (limited access)
+- Get admin token: Settings → Automations → API. Get bot token: per-bot in Settings → Automations → Integrations
+- Tokens are long-lived and do not expire. Can be reset by admin in Settings
+- TypeScript SDK: `const client = new PachcaClient("YOUR_TOKEN")`
+- Python SDK: `client = PachcaClient("YOUR_TOKEN")`
+
+## Pagination
+- Cursor-based: use `limit` (1–50, default 50) and `cursor` query parameters
+- Response includes `meta.paginate.next_page` — cursor for next page
+- End of data: when `data` array is empty (cursor is never null)
+- TypeScript auto-pagination: `client.users.listUsersAll()` returns flat array of all results
+- Python auto-pagination: `await client.users.list_users_all()` returns list of all results
+- Available for: users, chats, messages, members, tags, reactions, tasks, search results, audit events, webhook events
+
+## Rate Limiting
+- Messages (POST/PUT/DELETE /messages): ~4 req/sec per chat (burst: 30/sec for 5s)
+- Message read (GET /messages): ~10 req/sec
+- Other endpoints: ~50 req/sec
+- On `429 Too Many Requests`: respect `Retry-After` header value (seconds)
+- Recommended retry strategy: exponential backoff with jitter — base delay × 2^attempt × random(0.5–1.5)
+- SDK (@pachca/sdk, pachca-sdk) handles retry automatically: 3 retries, respects Retry-After, exponential backoff for 5xx
+
+## Webhooks (Real-time Events)
+- Create a bot in Pachca: Automations → Integrations → Bots
+- Set webhook URL in bot settings → Outgoing Webhook tab
+- Events: `new_message`, `edit_message`, `delete_message`, `new_reaction`, `delete_reaction`, `button_pressed`, `view_submit`, `chat_member_changed`, `company_member_changed`, `link_shared`
+- Verify: HMAC-SHA256 of raw body with bot's Signing Secret
+- Header: `Pachca-Signature` contains hex digest
+- Replay protection: check `webhook_timestamp` within ±60 seconds of current time
+- Alternative to webhooks: polling via GET /webhooks/events (enable "Save event history" in bot settings)
+- IP whitelist: Pachca webhook IP is `37.200.70.177`
+
+## File Uploads (3-step process)
+- Step 1: POST /uploads → get S3 presigned params (`direct_url`, `key`, `policy`, `x-amz-signature`, etc.)
+- Step 2: POST to `direct_url` (external S3 URL, NOT a Pachca API endpoint) with multipart/form-data — all params + `file` as LAST field
+- Step 3: Replace `${filename}` in `key` with actual filename, include in message `files` array
+- Note: `direct_url` is an external S3 presigned URL and does not require Authorization header
+
+## User Status
+- Get any user's status: GET /users/{id}/status → `{ emoji, title, expires_at, is_away, away_message }`
+- Set own status: PUT /profile/status `{ status: { emoji, title, expires_at, is_away, away_message } }`
+- Clear own status: DELETE /profile/status
+- Admin can manage any user: PUT /users/{id}/status, DELETE /users/{id}/status
+- No real-time presence webhooks — use polling with ≥60s interval for monitoring status changes
+
+## Error Handling
+- `400`: validation errors — `{ errors: [{ key, value, message, code }] }` with codes: `blank`, `invalid`, `taken`, `too_short`, `too_long`, `not_a_number`
+- `401`: unauthorized — `{ error, error_description }` (OAuthError)
+- `403`: forbidden — insufficient permissions. May return ApiError (business logic) or OAuthError (`insufficient_scope`)
+- `404`: not found
+- `409`: conflict (duplicate)
+- `422`: unprocessable — `{ errors: [{ key, value, message, code }] }`
+- `429`: rate limited — respect `Retry-After` header, use exponential backoff with jitter
+- SDK auto-retries `429` and `5xx` errors (3 attempts with exponential backoff)
+
+## Idempotency and Reliability
+- Pachca API operations are NOT idempotent by default — duplicate POST requests create duplicate resources
+- Client-side deduplication: track request IDs, check before sending, store results with TTL
+- Webhooks use at-least-once delivery — handlers MUST be idempotent (dedup by event fields: id + type + event)
+- For multi-step operations: implement compensating actions (saga pattern) for failure recovery
+- Separate critical operations (create chat) from non-critical (send welcome message) with independent error handling
+
+## SDK (Typed Clients for 6 Languages)
+- Unified pattern: `PachcaClient(token)` → `client.service.method(request)`
+- **Input**: path params and body fields (≤2) expand to method arguments; otherwise a single request object
+- **Output**: if API response has a single `data` field, SDK returns its contents directly
+- Service, method, and field names match operationId and parameters from OpenAPI
+
+| Language | Package | Install |
+|----------|---------|---------|
+| TypeScript | `@pachca/sdk` | `npm install @pachca/sdk` |
+| Python | `pachca-sdk` | `pip install pachca-sdk` |
+| Go | `github.com/pachca/go-sdk` | `go get github.com/pachca/openapi/sdk/go/generated` |
+| Kotlin | `com.pachca:sdk` | `implementation("com.pachca:pachca-sdk:1.0.1")` |
+| Swift | `PachcaSDK` | SPM: `https://github.com/pachca/openapi` |
+| C# | `Pachca.Sdk` | `dotnet add package Pachca.Sdk` |
+
+---
+
+# How-to Guides
+
+## How to authenticate with the API
+
+All API requests require a Bearer token in the Authorization header.
+
+### curl
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" https://api.pachca.com/api/shared/v1/users
+```
+
+### TypeScript SDK
+```typescript
+import { PachcaClient } from "@pachca/sdk"
+
+const client = new PachcaClient("YOUR_TOKEN")
+const profile = await client.profile.getProfile()
+console.log(profile.id, profile.firstName)
+```
+
+### Python SDK
+```python
+from pachca.client import PachcaClient
+
+client = PachcaClient("YOUR_TOKEN")
+profile = await client.profile.get_profile()
+print(profile.id, profile.first_name)
+```
+
+Token types: **admin** (full access, get in Settings → Automations → API), **bot** (messaging + webhooks, per-bot in Integrations), **user** (limited).
+
+## How to paginate through results
+
+### TypeScript SDK — auto-pagination
+```typescript
+// Returns all results as a flat array (handles cursors automatically)
+const allUsers = await client.users.listUsersAll()
+console.log(`Total: ${allUsers.length}`)
+
+// Manual pagination with cursor control
+let cursor: string | undefined
+for (;;) {
+  const response = await client.users.listUsers({ limit: 50, cursor })
+  if (response.data.length === 0) break
+  for (const user of response.data) {
+    console.log(user.firstName, user.lastName)
+  }
+  cursor = response.meta.paginate.nextPage
+}
+```
+
+### Python SDK — auto-pagination
+```python
+# Returns all results as a list (handles cursors automatically)
+all_users = await client.users.list_users_all()
+print(f"Total: {len(all_users)}")
+
+# Manual pagination with cursor control
+from pachca.models import ListUsersParams
+
+cursor = None
+while True:
+    response = await client.users.list_users(ListUsersParams(limit=50, cursor=cursor))
+    if not response.data:
+        break
+    for user in response.data:
+        print(user.first_name, user.last_name)
+    cursor = response.meta.paginate.next_page
+```
+
+Auto-pagination methods: `listUsersAll()`, `listChatsAll()`, `listChatMessagesAll()`, `listMembersAll()`, `listTagsAll()`, `listTasksAll()`, `searchMessagesAll()`, `searchChatsAll()`, `searchUsersAll()`, `listReactionsAll()`, `getAuditEventsAll()`, `getWebhookEventsAll()`.
+
+## How to create chats and manage members
+
+### TypeScript SDK
+```typescript
+import { PachcaClient, MessageEntityType } from "@pachca/sdk"
+
+const client = new PachcaClient("YOUR_TOKEN")
+
+// Create a group chat with initial members
+const chat = await client.chats.createChat({
+  chat: { name: "Project Discussion", memberIds: [1, 2, 3], channel: false, public: false }
+})
+console.log("Created chat:", chat.id, chat.name)
+
+// Add more members later
+await client.members.addMembers(chat.id, { memberIds: [4, 5] })
+
+// Remove a member
+await client.members.removeMember(chat.id, 5)
+
+// List current members
+const members = await client.members.listMembersAll(chat.id)
+console.log("Members:", members.map(m => m.firstName))
+
+// Send a message to the chat
+await client.messages.createMessage({
+  message: { entityType: MessageEntityType.Discussion, entityId: chat.id, content: "Welcome everyone!" }
+})
+```
+
+### Python SDK
+```python
+from pachca.client import PachcaClient
+from pachca.models import ChatCreateRequest, ChatCreateRequestChat, MessageCreateRequest, MessageCreateRequestMessage, AddMembersRequest
+
+client = PachcaClient("YOUR_TOKEN")
+
+# Create a group chat with initial members
+chat = await client.chats.create_chat(ChatCreateRequest(
+    chat=ChatCreateRequestChat(name="Project Discussion", member_ids=[1, 2, 3], channel=False, public=False)
+))
+print("Created chat:", chat.id, chat.name)
+
+# Add more members later
+await client.members.add_members(chat.id, AddMembersRequest(member_ids=[4, 5]))
+
+# List current members
+members = await client.members.list_members_all(chat.id)
+
+# Send a message to the chat
+await client.messages.create_message(MessageCreateRequest(
+    message=MessageCreateRequestMessage(entity_type="discussion", entity_id=chat.id, content="Welcome everyone!")
+))
+```
+
+Chat types: `channel: true` creates a channel (one-way announcements), `channel: false` creates a group chat (everyone can write). `public: true` makes it visible to all workspace members.
+
+## How to set up webhooks for real-time updates
+
+### Step-by-step setup
+1. Create a bot in Pachca: **Automations** → **Integrations** → **Bots**
+2. In bot settings, go to **Outgoing Webhook** tab and set your HTTPS URL
+3. Copy the **Signing Secret** for signature verification
+4. Select event types: new messages, reactions, button presses, form submissions, etc.
+5. Add the bot to chats where you want to receive events (global events like company member changes work without adding to chat)
+
+### TypeScript webhook handler (Express.js)
+```typescript
+import express from "express"
+import crypto from "crypto"
+
+const SIGNING_SECRET = "your_signing_secret" // From bot settings → Outgoing Webhook
+const app = express()
+
+app.post("/webhook", express.raw({ type: "application/json" }), (req, res) => {
+  // Step 1: Verify HMAC-SHA256 signature
+  const signature = crypto.createHmac("sha256", SIGNING_SECRET)
+    .update(req.body).digest("hex")
+  if (signature !== req.headers["pachca-signature"]) {
+    return res.status(401).send("Invalid signature")
+  }
+
+  // Step 2: Check timestamp for replay protection (±60 seconds)
+  const event = JSON.parse(req.body.toString())
+  if (Math.abs(Date.now() / 1000 - event.webhook_timestamp) > 60) {
+    return res.status(401).send("Expired event")
+  }
+
+  // Step 3: Process event by type
+  switch (event.type) {
+    case "message":
+      if (event.event === "new") console.log("New message:", event.content, "from user:", event.user_id)
+      if (event.event === "update") console.log("Message edited:", event.id)
+      if (event.event === "delete") console.log("Message deleted:", event.id)
+      break
+    case "reaction":
+      console.log(event.event === "new" ? "Reaction added:" : "Reaction removed:", event.emoji)
+      break
+    case "button":
+      console.log("Button pressed:", event.data, "by user:", event.user_id)
+      // Use event.trigger_id within 3 seconds to open a form
+      break
+    case "view_submit":
+      console.log("Form submitted:", event.payload)
+      break
+  }
+
+  res.status(200).send("OK")
+})
+app.listen(3000)
+```
+
+### Python webhook handler (Flask)
+```python
+import hmac, hashlib, json, time
+from flask import Flask, request, abort
+
+SIGNING_SECRET = "your_signing_secret"  # From bot settings → Outgoing Webhook
+app = Flask(__name__)
+
+@app.route("/webhook", methods=["POST"])
+def webhook():
+    raw_body = request.get_data()
+
+    # Step 1: Verify HMAC-SHA256 signature
+    expected = hmac.new(SIGNING_SECRET.encode(), raw_body, hashlib.sha256).hexdigest()
+    if expected != request.headers.get("Pachca-Signature"):
+        abort(401)
+
+    # Step 2: Check timestamp for replay protection
+    event = json.loads(raw_body)
+    if abs(time.time() - event["webhook_timestamp"]) > 60:
+        abort(401)
+
+    # Step 3: Process event by type
+    if event["type"] == "message" and event["event"] == "new":
+        print("New message:", event["content"], "from user:", event["user_id"])
+    elif event["type"] == "button":
+        print("Button pressed:", event["data"])
+
+    return "OK", 200
+```
+
+### Webhook event types
+| Event type | Description | Fields |
+|-----------|-------------|--------|
+| message (new) | New message in chat | id, content, user_id, chat_id, entity_type, entity_id, created_at, url |
+| message (update) | Message edited | id, content, user_id, chat_id |
+| message (delete) | Message deleted | id, user_id, chat_id |
+| reaction (new/delete) | Reaction added/removed | message_id, user_id, emoji, chat_id |
+| button | Button pressed | message_id, user_id, data, trigger_id, chat_id |
+| view_submit | Form submitted | payload (form field values), user_id, trigger_id |
+| chat_member (new/delete) | Member added/removed from chat | chat_id, user_id, event |
+| company_member (new/update/delete) | Workspace member changes | user_id, event (no chat needed) |
+| link_shared | URL shared (unfurl bots) | url, message_id, chat_id |
+
+### Alternative: Polling (when webhook URL is not available)
+Enable "Save event history" in bot settings, then poll:
+```typescript
+// Poll for events periodically
+const events = await client.bots.getWebhookEvents()
+for (const event of events.data) {
+  processEvent(event)
+  await client.bots.deleteWebhookEvent(event.id) // Remove processed event
+}
+```
+
+## How to handle rate limits and implement retry logic
+
+Both SDKs handle retry automatically — 3 retries with exponential backoff for `429` and `5xx` errors. No extra code needed:
+
+### TypeScript SDK
+```typescript
+import { PachcaClient, ApiError } from "@pachca/sdk"
+
+const client = new PachcaClient("YOUR_TOKEN")
+
+// SDK retries 429 and 5xx automatically (3 attempts, exponential backoff)
+// Just call methods normally — retries are transparent
+const users = await client.users.listUsersAll()
+
+// If all retries are exhausted, ApiError is thrown
+try {
+  await client.messages.createMessage({
+    message: { entityId: 12345, content: "Hello" }
+  })
+} catch (error) {
+  if (error instanceof ApiError) {
+    // After 3 retries, the error is surfaced — check error.errors for details
+    for (const e of error.errors ?? []) {
+      console.error(e.key, e.message)
+    }
+  }
+}
+```
+
+### Python SDK
+```python
+from pachca.client import PachcaClient
+from pachca.models import ApiError
+
+client = PachcaClient("YOUR_TOKEN")
+
+# SDK retries 429 and 5xx automatically (3 attempts, exponential backoff)
+# Just call methods normally — retries are transparent
+users = await client.users.list_users_all()
+
+# If all retries are exhausted, ApiError is raised
+try:
+    await client.messages.create_message(request)
+except ApiError as e:
+    # After 3 retries, the error is surfaced — check e.errors for details
+    for err in e.errors:
+        print(err.key, err.message)
+```
+
+Rate limits by endpoint category:
+- Messages send/edit/delete: ~4 req/sec per chat (burst: 30/sec for 5s)
+- Messages read: ~10 req/sec per token
+- All other endpoints: ~50 req/sec per token
+- On 429: SDK respects `Retry-After` header automatically
+
+## How to upload files and attach to messages
+
+File upload is a 3-step process: get presigned params → upload to S3 → attach to message.
+
+### TypeScript SDK
+```typescript
+import { PachcaClient, FileType } from "@pachca/sdk"
+import fs from "fs"
+import path from "path"
+
+const client = new PachcaClient("YOUR_TOKEN")
+
+const filePath = "./report.pdf"
+const fileName = path.basename(filePath)
+const fileBuffer = fs.readFileSync(filePath)
+
+// Step 1: Get S3 presigned upload parameters
+const params = await client.common.getUploadParams()
+
+// Step 2: Upload file to S3 (direct_url is an external presigned URL, not Pachca API)
+await client.common.uploadFile(params.directUrl, {
+  contentDisposition: params.contentDisposition,
+  acl: params.acl,
+  policy: params.policy,
+  xAmzCredential: params.xAmzCredential,
+  xAmzAlgorithm: params.xAmzAlgorithm,
+  xAmzDate: params.xAmzDate,
+  xAmzSignature: params.xAmzSignature,
+  key: params.key,
+  file: new File([fileBuffer], fileName)
+})
+
+// Step 3: Attach file to message (replace ${filename} in key with actual name)
+const fileKey = params.key.replace("${filename}", fileName)
+await client.messages.createMessage({
+  message: {
+    entityId: 12345,
+    content: "Report attached",
+    files: [{ key: fileKey, name: fileName, fileType: FileType.File, size: fileBuffer.length }]
+  }
+})
+```
+
+### Python SDK
+```python
+from pachca.client import PachcaClient
+from pachca.models import (
+    FileUploadRequest, MessageCreateRequest, MessageCreateRequestMessage,
+    MessageCreateRequestFile, FileType
+)
+import os
+
+client = PachcaClient("YOUR_TOKEN")
+
+file_path = "report.pdf"
+file_name = os.path.basename(file_path)
+
+# Step 1: Get S3 presigned upload parameters
+params = await client.common.get_upload_params()
+
+# Step 2: Upload file to S3 (direct_url is an external presigned URL, not Pachca API)
+with open(file_path, "rb") as f:
+    await client.common.upload_file(
+        direct_url=params.direct_url,
+        request=FileUploadRequest(
+            content_disposition=params.content_disposition,
+            acl=params.acl,
+            policy=params.policy,
+            x_amz_credential=params.x_amz_credential,
+            x_amz_algorithm=params.x_amz_algorithm,
+            x_amz_date=params.x_amz_date,
+            x_amz_signature=params.x_amz_signature,
+            key=params.key,
+            file=f.read()
+        )
+    )
+
+# Step 3: Attach file to message (replace ${filename} in key with actual name)
+file_key = params.key.replace("${filename}", file_name)
+await client.messages.create_message(MessageCreateRequest(
+    message=MessageCreateRequestMessage(
+        entity_id=12345,
+        content="Report attached",
+        files=[MessageCreateRequestFile(key=file_key, name=file_name, file_type=FileType.FILE, size=os.path.getsize(file_path))]
+    )
+))
+```
+
+File types: `FileType.File` / `FileType.FILE` (any file), `FileType.Image` / `FileType.IMAGE` (add `width` and `height`).
+
+## How to monitor user status and presence
+
+### TypeScript SDK
+```typescript
+import { PachcaClient } from "@pachca/sdk"
+
+const client = new PachcaClient("YOUR_TOKEN")
+
+// Get any user's status
+const status = await client.users.getUserStatus(userId)
+console.log(status.emoji, status.title, status.isAway, status.awayMessage)
+
+// Set your own status
+await client.profile.updateStatus({
+  status: { emoji: "🏖️", title: "On vacation", isAway: true, awayMessage: "Back on Monday" }
+})
+
+// Set status with expiration
+await client.profile.updateStatus({
+  status: { emoji: "🍽️", title: "Lunch break", expiresAt: new Date(Date.now() + 3600000).toISOString() }
+})
+
+// Clear your status
+await client.profile.deleteStatus()
+```
+
+### Python SDK
+```python
+from pachca.client import PachcaClient
+from pachca.models import StatusUpdateRequest, StatusUpdateRequestStatus
+
+client = PachcaClient("YOUR_TOKEN")
+
+# Get any user's status
+status = await client.users.get_user_status(user_id)
+print(status.emoji, status.title, status.is_away, status.away_message)
+
+# Set your own status
+await client.profile.update_status(StatusUpdateRequest(
+    status=StatusUpdateRequestStatus(emoji="🏖️", title="On vacation", is_away=True, away_message="Back on Monday")
+))
+
+# Clear your status
+await client.profile.delete_status()
+```
+
+### Polling pattern for monitoring status changes
+Pachca does not provide real-time webhooks for status/presence changes. Use polling with caching:
+
+```typescript
+const cache = new Map<number, { status: any; fetchedAt: number }>()
+const CACHE_TTL = 60_000 // Minimum 60 seconds between polls per user
+
+async function getUserPresence(userId: number) {
+  const cached = cache.get(userId)
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) return cached.status
+  const status = await client.users.getUserStatus(userId)
+  cache.set(userId, { status, fetchedAt: Date.now() })
+  return status
+}
+
+// Batch refresh for a team
+async function refreshTeamPresences(userIds: number[]) {
+  const results = []
+  for (const id of userIds) {
+    cache.delete(id)
+    results.push(await getUserPresence(id))
+  }
+  return results
+}
+```
+
+Status fields: `emoji` (string), `title` (string), `expires_at` (ISO datetime or null), `is_away` (boolean), `away_message` (string). Admin can manage any user's status via PUT/DELETE /users/{id}/status.
+
+---
+
+---
+
+# API Reference
+
+Base URL: `https://api.pachca.com/api/shared/v1`
+
+All endpoints require `Authorization: Bearer <TOKEN>` header.
+
+## Common
+
+### POST /api/shared/v1/chats/exports
+Request a message export for the specified time period.
+Body: { start_at*, end_at*, webhook_url*, chat_ids, skip_chats_file }
+
+### GET /api/shared/v1/chats/exports/{id}
+Download a completed message export archive. To download the archive you need to know its `id` and specify it in the request `URL`. The server will respond with `302 Found` and a `Location` header con
+Parameters: id
+
+### GET /api/shared/v1/custom_properties
+Working with "File" type custom properties is currently unavailable. Retrieve the current list of custom properties for employees and tasks in your workspace. By default, all entities in your workspac
+Parameters: entity_type
+
+### POST /api/shared/v1/direct_url
+Upload a file to the server using `multipart/form-data` format. Upload parameters are obtained via the [Get signature, key and other parameters](POST /uploads) method.
+Body: { Content-Disposition*, acl*, policy*, x-amz-credential*, x-amz-algorithm*, x-amz-date*, x-amz-signature*, key*, file* }
+
+### POST /api/shared/v1/uploads
+Retrieve the signature, key, and other parameters required for file upload. This method must be used for each file upload.
+
+## Profile
+
+### GET /api/shared/v1/oauth/token/info
+Retrieve information about the current OAuth token, including its scopes, creation date, and last usage date. The token in the response is masked — only the first 8 and last 4 characters are visible.
+
+### GET /api/shared/v1/profile
+Retrieve information about your own profile.
+
+### PUT /api/shared/v1/profile/avatar
+Upload or update your profile avatar. The file is sent in `multipart/form-data` format.
+Body: { image* }
+
+### DELETE /api/shared/v1/profile/avatar
+Delete your profile avatar.
+
+### GET /api/shared/v1/profile/status
+Retrieve information about your current status.
+
+### PUT /api/shared/v1/profile/status
+Set a new status for yourself.
+Body: { status: { emoji*, title*, expires_at, is_away, away_message } }
+
+### DELETE /api/shared/v1/profile/status
+Delete your current status.
+
+## Users
+
+### GET /api/shared/v1/users
+Retrieve the current list of employees in your workspace.
+Parameters: query?, limit?, cursor?
+
+### POST /api/shared/v1/users
+Create a new employee in your workspace. You can fill in custom properties for the employee that have been created in your workspace. You can get the current list of employee custom property IDs using
+Body: { user*, skip_email_notify }
+
+### GET /api/shared/v1/users/{id}
+Retrieve information about an employee. To get an employee you need to know their `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/users/{id}
+Edit an employee. To edit an employee you need to know their `id` and specify it in the request `URL`. All editable employee parameters are specified in the request body. You can get the current list 
+Parameters: id
+Body: { user: { first_name, last_name, email, phone_number, nickname, department, title, role, suspended, list_tags, custom_properties } }
+
+### DELETE /api/shared/v1/users/{id}
+Delete an employee. To delete an employee you need to know their `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/users/{user_id}/avatar
+Upload or update an employee's avatar. The file is sent in `multipart/form-data` format.
+Parameters: user_id
+Body: { image* }
+
+### DELETE /api/shared/v1/users/{user_id}/avatar
+Delete an employee's avatar.
+Parameters: user_id
+
+### GET /api/shared/v1/users/{user_id}/status
+Retrieve information about an employee's status.
+Parameters: user_id
+
+### PUT /api/shared/v1/users/{user_id}/status
+Set a new status for an employee.
+Parameters: user_id
+Body: { status: { emoji*, title*, expires_at, is_away, away_message } }
+
+### DELETE /api/shared/v1/users/{user_id}/status
+Delete an employee's status.
+Parameters: user_id
+
+## Group tags
+
+### GET /api/shared/v1/group_tags
+Retrieve the current list of employee tags. Tag names are unique within the workspace.
+Parameters: names?, limit?, cursor?
+
+### POST /api/shared/v1/group_tags
+Create a new tag.
+Body: { group_tag: { name* } }
+
+### GET /api/shared/v1/group_tags/{id}
+Retrieve information about a tag. Tag names are unique within the workspace. To get a tag you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/group_tags/{id}
+Edit a tag. To edit a tag you need to know its `id` and specify it in the request `URL`. All editable tag parameters are specified in the request body.
+Parameters: id
+Body: { group_tag: { name* } }
+
+### DELETE /api/shared/v1/group_tags/{id}
+Delete a tag. To delete a tag you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+### GET /api/shared/v1/group_tags/{id}/users
+Retrieve the current list of employees in a tag.
+Parameters: id, limit?, cursor?
+
+## Chats
+
+### GET /api/shared/v1/chats
+Retrieve a list of chats based on the specified parameters.
+Parameters: sort?, order?, availability?, last_message_at_after?, last_message_at_before?, personal?, limit?, cursor?
+
+### POST /api/shared/v1/chats
+Create a new chat. To create a one-on-one direct message with a user, use the [New message](POST /messages) method. When creating a chat, you automatically become a member.
+Body: { chat: { name*, member_ids, group_tag_ids, channel, public } }
+
+### GET /api/shared/v1/chats/{id}
+Retrieve information about a chat. To get a chat you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/chats/{id}
+Update chat parameters. To update a chat you need to know its `id` and specify it in the `URL`. All updatable fields are passed in the request body.
+Parameters: id
+Body: { chat: { name, public } }
+
+### PUT /api/shared/v1/chats/{id}/archive
+Archive a chat. To archive a chat you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/chats/{id}/unarchive
+Restore a chat from the archive. To unarchive a chat you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+## Members
+
+### POST /api/shared/v1/chats/{id}/group_tags
+Add tags to the member list of a conversation or channel. After adding a tag, all its members automatically become members of the chat. The tag and chat member lists are synchronized automatically: wh
+Parameters: id
+Body: { group_tag_ids* }
+
+### DELETE /api/shared/v1/chats/{id}/group_tags/{tag_id}
+Remove a tag from the member list of a conversation or channel. To remove a tag you need to know its `id` and specify it in the request `URL`.
+Parameters: id, tag_id
+
+### DELETE /api/shared/v1/chats/{id}/leave
+Leave a conversation or channel on your own.
+Parameters: id
+
+### GET /api/shared/v1/chats/{id}/members
+Retrieve the current list of chat members. The workspace owner can retrieve the member list of any chat in the workspace. Admins and bots can only retrieve the member list of chats they belong to (or 
+Parameters: id, role?, limit?, cursor?
+
+### POST /api/shared/v1/chats/{id}/members
+Add users to the member list of a conversation, channel, or thread.
+Parameters: id
+Body: { member_ids*, silent }
+
+### PUT /api/shared/v1/chats/{id}/members/{user_id}
+Edit a user's or bot's role in a conversation or channel. To edit a role in a conversation or channel you need to know the `id` of the chat and the user (or bot) and specify them in the request `URL`.
+Parameters: id, user_id
+Body: { role* }
+
+### DELETE /api/shared/v1/chats/{id}/members/{user_id}
+Remove a user from the member list of a conversation or channel. If the user is the chat owner, they cannot be removed. They can only leave the chat on their own using the [Leave conversation or chann
+Parameters: id, user_id
+
+## Threads
+
+### POST /api/shared/v1/messages/{id}/thread
+Create a new thread on a message. If a thread has already been created for the message, the response will return information about the previously created thread.
+Parameters: id
+
+### GET /api/shared/v1/threads/{id}
+Retrieve information about a thread. To get a thread you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+## Messages
+
+### GET /api/shared/v1/messages
+Retrieve a list of messages from conversations, channels, threads, and direct messages. To retrieve messages you need to know the `chat_id` of the required conversation, channel, thread, or direct mes
+Parameters: chat_id, sort?, order?, limit?, cursor?
+
+### POST /api/shared/v1/messages
+Send a message to a conversation or channel, a direct message to a user, or a comment to a thread. When using `entity_type: "discussion"` (or simply without specifying `entity_type`), any `chat_id` ca
+Body: { message*, link_preview }
+
+### GET /api/shared/v1/messages/{id}
+Retrieve information about a message. To get a message you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/messages/{id}
+Edit a message or comment. To edit a message you need to know its `id` and specify it in the request `URL`. All editable message parameters are specified in the request body.
+Parameters: id
+Body: { message: { content, files, buttons, display_avatar_url, display_name } }
+
+### DELETE /api/shared/v1/messages/{id}
+Delete a message. Message deletion is available to the sender, admins, and editors in the chat. In direct messages, both users are editors. There are no time restrictions on message deletion. To delet
+Parameters: id
+
+### POST /api/shared/v1/messages/{id}/pin
+Pin a message in a chat. To pin a message you need to know the message `id` and specify it in the request `URL`.
+Parameters: id
+
+### DELETE /api/shared/v1/messages/{id}/pin
+Unpin a message from a chat. To unpin a message you need to know the message `id` and specify it in the request `URL`.
+Parameters: id
+
+## Read members
+
+### GET /api/shared/v1/messages/{id}/read_member_ids
+Retrieve the current list of users who have read the message.
+Parameters: id, limit?, cursor?
+
+## Reactions
+
+### GET /api/shared/v1/messages/{id}/reactions
+Retrieve the current list of reactions on a message.
+Parameters: id, limit?, cursor?
+
+### POST /api/shared/v1/messages/{id}/reactions
+Add a reaction to a message. To add a reaction you need to know the message `id` and specify it in the request `URL`. Message reactions are sent as `Emoji` characters. If the user has already added th
+Parameters: id
+Body: { code*, name }
+
+### DELETE /api/shared/v1/messages/{id}/reactions
+Remove a reaction from a message. To remove a reaction you need to know the message `id` and specify it in the request `URL`. Message reactions are stored as `Emoji` characters. You can only remove re
+Parameters: id, code, name?
+
+## Link Previews
+
+### POST /api/shared/v1/messages/{id}/link_previews
+Create link previews in messages. Only available for Unfurl bots.
+Parameters: id
+Body: { link_previews* }
+
+## Search
+
+### GET /api/shared/v1/search/chats
+Full-text search for channels and conversations.
+Parameters: query?, limit?, cursor?, order?, created_from?, created_to?, active?, chat_subtype?, personal?
+
+### GET /api/shared/v1/search/messages
+Full-text search for messages.
+Parameters: query?, limit?, cursor?, order?, created_from?, created_to?, chat_ids?, user_ids?, active?
+
+### GET /api/shared/v1/search/users
+Full-text search for employees by name, email, position, and other fields.
+Parameters: query?, limit?, cursor?, sort?, order?, created_from?, created_to?, company_roles?
+
+## Tasks
+
+### GET /api/shared/v1/tasks
+Retrieve a list of tasks.
+Parameters: limit?, cursor?
+
+### POST /api/shared/v1/tasks
+Create a new task. When creating a task, specifying the task type is required: call, meeting, simple reminder, event, or email. No additional description is needed — you simply create a task with the 
+Body: { task: { kind*, content, due_at, priority, performer_ids, chat_id, all_day, custom_properties } }
+
+### GET /api/shared/v1/tasks/{id}
+Retrieve information about a task. To get a task you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+### PUT /api/shared/v1/tasks/{id}
+Edit a task. To edit a task you need to know its `id` and specify it in the request `URL`. All editable task parameters are specified in the request body.
+Parameters: id
+Body: { task: { kind, content, due_at, priority, performer_ids, status, all_day, done_at, custom_properties } }
+
+### DELETE /api/shared/v1/tasks/{id}
+Delete a task. To delete a task you need to know its `id` and specify it in the request `URL`.
+Parameters: id
+
+## Views
+
+### POST /api/shared/v1/views/open
+Open a modal window with a view for the user. To open a modal window with a view, your application must have a valid, non-expired `trigger_id`.
+Body: { type*, trigger_id*, private_metadata, callback_id, view* }
+
+## Bots
+
+### PUT /api/shared/v1/bots/{id}
+Edit a bot's settings. To edit a bot you need to know its `user_id` and specify it in the request `URL`. All editable bot parameters are specified in the request body. You can find the bot's `user_id`
+Parameters: id
+Body: { bot: { webhook* } }
+
+### GET /api/shared/v1/webhooks/events
+Retrieve the history of a bot's recent events. This method is useful if you cannot receive events in real time at your `URL`, but need to process all events you have subscribed to. Event history is on
+Parameters: limit?, cursor?
+
+### DELETE /api/shared/v1/webhooks/events/{id}
+This method is only available with a bot's `access_token`. Delete an event from the bot's event history. To delete an event you need to know the bot's `access_token` that owns the event and the event 
+Parameters: id
+
+## Security
+
+### GET /api/shared/v1/audit_events
+Retrieve event logs based on the specified filters.
+Parameters: start_time?, end_time?, event_key?, actor_id?, actor_type?, entity_id?, entity_type?, limit?, cursor?
+

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -73,8 +73,8 @@
 |---------|-------------|-------|
 | LIBRARY RULES | Core rules, auth, pagination, rate limits, SDK overview | 81–163 |
 | How-to Guides | Step-by-step solutions with TypeScript + Python code | 164–623 |
-| Guides | Full SDK docs (6 languages), webhooks, bots, forms, n8n | 624–10116 |
-| API Reference | Complete REST API — every endpoint with schemas and examples | 10117–25035 |
+| Guides | Full SDK docs (6 languages), webhooks, bots, forms, n8n | 624–10117 |
+| API Reference | Complete REST API — every endpoint with schemas and examples | 10118–25036 |
 
 ---
 
@@ -715,6 +715,7 @@ curl "https://api.pachca.com/api/shared/v1/messages" \
 - [Коллекция Postman](/pachca.postman_collection.json) — Все методы с примерами для Postman и Bruno
 - [llms.txt](/llms.txt) — Краткое описание API для LLM
 - [llms-full.txt](/llms-full.txt) — Полное описание API для LLM
+- [llms-en.txt](/llms-en.txt) — English API documentation for LLM
 
 
 ---

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -4,6 +4,8 @@
 
 > Полная документация в одном файле: [llms-full.txt](https://dev.pachca.com/llms-full.txt)
 
+> English documentation: [llms-en.txt](https://dev.pachca.com/llms-en.txt)
+
 ## CLI Quick Start
 
 ```bash

--- a/apps/docs/scripts/generate-llms.ts
+++ b/apps/docs/scripts/generate-llms.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import * as yaml from 'js-yaml';
 import { parseOpenAPI, clearCache } from '../lib/openapi/parser';
 import { generateUrlFromOperation, generateTitle } from '../lib/openapi/mapper';
 import {
@@ -35,6 +36,7 @@ function generateLlmsTxt(api: Awaited<ReturnType<typeof parseOpenAPI>>) {
   content +=
     '> REST API мессенджера Пачка для управления сообщениями, чатами, пользователями и задачами.\n\n';
   content += `> Полная документация в одном файле: [llms-full.txt](${SITE_URL}/llms-full.txt)\n\n`;
+  content += `> English documentation: [llms-en.txt](${SITE_URL}/llms-en.txt)\n\n`;
 
   content += '## CLI Quick Start\n\n';
   content += '```bash\n';
@@ -1317,6 +1319,172 @@ async function generateGuideMdFiles() {
   return files;
 }
 
+/**
+ * Parse the English OpenAPI spec and generate a concise English API reference.
+ * Each endpoint: METHOD /path — description, parameters, request body fields.
+ */
+function generateEnglishApiReference(): string {
+  const enYamlPath = path.join(process.cwd(), '..', '..', 'packages', 'spec', 'openapi.en.yaml');
+  const fileContents = fs.readFileSync(enYamlPath, 'utf8');
+  const spec = yaml.load(fileContents) as Record<string, unknown>;
+
+  const paths = spec.paths as Record<string, Record<string, unknown>> | undefined;
+  const components = spec.components as Record<string, Record<string, unknown>> | undefined;
+  const schemas = (components?.schemas ?? {}) as Record<string, Record<string, unknown>>;
+
+  if (!paths) return '';
+
+  // Resolve top-level $ref in schemas
+  function resolveSchema(ref: unknown): Record<string, unknown> | undefined {
+    if (!ref || typeof ref !== 'object') return undefined;
+    const obj = ref as Record<string, unknown>;
+    if (typeof obj.$ref === 'string') {
+      const name = obj.$ref.replace('#/components/schemas/', '');
+      return schemas[name] as Record<string, unknown> | undefined;
+    }
+    return obj;
+  }
+
+  // Extract property names and descriptions from a schema
+  function getSchemaProperties(
+    schema: Record<string, unknown>
+  ): { name: string; desc: string; required: boolean }[] {
+    const props = schema.properties as Record<string, Record<string, unknown>> | undefined;
+    const requiredArr = (schema.required as string[]) ?? [];
+    if (!props) return [];
+    return Object.entries(props).map(([name, prop]) => ({
+      name,
+      desc: (prop.description as string) ?? '',
+      required: requiredArr.includes(name),
+    }));
+  }
+
+  // Group operations by tag
+  const grouped = new Map<
+    string,
+    { method: string; path: string; desc: string; params: string; body: string }[]
+  >();
+
+  const methodOrder = ['get', 'post', 'put', 'patch', 'delete'];
+  for (const [pathStr, pathItem] of Object.entries(paths)) {
+    for (const method of methodOrder) {
+      const operation = pathItem[method] as Record<string, unknown> | undefined;
+      if (!operation) continue;
+
+      const tag = ((operation.tags as string[]) ?? ['Other'])[0];
+      if (!grouped.has(tag)) grouped.set(tag, []);
+
+      // Description: first line is title, rest is detail
+      const rawDesc = (operation.description as string) ?? '';
+      const descLines = rawDesc
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      const desc = descLines.slice(1).join(' ').substring(0, 200) || descLines[0] || '';
+
+      // Parameters
+      const params = (operation.parameters as Record<string, unknown>[] | undefined) ?? [];
+      const paramStr = params
+        .filter((p) => p.in === 'query' || p.in === 'path')
+        .map((p) => {
+          const required = p.required ? '' : '?';
+          return `${p.name}${required}`;
+        })
+        .join(', ');
+
+      // Request body properties
+      let bodyStr = '';
+      const requestBody = operation.requestBody as Record<string, unknown> | undefined;
+      if (requestBody) {
+        const content = requestBody.content as Record<string, Record<string, unknown>> | undefined;
+        const jsonContent = content?.['application/json'] ?? content?.['multipart/form-data'];
+        if (jsonContent?.schema) {
+          const bodySchema = resolveSchema(jsonContent.schema);
+          if (bodySchema) {
+            const bodyProps = getSchemaProperties(bodySchema);
+            if (bodyProps.length > 0) {
+              // If there's a single wrapper property (like "chat" or "message"), dig into it
+              if (bodyProps.length === 1) {
+                const wrapper = bodyProps[0];
+                const wrapperSchema = resolveSchema(
+                  (bodySchema.properties as Record<string, unknown>)?.[wrapper.name]
+                );
+                if (wrapperSchema) {
+                  const innerProps = getSchemaProperties(wrapperSchema);
+                  if (innerProps.length > 0) {
+                    bodyStr = `{ ${wrapper.name}: { ${innerProps.map((p) => `${p.name}${p.required ? '*' : ''}`).join(', ')} } }`;
+                  }
+                }
+              }
+              if (!bodyStr) {
+                bodyStr = `{ ${bodyProps.map((p) => `${p.name}${p.required ? '*' : ''}`).join(', ')} }`;
+              }
+            }
+          }
+        }
+      }
+
+      grouped.get(tag)!.push({
+        method: method.toUpperCase(),
+        path: `/api/shared/v1${pathStr}`,
+        desc,
+        params: paramStr,
+        body: bodyStr,
+      });
+    }
+  }
+
+  let content = '# API Reference\n\n';
+  content += 'Base URL: `https://api.pachca.com/api/shared/v1`\n\n';
+  content += 'All endpoints require `Authorization: Bearer <TOKEN>` header.\n\n';
+
+  // Sort tags to match the spec order
+  const tagOrder = ((spec.tags as { name: string }[]) ?? []).map((t) => t.name);
+  const sortedTags = [...grouped.keys()].sort(
+    (a, b) =>
+      (tagOrder.indexOf(a) === -1 ? 999 : tagOrder.indexOf(a)) -
+      (tagOrder.indexOf(b) === -1 ? 999 : tagOrder.indexOf(b))
+  );
+
+  for (const tag of sortedTags) {
+    const endpoints = grouped.get(tag)!;
+    content += `## ${tag}\n\n`;
+    for (const ep of endpoints) {
+      content += `### ${ep.method} ${ep.path}\n`;
+      if (ep.desc) content += `${ep.desc}\n`;
+      if (ep.params) content += `Parameters: ${ep.params}\n`;
+      if (ep.body) content += `Body: ${ep.body}\n`;
+      content += '\n';
+    }
+  }
+
+  return content;
+}
+
+/**
+ * Generate an English-only documentation file for Context7 indexing.
+ * Combines: Library Rules + How-to Guides (with SDK examples) + English API Reference.
+ * Must stay under ~1M chars to avoid Context7's "File too large" filter.
+ */
+function generateLlmsEnTxt(): string {
+  let content = '# Pachca API — Complete English Documentation\n\n';
+  content +=
+    '> REST API for Pachca corporate messenger. Manage messages, chats, users, tasks, bots, and webhooks.\n\n';
+  content += '> Base URL: https://api.pachca.com/api/shared/v1\n\n';
+
+  content += generateLibraryRules();
+  content += '---\n\n';
+
+  const howToContent = generateHowToGuides();
+  validateSdkCodeBlocks('How-to Guides (EN)', howToContent);
+  content += howToContent;
+  content += '---\n\n';
+
+  content += generateEnglishApiReference();
+
+  return content;
+}
+
 const REPO_ROOT = path.join(process.cwd(), '..', '..');
 
 const UTF8_BOM = '\uFEFF';
@@ -1345,6 +1513,10 @@ async function main() {
   const llmsFullTxt = await generateLlmsFullTxt(api);
   writeFile('public/llms-full.txt', llmsFullTxt);
   console.log('✓ public/llms-full.txt');
+
+  const llmsEnTxt = generateLlmsEnTxt();
+  writeFile('public/llms-en.txt', llmsEnTxt);
+  console.log(`✓ public/llms-en.txt (${llmsEnTxt.length} chars)`);
 
   const skillMd = generateLegacySkillMd(api);
   writeFile('public/skill.md', skillMd);
@@ -1375,7 +1547,7 @@ async function main() {
   console.log(`✓ ${guideFiles.length} guide .md files`);
 
   console.log(
-    `\nTotal: ${6 + skillFiles.length + endpointFiles.length + guideFiles.length} files generated`
+    `\nTotal: ${7 + skillFiles.length + endpointFiles.length + guideFiles.length} files generated`
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds `llms-en.txt` — compact English-only documentation (35K chars) generated from existing content
- Context7 skips `llms-full.txt` (1.2M+ chars, "File too large") and filters Russian `.md` files as "different-language-content"
- The new file combines Library Rules + How-to Guides (with SDK examples) + English API reference from `openapi.en.yaml`
- References added to `llms.txt`, `llms-full.txt`, `index.md`, and `home.mdx`

## After merge

1. Add `apps/docs/public/llms-en.txt` to Context7 admin panel "Folders to Include"
2. Re-parse at https://context7.com/pachca/openapi/admin