### PR TITLE
fix(docs): generate date pages and OG images for release-only dates

### DIFF
--- a/apps/docs/app/api/og/route.tsx
+++ b/apps/docs/app/api/og/route.tsx
@@ -3,7 +3,7 @@ import { getEndpointByUrl } from '@/lib/openapi/parser';
 import { generateTitle } from '@/lib/openapi/mapper';
 import { getGuideData } from '@/lib/content-loader';
 import { getSectionTitle } from '@/lib/tabs-config';
-import { loadUpdates } from '@/lib/updates-parser';
+import { loadUpdates, loadReleases, formatDateRu } from '@/lib/updates-parser';
 import { type NextRequest } from 'next/server';
 
 // In-memory cache: URL → PNG buffer (max 50 entries)
@@ -120,6 +120,13 @@ async function generateMethodImage(path: string) {
   );
 }
 
+const OG_PRODUCT_TITLES: Record<string, string> = {
+  cli: 'CLI',
+  sdk: 'SDK',
+  generator: 'Generator',
+  n8n: 'n8n Node',
+};
+
 async function generateUpdatesImage(date: string | null) {
   if (!date) {
     return generateGuideImage('updates');
@@ -128,8 +135,20 @@ async function generateUpdatesImage(date: string | null) {
   const updates = loadUpdates();
   const latest = updates.find((u) => u.date === date);
 
-  if (!latest) {
-    return generateGuideImage('updates');
+  let displayDate: string;
+  let title: string;
+
+  if (latest) {
+    displayDate = latest.displayDate;
+    title = latest.title;
+  } else {
+    const releases = loadReleases().filter((r) => r.date === date);
+    if (releases.length === 0) {
+      return generateGuideImage('updates');
+    }
+    displayDate = formatDateRu(date);
+    const products = [...new Set(releases.map((r) => OG_PRODUCT_TITLES[r.product]))];
+    title = products.join(', ') + ' ' + releases.map((r) => `v${r.version}`).join(', ');
   }
 
   return createOgImageResponse(
@@ -155,7 +174,7 @@ async function generateUpdatesImage(date: string | null) {
             letterSpacing: '0.15em',
           }}
         >
-          {latest.displayDate}
+          {displayDate}
         </span>
         <span
           style={{
@@ -165,7 +184,7 @@ async function generateUpdatesImage(date: string | null) {
             lineHeight: 1.3,
           }}
         >
-          {latest.title}
+          {title}
         </span>
       </div>
       <span

--- a/apps/docs/app/updates/[date]/page.tsx
+++ b/apps/docs/app/updates/[date]/page.tsx
@@ -1,12 +1,21 @@
 import { UpdatesPageContent } from '@/components/api/updates-page-content';
 import { getGuideData } from '@/lib/content-loader';
-import { loadUpdates } from '@/lib/updates-parser';
+import { loadUpdates, loadReleases, formatDateRu } from '@/lib/updates-parser';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 
+const PRODUCT_TITLES: Record<string, string> = {
+  cli: 'CLI',
+  sdk: 'SDK',
+  generator: 'Generator',
+  n8n: 'n8n Node',
+};
+
 export async function generateStaticParams() {
   const updates = loadUpdates();
-  return updates.map((u) => ({ date: u.date }));
+  const releases = loadReleases();
+  const dates = new Set([...updates.map((u) => u.date), ...releases.map((r) => r.date)]);
+  return Array.from(dates).map((date) => ({ date }));
 }
 
 export async function generateMetadata({
@@ -17,24 +26,35 @@ export async function generateMetadata({
   const { date } = await params;
   const data = getGuideData('updates');
   const updates = loadUpdates();
+  const releases = loadReleases();
   const update = updates.find((u) => u.date === date);
+  const dateReleases = releases.filter((r) => r.date === date);
 
-  if (!data || !update) {
+  if (!data || (!update && dateReleases.length === 0)) {
     return { title: 'Страница не найдена' };
   }
 
-  const title = update.title;
-  const description = update.content
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    .replace(/\n+[-*]\s+/g, ', ')
-    .replace(/^[-*]\s+/gm, '')
-    .replace(/([:.]),/g, '$1')
-    .replace(/[#*`]/g, '')
-    .replace(/([^.!?:,])\n\n/g, '$1.\n\n')
-    .replace(/\n+/g, ' ')
-    .replace(/\s{2,}/g, ' ')
-    .slice(0, 200)
-    .trim();
+  let title: string;
+  let description: string;
+
+  if (update) {
+    title = update.title;
+    description = update.content
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/\n+[-*]\s+/g, ', ')
+      .replace(/^[-*]\s+/gm, '')
+      .replace(/([:.]),/g, '$1')
+      .replace(/[#*`]/g, '')
+      .replace(/([^.!?:,])\n\n/g, '$1.\n\n')
+      .replace(/\n+/g, ' ')
+      .replace(/\s{2,}/g, ' ')
+      .slice(0, 200)
+      .trim();
+  } else {
+    const products = [...new Set(dateReleases.map((r) => PRODUCT_TITLES[r.product]))].join(', ');
+    title = `${products} — ${formatDateRu(date)}`;
+    description = dateReleases.map((r) => `${PRODUCT_TITLES[r.product]} v${r.version}`).join(', ');
+  }
 
   return {
     title: { absolute: `${title} | Руководство разработчика` },
@@ -55,9 +75,11 @@ export async function generateMetadata({
 export default async function UpdateDatePage({ params }: { params: Promise<{ date: string }> }) {
   const { date } = await params;
   const updates = loadUpdates();
+  const releases = loadReleases();
   const update = updates.find((u) => u.date === date);
+  const dateReleases = releases.filter((r) => r.date === date);
 
-  if (!update) {
+  if (!update && dateReleases.length === 0) {
     notFound();
   }
 


### PR DESCRIPTION
Extend /updates/[date] to generate pages for dates that have only product releases (no API updates). Previously these returned 404. Also fix OG image generation to show release info for such dates.