### PR TITLE
Remove LinkSharedWebhookPayload from union

### DIFF
--- a/sdk/csharp/generated/Models.cs
+++ b/sdk/csharp/generated/Models.cs
@@ -1690,7 +1690,6 @@ public class ViewBlockFileInput : ViewBlockUnion
 [JsonDerivedType(typeof(ViewSubmitWebhookPayload), "view")]
 [JsonDerivedType(typeof(ChatMemberWebhookPayload), "chat_member")]
 [JsonDerivedType(typeof(CompanyMemberWebhookPayload), "company_member")]
-[JsonDerivedType(typeof(LinkSharedWebhookPayload), "message")]
 public abstract class WebhookPayloadUnion
 {
     [JsonPropertyName("type")]


### PR DESCRIPTION
type message был привязан дважды к двум различным классам. Убрал дубль, что бы это хоть как то работало.  Вероятно нужно поправить код на основе которого это генерируется.