### PR TITLE
Webmaster verification files for Yandex and Bing

### DIFF
--- a/apps/docs/.prettierignore
+++ b/apps/docs/.prettierignore
@@ -35,3 +35,8 @@ public/**/*.txt
 public/.well-known/
 public/pachca.postman_collection.json
 public/scenarios.json
+
+# Webmaster verification files — vendor expects byte-exact content from
+# their UI download. Don't let Prettier touch them.
+public/yandex_*.html
+public/BingSiteAuth.xml

--- a/apps/docs/public/BingSiteAuth.xml
+++ b/apps/docs/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>A9A738CFFD382AE83752A1232BAA1916</user>
+</users>

--- a/apps/docs/public/yandex_ab7926a3769a9885.html
+++ b/apps/docs/public/yandex_ab7926a3769a9885.html
@@ -1,0 +1,6 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    </head>
+    <body>Verification: ab7926a3769a9885</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `apps/docs/public/yandex_ab7926a3769a9885.html` so dev.pachca.com can be verified in Yandex Webmaster (HTML-file method).
- Adds `apps/docs/public/BingSiteAuth.xml` (token `A9A738CFFD382AE83752A1232BAA1916`) for Bing Webmaster Tools (XML File method).
- Pins both in `.prettierignore` — the vendor UIs check for byte-exact content from their download/snippet, so Prettier mustn't touch them.

The IndexNow key file (`364c252f345b89209726bebbc01b8711.txt`) already lives at the same path from #144, so after this PR merges and Vercel deploys, all three search-engine integrations have their root-level proof artefacts.

## Follow-ups (manual, after deploy)

- [ ] Yandex Webmaster: жать «Подтвердить» на dev.pachca.com.
- [ ] Bing Webmaster Tools: жать `Verify` на dev.pachca.com.
- [ ] Подача sitemap.xml в обеих консолях.

IndexNow первый POST уже отправлен вручную (HTTP 202) с приоритетным списком URL — отдельной автоматизации в CI пока не делаем по решению из чата.