### PR TITLE
chore(docs): update product updates link to 18 May 2026 entry

### DIFF
--- a/apps/docs/components/mdx/mdx-components.tsx
+++ b/apps/docs/components/mdx/mdx-components.tsx
@@ -447,8 +447,8 @@ export async function ScopeRoles() {
 
 // Update manually when a new product release goes out
 const LATEST_PRODUCT_UPDATE = {
-  date: '27 мая 2026',
-  title: 'Есть что переслать 📤',
+  date: '18 мая 2026',
+  title: 'Новое окно прочитавших и поставивших реакцию',
 };
 
 export function ProductUpdatesLink() {


### PR DESCRIPTION
Point the <ProductUpdatesLink /> badge at the new pachca.com/updates release ('Новое окно прочитавших и поставивших реакцию', 18 мая 2026). Also fixes the previous entry's incorrect month (was '27 мая', the 'Есть что переслать' release is dated 27.04.26).