### PR TITLE
Drop Vercel-specific framing from proxy.ts comments

### DIFF
--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -71,10 +71,10 @@ export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const twin = markdownTwin(pathname);
 
-  // Markdown content negotiation (Cloudflare/Vercel "agent-friendly pages"
-  // pattern, 2026): an agent that prefers `text/markdown` over `text/html`
-  // gets the .md twin at the same URL. Browsers send `text/html` with q=1
-  // (or `*/*`) → unaffected. See `prefersMarkdown` for q-value handling.
+  // Markdown content negotiation (2026 "agent-friendly pages" pattern): an
+  // agent that prefers `text/markdown` over `text/html` gets the .md twin
+  // at the same URL. Browsers send `text/html` with q=1 (or `*/*`) →
+  // unaffected. See `prefersMarkdown` for q-value handling.
   // Also honored: known live-fetch agent UAs (ChatGPT-User, Claude-User,
   // Perplexity-User, etc.) get the MD twin automatically, since the vendor
   // documents these UAs as live-fetch (vs their indexing crawler counterparts
@@ -120,10 +120,10 @@ export function proxy(request: NextRequest) {
   );
   response.headers.set('X-Llms-Txt', '/llms.txt');
   response.headers.set('Vary', 'Accept');
-  // Default Vercel CDN caching for SSG pages is `s-maxage=31536000` (1 year),
-  // which afdocs flags as «aggressive» and which delays content updates
-  // reaching agents until the next deploy. Match agent artefacts: short CDN
-  // cache + must-revalidate against the ETag Next.js already sets.
+  // CDN-fronted SSG pages often default to a year-long `s-maxage`, which
+  // afdocs flags as «aggressive» and which delays content updates reaching
+  // agents until the next deploy. Match agent artefacts: short CDN cache +
+  // must-revalidate against the ETag Next.js already sets.
   response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate, s-maxage=3600');
   return response;
 }


### PR DESCRIPTION
## Summary

Two comments in [apps/docs/proxy.ts](apps/docs/proxy.ts) described the markdown content-negotiation and the `s-maxage` override as «Cloudflare/Vercel agent-friendly pages pattern» and «default Vercel CDN caching». dev.pachca.com runs behind Angie on self-hosted infra, so the Vercel-specific framing is misleading.

Rephrased to describe the pattern and behaviour without naming a specific platform. Logic, headers, and matcher are unchanged — comment-only diff.