### PR TITLE
feat(docs): add Fira Code as monospace font via next/font/google

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -59,9 +59,7 @@
   --mobile-nav-height: 0px;
   --scroll-offset: calc(var(--mobile-header-height) + var(--mobile-nav-height) + 24px);
 
-  /* Font Families — sans is set by next/font on <html>, mono is for code blocks */
-  --font-mono:
-    'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  /* Font Families — sans is set by next/font on <html>, mono is set via --font-mono CSS variable from next/font (JetBrains Mono) */
 }
 
 @media (max-width: 1023px) {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
+import { Inter, Fira_Code } from 'next/font/google';
 import { Sidebar } from '@/components/layout/sidebar-wrapper';
 import { HeaderServer } from '@/components/layout/header-wrapper';
 import { TransitionProvider } from '@/components/layout/transition-provider';
@@ -11,6 +11,12 @@ import './globals.css';
 const inter = Inter({
   subsets: ['cyrillic', 'latin'],
   display: 'swap',
+});
+
+const firaCode = Fira_Code({
+  subsets: ['cyrillic', 'latin'],
+  display: 'swap',
+  variable: '--font-mono',
 });
 
 export const viewport: Viewport = {
@@ -95,7 +101,11 @@ const jsonLd = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ru" className={`min-h-screen ${inter.className}`} suppressHydrationWarning>
+    <html
+      lang="ru"
+      className={`min-h-screen ${inter.className} ${firaCode.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#36373d" media="(prefers-color-scheme: dark)" />

--- a/apps/docs/components/api/updates-list.tsx
+++ b/apps/docs/components/api/updates-list.tsx
@@ -190,7 +190,7 @@ export async function UpdatesList() {
               }`}
             />
             <div className="flex flex-col mb-3">
-              <span className="text-[11px] font-mono font-bold text-text-tertiary uppercase tracking-widest leading-none mb-2">
+              <span className="text-[12px] font-mono font-bold text-text-tertiary uppercase tracking-widest leading-none mb-2">
                 {group.displayDate}
               </span>
 


### PR DESCRIPTION
Replace system monospace stack with Fira Code for consistent rendering across all platforms. Date font weight fix in updates timeline.