### PR TITLE
fix(sdk): TS SDK ESM/CJS dual-publish + object-form stub

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -6,11 +6,6 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      e2e:
-        description: "Run E2E tests against real backend"
-        type: boolean
-        default: false
 
 concurrency:
   group: sdk-${{ github.ref }}
@@ -49,7 +44,7 @@ jobs:
         working-directory: packages/openapi-parser
         run: bun run build
       - name: Generate SDKs
-        run: npx turbo run generate
+        run: bunx turbo run generate
 
       - name: Check for SDK changes
         id: sdk_changes
@@ -99,17 +94,17 @@ jobs:
 
       - name: Build TypeScript SDK
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.ts_changed == 'true'
-        run: npm run build
+        run: bun run build
         working-directory: sdk/typescript
 
       - name: Smoke test TypeScript SDK under Node
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.ts_changed == 'true'
-        run: npm run test:node
+        run: bun run test:node
         working-directory: sdk/typescript
 
       - name: Verify TypeScript SDK package (attw)
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.ts_changed == 'true'
-        run: npm run verify
+        run: bun run verify
         working-directory: sdk/typescript
 
       - name: Compile Go SDK
@@ -121,14 +116,6 @@ jobs:
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.kotlin_changed == 'true'
         working-directory: sdk/kotlin/generated
         run: ./gradlew compileKotlin -Pversion=0.0.0
-
-      - name: E2E Kotlin
-        if: inputs.e2e
-        working-directory: sdk/kotlin/generated
-        env:
-          PACHCA_BASE_URL: https://api.pachca.com/api/shared/v1
-          PACHCA_TOKEN: ${{ secrets.PACHCA_TEST_TOKEN }}
-        run: ./gradlew test -Pversion=0.0.0
 
       - name: Check Python SDK
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.python_changed == 'true'
@@ -223,10 +210,13 @@ jobs:
         run: |
           sed -i 's/"version": "0.0.0"/"version": "${{ needs.generate-and-build.outputs.version }}"/' package.json
       - name: Build TypeScript SDK
-        run: npm run build
+        run: bun run build
         working-directory: sdk/typescript
       - name: Smoke test TypeScript SDK under Node
-        run: npm run test:node
+        run: bun run test:node
+        working-directory: sdk/typescript
+      - name: Verify TypeScript SDK package (attw)
+        run: bun run verify
         working-directory: sdk/typescript
       - name: Publish to npm
         working-directory: sdk/typescript
@@ -281,9 +271,9 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           cd packages/cli && node -e "const fs=require('fs'),p=JSON.parse(fs.readFileSync('package.json'));p.version='$VERSION';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
       - name: Generate changelog
-        run: npx tsx scripts/diff-endpoints.ts
+        run: bun scripts/diff-endpoints.ts
         working-directory: packages/cli
-      - run: npm run build
+      - run: bun run build
         working-directory: packages/cli
       - working-directory: packages/cli
         env:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      e2e:
+        description: "Run E2E tests against real backend"
+        type: boolean
+        default: false
 
 concurrency:
   group: sdk-${{ github.ref }}
@@ -97,6 +102,11 @@ jobs:
         run: npm run build
         working-directory: sdk/typescript
 
+      - name: Smoke test TypeScript SDK under Node
+        if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.ts_changed == 'true'
+        run: npm run test:node
+        working-directory: sdk/typescript
+
       - name: Compile Go SDK
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.go_changed == 'true'
         working-directory: sdk/go/generated
@@ -106,6 +116,14 @@ jobs:
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.kotlin_changed == 'true'
         working-directory: sdk/kotlin/generated
         run: ./gradlew compileKotlin -Pversion=0.0.0
+
+      - name: E2E Kotlin
+        if: inputs.e2e
+        working-directory: sdk/kotlin/generated
+        env:
+          PACHCA_BASE_URL: https://api.pachca.com/api/shared/v1
+          PACHCA_TOKEN: ${{ secrets.PACHCA_TEST_TOKEN }}
+        run: ./gradlew test -Pversion=0.0.0
 
       - name: Check Python SDK
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.python_changed == 'true'
@@ -201,6 +219,9 @@ jobs:
           sed -i 's/"version": "0.0.0"/"version": "${{ needs.generate-and-build.outputs.version }}"/' package.json
       - name: Build TypeScript SDK
         run: npm run build
+        working-directory: sdk/typescript
+      - name: Smoke test TypeScript SDK under Node
+        run: npm run test:node
         working-directory: sdk/typescript
       - name: Publish to npm
         working-directory: sdk/typescript

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -107,6 +107,11 @@ jobs:
         run: npm run test:node
         working-directory: sdk/typescript
 
+      - name: Verify TypeScript SDK package (attw)
+        if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.ts_changed == 'true'
+        run: npm run verify
+        working-directory: sdk/typescript
+
       - name: Compile Go SDK
         if: github.event_name != 'pull_request' || steps.sdk_changes.outputs.go_changed == 'true'
         working-directory: sdk/go/generated

--- a/packages/generator/src/lang/typescript.ts
+++ b/packages/generator/src/lang/typescript.ts
@@ -497,11 +497,11 @@ function generateClient(ir: IR): { content: string; needsUtils: boolean } {
     lines.push('  }');
     lines.push('');
     // Static stub() factory method
-    const stubArgs = serviceEntries.map((s) => `${s.prop}: ${s.cls} = new ${s.cls}()`);
-    lines.push(`  static stub(${stubArgs.join(', ')}): PachcaClient {`);
+    const stubFields = serviceEntries.map((s) => `${s.prop}?: ${s.cls}`).join('; ');
+    lines.push(`  static stub(overrides: { ${stubFields} } = {}): PachcaClient {`);
     lines.push('    const client = Object.create(PachcaClient.prototype);');
     for (const s of serviceEntries) {
-      lines.push(`    client.${s.prop} = ${s.prop};`);
+      lines.push(`    client.${s.prop} = overrides.${s.prop} ?? new ${s.cls}();`);
     }
     lines.push('    return client;');
     lines.push('  }');

--- a/packages/generator/src/lang/typescript.ts
+++ b/packages/generator/src/lang/typescript.ts
@@ -435,11 +435,11 @@ function generateClient(ir: IR): { content: string; needsUtils: boolean } {
   const typesList = importedTypes;
   if (typesList.length > 0) {
     if (typesList.length <= 3) {
-      lines.push(`import { ${typesList.join(', ')} } from "./types";`);
+      lines.push(`import { ${typesList.join(', ')} } from "./types.js";`);
     } else {
       lines.push('import {');
       for (const t of typesList) lines.push(`  ${t},`);
-      lines.push('} from "./types";');
+      lines.push('} from "./types.js";');
     }
   }
 
@@ -451,7 +451,7 @@ function generateClient(ir: IR): { content: string; needsUtils: boolean } {
     ]
       .filter((x): x is string => !!x)
       .join(', ');
-    lines.push(`import { ${utils} } from "./utils";`);
+    lines.push(`import { ${utils} } from "./utils.js";`);
   }
 
   if (hasServices) lines.push('');

--- a/packages/generator/tests/additional-props-bool/snapshots/ts/client.ts
+++ b/packages/generator/tests/additional-props-bool/snapshots/ts/client.ts
@@ -1,1 +1,1 @@
-import { Metadata, Event } from "./types";
+import { Metadata, Event } from "./types.js";

--- a/packages/generator/tests/allof-sibling/snapshots/ts/client.ts
+++ b/packages/generator/tests/allof-sibling/snapshots/ts/client.ts
@@ -1,1 +1,1 @@
-import { BaseEntity, Article } from "./types";
+import { BaseEntity, Article } from "./types.js";

--- a/packages/generator/tests/array-no-brackets/snapshots/ts/client.ts
+++ b/packages/generator/tests/array-no-brackets/snapshots/ts/client.ts
@@ -3,8 +3,8 @@ import {
   SearchMessagesResponse,
   MessageResult,
   OAuthError,
-} from "./types";
-import { deserialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, fetchWithRetry } from "./utils.js";
 
 export class SearchService {
   async searchMessages(params: SearchMessagesParams): Promise<SearchMessagesResponse> {

--- a/packages/generator/tests/array-no-brackets/snapshots/ts/client.ts
+++ b/packages/generator/tests/array-no-brackets/snapshots/ts/client.ts
@@ -83,9 +83,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(search: SearchService = new SearchService()): PachcaClient {
+  static stub(overrides: { search?: SearchService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.search = search;
+    client.search = overrides.search ?? new SearchService();
     return client;
   }
 }

--- a/packages/generator/tests/circular-ref/snapshots/ts/client.ts
+++ b/packages/generator/tests/circular-ref/snapshots/ts/client.ts
@@ -1,1 +1,1 @@
-import { Category, TreeNode } from "./types";
+import { Category, TreeNode } from "./types.js";

--- a/packages/generator/tests/crud/snapshots/ts/client.ts
+++ b/packages/generator/tests/crud/snapshots/ts/client.ts
@@ -182,9 +182,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(chats: ChatsService = new ChatsService()): PachcaClient {
+  static stub(overrides: { chats?: ChatsService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.chats = chats;
+    client.chats = overrides.chats ?? new ChatsService();
     return client;
   }
 }

--- a/packages/generator/tests/crud/snapshots/ts/client.ts
+++ b/packages/generator/tests/crud/snapshots/ts/client.ts
@@ -6,8 +6,8 @@ import {
   ApiError,
   ChatCreateRequest,
   ChatUpdateRequest,
-} from "./types";
-import { deserialize, serialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, serialize, fetchWithRetry } from "./utils.js";
 
 export class ChatsService {
   async listChats(params?: ListChatsParams): Promise<ListChatsResponse> {

--- a/packages/generator/tests/date-format/snapshots/ts/client.ts
+++ b/packages/generator/tests/date-format/snapshots/ts/client.ts
@@ -82,9 +82,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(export: ExportService = new ExportService()): PachcaClient {
+  static stub(overrides: { export?: ExportService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.export = export;
+    client.export = overrides.export ?? new ExportService();
     return client;
   }
 }

--- a/packages/generator/tests/date-format/snapshots/ts/client.ts
+++ b/packages/generator/tests/date-format/snapshots/ts/client.ts
@@ -4,8 +4,8 @@ import {
   OAuthError,
   ExportRequest,
   Export,
-} from "./types";
-import { deserialize, serialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, serialize, fetchWithRetry } from "./utils.js";
 
 export class ExportService {
   async listEvents(params: ListEventsParams): Promise<ListEventsResponse> {

--- a/packages/generator/tests/deep-nesting/snapshots/ts/client.ts
+++ b/packages/generator/tests/deep-nesting/snapshots/ts/client.ts
@@ -3,4 +3,4 @@ import {
   OrganizationSettingsNotificationsPush,
   OrganizationSettingsNotifications,
   Organization,
-} from "./types";
+} from "./types.js";

--- a/packages/generator/tests/edge-cases/snapshots/ts/client.ts
+++ b/packages/generator/tests/edge-cases/snapshots/ts/client.ts
@@ -115,10 +115,10 @@ export class PachcaClient {
     }
   }
 
-  static stub(events: EventsService = new EventsService(), uploads: UploadsService = new UploadsService()): PachcaClient {
+  static stub(overrides: { events?: EventsService; uploads?: UploadsService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.events = events;
-    client.uploads = uploads;
+    client.events = overrides.events ?? new EventsService();
+    client.uploads = overrides.uploads ?? new UploadsService();
     return client;
   }
 }

--- a/packages/generator/tests/edge-cases/snapshots/ts/client.ts
+++ b/packages/generator/tests/edge-cases/snapshots/ts/client.ts
@@ -4,8 +4,8 @@ import {
   OAuthScope,
   Event,
   UploadRequest,
-} from "./types";
-import { deserialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, fetchWithRetry } from "./utils.js";
 
 export class EventsService {
   async listEvents(params?: ListEventsParams): Promise<ListEventsResponse> {

--- a/packages/generator/tests/enums/snapshots/ts/client.ts
+++ b/packages/generator/tests/enums/snapshots/ts/client.ts
@@ -1,1 +1,1 @@
-import { SortOrder, UserRole, ViewBlockHeaderType } from "./types";
+import { SortOrder, UserRole, ViewBlockHeaderType } from "./types.js";

--- a/packages/generator/tests/models/snapshots/ts/client.ts
+++ b/packages/generator/tests/models/snapshots/ts/client.ts
@@ -13,4 +13,4 @@ import {
   OAuthError,
   PaginationMeta,
   SearchPaginationMeta,
-} from "./types";
+} from "./types.js";

--- a/packages/generator/tests/multi-path-params/snapshots/ts/client.ts
+++ b/packages/generator/tests/multi-path-params/snapshots/ts/client.ts
@@ -1,5 +1,5 @@
-import { Task, TaskUpdateRequest } from "./types";
-import { deserialize, serialize, fetchWithRetry } from "./utils";
+import { Task, TaskUpdateRequest } from "./types.js";
+import { deserialize, serialize, fetchWithRetry } from "./utils.js";
 
 export class TasksService {
   async getTask(projectId: number, taskId: number): Promise<Task> {

--- a/packages/generator/tests/multi-path-params/snapshots/ts/client.ts
+++ b/packages/generator/tests/multi-path-params/snapshots/ts/client.ts
@@ -86,9 +86,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(tasks: TasksService = new TasksService()): PachcaClient {
+  static stub(overrides: { tasks?: TasksService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.tasks = tasks;
+    client.tasks = overrides.tasks ?? new TasksService();
     return client;
   }
 }

--- a/packages/generator/tests/nullable-ref/snapshots/ts/client.ts
+++ b/packages/generator/tests/nullable-ref/snapshots/ts/client.ts
@@ -1,1 +1,1 @@
-import { Address, Person } from "./types";
+import { Address, Person } from "./types.js";

--- a/packages/generator/tests/oneof/snapshots/ts/client.ts
+++ b/packages/generator/tests/oneof/snapshots/ts/client.ts
@@ -3,4 +3,4 @@ import {
   ImageContent,
   VideoContent,
   ContentBlock,
-} from "./types";
+} from "./types.js";

--- a/packages/generator/tests/patch/snapshots/ts/client.ts
+++ b/packages/generator/tests/patch/snapshots/ts/client.ts
@@ -1,5 +1,5 @@
-import { ItemPatchRequest, Item, ApiError } from "./types";
-import { deserialize, serialize, fetchWithRetry } from "./utils";
+import { ItemPatchRequest, Item, ApiError } from "./types.js";
+import { deserialize, serialize, fetchWithRetry } from "./utils.js";
 
 export class ItemsService {
   async patchItem(id: number, request: ItemPatchRequest): Promise<Item> {

--- a/packages/generator/tests/patch/snapshots/ts/client.ts
+++ b/packages/generator/tests/patch/snapshots/ts/client.ts
@@ -52,9 +52,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(items: ItemsService = new ItemsService()): PachcaClient {
+  static stub(overrides: { items?: ItemsService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.items = items;
+    client.items = overrides.items ?? new ItemsService();
     return client;
   }
 }

--- a/packages/generator/tests/record/snapshots/ts/client.ts
+++ b/packages/generator/tests/record/snapshots/ts/client.ts
@@ -53,9 +53,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(linkPreviews: LinkPreviewsService = new LinkPreviewsService()): PachcaClient {
+  static stub(overrides: { linkPreviews?: LinkPreviewsService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.linkPreviews = linkPreviews;
+    client.linkPreviews = overrides.linkPreviews ?? new LinkPreviewsService();
     return client;
   }
 }

--- a/packages/generator/tests/record/snapshots/ts/client.ts
+++ b/packages/generator/tests/record/snapshots/ts/client.ts
@@ -1,5 +1,5 @@
-import { LinkPreviewsRequest, OAuthError, ApiError } from "./types";
-import { serialize, fetchWithRetry } from "./utils";
+import { LinkPreviewsRequest, OAuthError, ApiError } from "./types.js";
+import { serialize, fetchWithRetry } from "./utils.js";
 
 export class LinkPreviewsService {
   async createLinkPreviews(id: number, request: LinkPreviewsRequest): Promise<void> {

--- a/packages/generator/tests/redirect/snapshots/ts/client.ts
+++ b/packages/generator/tests/redirect/snapshots/ts/client.ts
@@ -57,9 +57,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(common: CommonService = new CommonService()): PachcaClient {
+  static stub(overrides: { common?: CommonService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.common = common;
+    client.common = overrides.common ?? new CommonService();
     return client;
   }
 }

--- a/packages/generator/tests/redirect/snapshots/ts/client.ts
+++ b/packages/generator/tests/redirect/snapshots/ts/client.ts
@@ -1,5 +1,5 @@
-import { OAuthError, ApiError } from "./types";
-import { fetchWithRetry } from "./utils";
+import { OAuthError, ApiError } from "./types.js";
+import { fetchWithRetry } from "./utils.js";
 
 export class CommonService {
   async downloadExport(id: number): Promise<string> {

--- a/packages/generator/tests/reserved-keywords/snapshots/ts/client.ts
+++ b/packages/generator/tests/reserved-keywords/snapshots/ts/client.ts
@@ -1,1 +1,1 @@
-import { Entity } from "./types";
+import { Entity } from "./types.js";

--- a/packages/generator/tests/search/snapshots/ts/client.ts
+++ b/packages/generator/tests/search/snapshots/ts/client.ts
@@ -86,9 +86,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(search: SearchService = new SearchService()): PachcaClient {
+  static stub(overrides: { search?: SearchService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.search = search;
+    client.search = overrides.search ?? new SearchService();
     return client;
   }
 }

--- a/packages/generator/tests/search/snapshots/ts/client.ts
+++ b/packages/generator/tests/search/snapshots/ts/client.ts
@@ -3,8 +3,8 @@ import {
   SearchMessagesResponse,
   MessageSearchResult,
   OAuthError,
-} from "./types";
-import { deserialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, fetchWithRetry } from "./utils.js";
 
 export class SearchService {
   async searchMessages(params: SearchMessagesParams): Promise<SearchMessagesResponse> {

--- a/packages/generator/tests/unions/snapshots/ts/client.ts
+++ b/packages/generator/tests/unions/snapshots/ts/client.ts
@@ -3,4 +3,4 @@ import {
   ViewBlockPlainText,
   ViewBlockImage,
   ViewBlockUnion,
-} from "./types";
+} from "./types.js";

--- a/packages/generator/tests/unwrap/snapshots/ts/client.ts
+++ b/packages/generator/tests/unwrap/snapshots/ts/client.ts
@@ -112,10 +112,10 @@ export class PachcaClient {
     }
   }
 
-  static stub(chats: ChatsService = new ChatsService(), members: MembersService = new MembersService()): PachcaClient {
+  static stub(overrides: { chats?: ChatsService; members?: MembersService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.chats = chats;
-    client.members = members;
+    client.chats = overrides.chats ?? new ChatsService();
+    client.members = overrides.members ?? new MembersService();
     return client;
   }
 }

--- a/packages/generator/tests/unwrap/snapshots/ts/client.ts
+++ b/packages/generator/tests/unwrap/snapshots/ts/client.ts
@@ -3,8 +3,8 @@ import {
   ApiError,
   ChatCreateRequest,
   Chat,
-} from "./types";
-import { deserialize, serialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, serialize, fetchWithRetry } from "./utils.js";
 
 export class MembersService {
   async addMembers(id: number, memberIds: number[]): Promise<void> {

--- a/packages/generator/tests/upload/snapshots/ts/client.ts
+++ b/packages/generator/tests/upload/snapshots/ts/client.ts
@@ -82,9 +82,9 @@ export class PachcaClient {
     }
   }
 
-  static stub(common: CommonService = new CommonService()): PachcaClient {
+  static stub(overrides: { common?: CommonService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.common = common;
+    client.common = overrides.common ?? new CommonService();
     return client;
   }
 }

--- a/packages/generator/tests/upload/snapshots/ts/client.ts
+++ b/packages/generator/tests/upload/snapshots/ts/client.ts
@@ -1,5 +1,5 @@
-import { FileUploadRequest, OAuthError, UploadParams } from "./types";
-import { deserialize, fetchWithRetry } from "./utils";
+import { FileUploadRequest, OAuthError, UploadParams } from "./types.js";
+import { deserialize, fetchWithRetry } from "./utils.js";
 
 export class CommonService {
   async uploadFile(directUrl: string, request: FileUploadRequest): Promise<void> {

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -10,6 +10,8 @@ npm install @pachca/sdk
 
 ## Использование
 
+ESM:
+
 ```typescript
 import { PachcaClient } from "@pachca/sdk";
 
@@ -22,6 +24,14 @@ const message = await pachca.messages.createMessage({
 
 // Список пользователей
 const users = await pachca.users.listUsers();
+```
+
+CommonJS:
+
+```javascript
+const { PachcaClient } = require("@pachca/sdk");
+
+const pachca = new PachcaClient("YOUR_TOKEN");
 ```
 
 ## Конвенции

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "setup": "true",
     "generate": "bun ../../packages/generator/bin/generator.ts --spec ../../packages/spec/openapi.yaml --output . --lang typescript --examples && rm -rf src/generated && mv ts src/generated",
-    "build": "tsc"
+    "build": "tsc",
+    "test:node": "node test/smoke.mjs"
   },
   "dependencies": {},
   "devDependencies": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "exports": {
     ".": {
       "import": {
@@ -33,7 +33,7 @@
     "build": "tsc && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "typecheck": "tsc --noEmit",
     "test:node": "node test/smoke.mjs && node test/smoke.cjs",
-    "verify": "npx --yes @arethetypeswrong/cli --pack ."
+    "verify": "bunx --bun @arethetypeswrong/cli --pack ."
   },
   "dependencies": {},
   "devDependencies": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -2,18 +2,25 @@
   "name": "@pachca/sdk",
   "version": "0.0.0",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": ["dist", "src/generated"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/pachca/openapi.git",
+    "url": "git+https://github.com/pachca/openapi.git",
     "directory": "sdk/typescript"
   },
   "publishConfig": {
@@ -23,8 +30,10 @@
   "scripts": {
     "setup": "true",
     "generate": "bun ../../packages/generator/bin/generator.ts --spec ../../packages/spec/openapi.yaml --output . --lang typescript --examples && rm -rf src/generated && mv ts src/generated",
-    "build": "tsc",
-    "test:node": "node test/smoke.mjs"
+    "build": "tsc && tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json','{\\\"type\\\":\\\"commonjs\\\"}')\"",
+    "typecheck": "tsc --noEmit",
+    "test:node": "node test/smoke.mjs && node test/smoke.cjs",
+    "verify": "npx --yes @arethetypeswrong/cli --pack ."
   },
   "dependencies": {},
   "devDependencies": {

--- a/sdk/typescript/src/generated/client.ts
+++ b/sdk/typescript/src/generated/client.ts
@@ -1972,24 +1972,24 @@ export class PachcaClient {
     }
   }
 
-  static stub(bots: BotsService = new BotsService(), chats: ChatsService = new ChatsService(), common: CommonService = new CommonService(), groupTags: GroupTagsService = new GroupTagsService(), linkPreviews: LinkPreviewsService = new LinkPreviewsService(), members: MembersService = new MembersService(), messages: MessagesService = new MessagesService(), profile: ProfileService = new ProfileService(), reactions: ReactionsService = new ReactionsService(), readMembers: ReadMembersService = new ReadMembersService(), search: SearchService = new SearchService(), security: SecurityService = new SecurityService(), tasks: TasksService = new TasksService(), threads: ThreadsService = new ThreadsService(), users: UsersService = new UsersService(), views: ViewsService = new ViewsService()): PachcaClient {
+  static stub(overrides: { bots?: BotsService; chats?: ChatsService; common?: CommonService; groupTags?: GroupTagsService; linkPreviews?: LinkPreviewsService; members?: MembersService; messages?: MessagesService; profile?: ProfileService; reactions?: ReactionsService; readMembers?: ReadMembersService; search?: SearchService; security?: SecurityService; tasks?: TasksService; threads?: ThreadsService; users?: UsersService; views?: ViewsService } = {}): PachcaClient {
     const client = Object.create(PachcaClient.prototype);
-    client.bots = bots;
-    client.chats = chats;
-    client.common = common;
-    client.groupTags = groupTags;
-    client.linkPreviews = linkPreviews;
-    client.members = members;
-    client.messages = messages;
-    client.profile = profile;
-    client.reactions = reactions;
-    client.readMembers = readMembers;
-    client.search = search;
-    client.security = security;
-    client.tasks = tasks;
-    client.threads = threads;
-    client.users = users;
-    client.views = views;
+    client.bots = overrides.bots ?? new BotsService();
+    client.chats = overrides.chats ?? new ChatsService();
+    client.common = overrides.common ?? new CommonService();
+    client.groupTags = overrides.groupTags ?? new GroupTagsService();
+    client.linkPreviews = overrides.linkPreviews ?? new LinkPreviewsService();
+    client.members = overrides.members ?? new MembersService();
+    client.messages = overrides.messages ?? new MessagesService();
+    client.profile = overrides.profile ?? new ProfileService();
+    client.reactions = overrides.reactions ?? new ReactionsService();
+    client.readMembers = overrides.readMembers ?? new ReadMembersService();
+    client.search = overrides.search ?? new SearchService();
+    client.security = overrides.security ?? new SecurityService();
+    client.tasks = overrides.tasks ?? new TasksService();
+    client.threads = overrides.threads ?? new ThreadsService();
+    client.users = overrides.users ?? new UsersService();
+    client.views = overrides.views ?? new ViewsService();
     return client;
   }
 }

--- a/sdk/typescript/src/generated/client.ts
+++ b/sdk/typescript/src/generated/client.ts
@@ -63,8 +63,8 @@ import {
   UserCreateRequest,
   UserUpdateRequest,
   OpenViewRequest,
-} from "./types";
-import { deserialize, serialize, fetchWithRetry } from "./utils";
+} from "./types.js";
+import { deserialize, serialize, fetchWithRetry } from "./utils.js";
 
 export class SecurityService {
   async getAuditEvents(params?: GetAuditEventsParams): Promise<GetAuditEventsResponse> {

--- a/sdk/typescript/test/smoke.cjs
+++ b/sdk/typescript/test/smoke.cjs
@@ -12,10 +12,7 @@ class FakeMessages extends MessagesService {
   }
 }
 
-const client = PachcaClient.stub(
-  undefined, undefined, undefined, undefined, undefined, undefined,
-  new FakeMessages(),
-);
+const client = PachcaClient.stub({ messages: new FakeMessages() });
 
 (async () => {
   const msg = await client.messages.getMessage(1);

--- a/sdk/typescript/test/smoke.cjs
+++ b/sdk/typescript/test/smoke.cjs
@@ -1,0 +1,27 @@
+// Node CommonJS smoke test against the built dist/cjs/.
+// Verifies the package can be `require()`d from a CommonJS consumer.
+//
+// Run after `npm run build`:
+//   node test/smoke.cjs
+
+const { PachcaClient, MessagesService } = require("../dist/cjs/index.js");
+
+class FakeMessages extends MessagesService {
+  async getMessage(_id) {
+    return { id: 1, content: "fake message" };
+  }
+}
+
+const client = PachcaClient.stub(
+  undefined, undefined, undefined, undefined, undefined, undefined,
+  new FakeMessages(),
+);
+
+(async () => {
+  const msg = await client.messages.getMessage(1);
+  if (msg.content !== "fake message" || msg.id !== 1) {
+    console.error("smoke failed: unexpected stub response", msg);
+    process.exit(1);
+  }
+  console.log("smoke ok (cjs)");
+})();

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -13,10 +13,7 @@ class FakeMessages extends MessagesService {
   }
 }
 
-const client = PachcaClient.stub(
-  undefined, undefined, undefined, undefined, undefined, undefined,
-  new FakeMessages(),
-);
+const client = PachcaClient.stub({ messages: new FakeMessages() });
 
 const msg = await client.messages.getMessage(1);
 if (msg.content !== "fake message" || msg.id !== 1) {

--- a/sdk/typescript/test/smoke.mjs
+++ b/sdk/typescript/test/smoke.mjs
@@ -1,0 +1,26 @@
+// Node ESM smoke test against the built dist/.
+// Verifies the published artifact resolves under Node's strict ESM resolver
+// (catches missing .js extensions in generated imports).
+//
+// Run after `npm run build`:
+//   node test/smoke.mjs
+
+import { PachcaClient, MessagesService } from "../dist/index.js";
+
+class FakeMessages extends MessagesService {
+  async getMessage(_id) {
+    return { id: 1, content: "fake message" };
+  }
+}
+
+const client = PachcaClient.stub(
+  undefined, undefined, undefined, undefined, undefined, undefined,
+  new FakeMessages(),
+);
+
+const msg = await client.messages.getMessage(1);
+if (msg.content !== "fake message" || msg.id !== 1) {
+  console.error("smoke failed: unexpected stub response", msg);
+  process.exit(1);
+}
+console.log("smoke ok");

--- a/sdk/typescript/tsconfig.cjs.json
+++ b/sdk/typescript/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node10",
+    "outDir": "dist/cjs",
+    "verbatimModuleSyntax": false
+  }
+}


### PR DESCRIPTION
## Summary

- **Generator**: emit `.js` extensions on TypeScript relative imports so the published artifact resolves under Node's strict ESM resolver.
- **Generator**: change `PachcaClient.stub()` from 16 positional args to a single optional overrides object (`{ messages?: ..., ... }`) — robust to service additions and matches the README.
- **SDK packaging**: dual-publish ESM (`dist/`) + CJS (`dist/cjs/`) with a co-located `{"type":"commonjs"}` shim and conditional `exports` map. Top-level `types` aligned with `main` for legacy resolvers.
- **CI**: build TS SDK, run ESM + CJS smoke tests against the dist, and validate the package with `attw --pack` on both PRs and pre-publish.
- **CI hygiene**: drop the unused Kotlin E2E step and `workflow_dispatch.e2e` input; standardize on `bun`/`bunx` for script execution (npm publish + npm view kept for canonical registry/provenance ops).

## Test plan

- [x] `bun run --cwd packages/generator test` — 21/21 generator tests pass with regenerated snapshots.
- [x] `bun run --cwd sdk/typescript build` — emits both `dist/` (ESM) and `dist/cjs/` (CJS).
- [x] `bun run --cwd sdk/typescript test:node` — both `smoke.mjs` and `smoke.cjs` exercise the built artifacts.
- [x] `bun run --cwd sdk/typescript typecheck` — clean.
- [ ] CI: `attw --pack .` reports a clean exports map.
- [ ] CI: SDK build / smoke / verify run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the published TypeScript package entrypoints/exports and the generated client API (`PachcaClient.stub` signature), which can break existing consumers and tests if misconfigured.
> 
> **Overview**
> **TypeScript SDK packaging is updated to support both Node ESM and CommonJS consumers.** The SDK now builds ESM to `dist/` and an additional CJS build to `dist/cjs/`, with a conditional `exports` map and aligned `main`/`types` fields; new Node smoke tests validate both import styles and `attw` verification is added.
> 
> **The TypeScript generator output is made ESM-safe and the testing stub API is simplified.** Generated relative imports now include `.js` extensions (e.g., `./types.js`, `./utils.js`), and `PachcaClient.stub()` switches from many positional args to a single optional `overrides` object; snapshots and the generated SDK client are updated accordingly.
> 
> **CI/workflow steps are standardized on Bun tooling.** The SDK workflow uses `bunx`/`bun` for generation/build, adds TS build+smoke+verify steps on relevant changes, and updates the CLI changelog/build steps to Bun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e595ffa7f3388cc7f77134ae10e1f41197190f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->