### PR TITLE
ci(gitlab-sync): force-push mirror

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Push to GitLab
         run: |
           git remote add gitlab https://maximov:${{ secrets.GITLAB_TOKEN }}@gitlab.primaverahq.com/mp/docs.git
-          git push gitlab main:main
+          git push --force gitlab main:main


### PR DESCRIPTION
After the sensitive-data history rewrite of `main`, the GitLab mirror diverged and the plain `git push gitlab main:main` fails non-fast-forward (won't self-heal). GitLab here is a **one-directional read-only mirror**, so `--force` is the correct, robust config — it overwrites the mirror with the current clean `main` on every sync and is immune to future history operations.

On merge, the push to `main` triggers **Gitlab sync** which now force-pushes the clean `main`, fixing the divergence in one run. Recommend keeping `--force` permanently (no revert needed) for mirror robustness; revert is a one-line follow-up if you prefer the old behavior.