### PR TITLE
Fix: search modal lingering on Safari + shared body scroll lock

### DIFF
--- a/apps/docs/components/layout/mobile-sidebar.tsx
+++ b/apps/docs/components/layout/mobile-sidebar.tsx
@@ -8,6 +8,7 @@ import { SidebarNav } from './sidebar-nav';
 import type { NavigationSection } from '@/lib/openapi/types';
 import { TABS, type TabId } from '@/lib/tabs-config';
 import { useActiveTab } from './use-last-tab';
+import { useBodyScrollLock } from '@/lib/hooks/use-body-scroll-lock';
 
 interface MobileSidebarProps {
   navigationByTab: Record<TabId, NavigationSection[]>;
@@ -57,17 +58,8 @@ export function MobileSidebar({ navigationByTab }: MobileSidebarProps) {
     setIsOpen(false);
   }, [pathname]);
 
-  // Lock body scroll when open
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = '';
-    }
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isOpen]);
+  // Lock body scroll when open (shared with the search modal)
+  useBodyScrollLock(isOpen);
 
   const handleTabChange = (tabId: TabId) => {
     setSelectedTab(tabId);

--- a/apps/docs/components/search/search-dialog.tsx
+++ b/apps/docs/components/search/search-dialog.tsx
@@ -6,6 +6,7 @@ import { Search, SquareTerminal, Loader2, BookText, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import type { SearchResult } from '@/lib/search/indexer';
 import { SUGGESTED_QUERIES } from '@/lib/search/synonyms';
+import { useBodyScrollLock } from '@/lib/hooks/use-body-scroll-lock';
 
 function generateParamId(path: string): string {
   return `param-${path
@@ -33,8 +34,6 @@ export function SearchDialog({ onClose }: SearchDialogProps) {
   }, [onClose]);
 
   const handleResultClick = (result: SearchResult) => {
-    requestClose();
-
     if (result.matchedByField && result.matchedValue?.path) {
       const paramId = generateParamId(result.matchedValue.path);
       const url = `${result.url}#${paramId}`;
@@ -48,6 +47,11 @@ export function SearchDialog({ onClose }: SearchDialogProps) {
     } else {
       router.push(result.url);
     }
+
+    // Закрываем синхронно, без exit-анимации: мы всё равно уходим на другую
+    // страницу. Отложенный unmount (requestClose) на Safari/WebKit гонится с
+    // re-render навигации, и диалог остаётся висеть поверх новой страницы.
+    onClose();
   };
 
   const removeTagsFromDescription = (text: string) => {
@@ -84,6 +88,10 @@ export function SearchDialog({ onClose }: SearchDialogProps) {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [requestClose]);
+
+  // Блокируем скролл основной страницы, пока открыта модалка (диалог монтируется
+  // только когда открыт, поэтому без флага).
+  useBodyScrollLock();
 
   const performSearch = useCallback(async (q: string) => {
     if (!q.trim()) {
@@ -167,7 +175,7 @@ export function SearchDialog({ onClose }: SearchDialogProps) {
   const dialogContent = (
     <div
       className={`fixed inset-0 bg-[oklch(0%_0_0/0.2)] backdrop-blur-sm z-[9999] flex items-start justify-center pt-[60px] pb-[60px] px-4 transition-opacity duration-200 ease-out ${
-        visible ? 'opacity-100' : 'opacity-0'
+        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
       }`}
       onClick={requestClose}
     >

--- a/apps/docs/lib/hooks/use-body-scroll-lock.ts
+++ b/apps/docs/lib/hooks/use-body-scroll-lock.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Блокировка скролла страницы под модалками/оверлеями. Reference-counted, чтобы
+// несколько одновременных локов (если такое случится) не мешали друг другу:
+// разблокировка происходит только когда снят последний лок. Ширину скроллбара
+// компенсируем паддингом на body и на фиксированной шапке, чтобы контент не
+// дёргался вбок (на overlay-скроллбарах macOS ширина = 0 — паддинг не ставится).
+
+let lockCount = 0;
+let saved: {
+  overflow: string;
+  bodyPad: string;
+  header: HTMLElement | null;
+  headerPad: string;
+} | null = null;
+
+function lock() {
+  lockCount += 1;
+  if (lockCount > 1) return; // уже заблокировано первым локом
+
+  const { body } = document;
+  const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+  const header = document.querySelector('header');
+
+  saved = {
+    overflow: body.style.overflow,
+    bodyPad: body.style.paddingRight,
+    header,
+    headerPad: header?.style.paddingRight ?? '',
+  };
+
+  body.style.overflow = 'hidden';
+  if (scrollbarWidth > 0) {
+    body.style.paddingRight = `${scrollbarWidth}px`;
+    if (header) header.style.paddingRight = `${scrollbarWidth}px`;
+  }
+}
+
+function unlock() {
+  lockCount = Math.max(0, lockCount - 1);
+  if (lockCount > 0 || !saved) return; // ещё есть активные локи
+
+  const { body } = document;
+  body.style.overflow = saved.overflow;
+  body.style.paddingRight = saved.bodyPad;
+  if (saved.header) saved.header.style.paddingRight = saved.headerPad;
+  saved = null;
+}
+
+/**
+ * Блокирует скролл основной страницы, пока `enabled === true`.
+ *
+ * Два сценария использования:
+ * - компонент монтируется только когда открыт → `useBodyScrollLock()`;
+ * - компонент всегда смонтирован, открытие по флагу → `useBodyScrollLock(isOpen)`.
+ */
+export function useBodyScrollLock(enabled = true) {
+  useEffect(() => {
+    if (!enabled) return;
+    lock();
+    return unlock;
+  }, [enabled]);
+}


### PR DESCRIPTION
## Проблема

При клике по результату поиска на Safari/WebKit (воспроизводится на Safari 26.5) страница открывается, но модалка поиска остаётся висеть поверх неё — выглядит как «поиск открылся снова / не закрылся». На Chrome не воспроизводится.

## Причина

Закрытие диалога шло через `requestClose()` — отложенный на 200 мс unmount (CSS-фейд + `setTimeout(onClose, 200)`). Эти 200 мс полноэкранный backdrop (`fixed inset-0 z-[9999]`) висит над страницей и гонится с ре-рендером навигации от `router.push`. На WebKit ре-рендер занимает main thread, opacity-переход и таймер коалесцируются — диалог остаётся отрисованным поверх новой страницы. В коде нет ни одного второго вызова `setSearchOpen(true)`, так что «переоткрытие» — это на самом деле не закрывшийся диалог.

## Изменения

- **Клик по результату закрывает синхронно** (`onClose()` вместо `requestClose()`): мы всё равно уходим на другую страницу, exit-анимация не нужна, unmount происходит в том же коммите и не гонится с навигацией. Анимированный `requestClose` остаётся для Escape и клика по фону.
- **`pointer-events-none` на затухающем backdrop**, чтобы он не перехватывал клики во время фейда.
- **Блокировка скролла страницы**, пока открыта модалка поиска.
- **Общий хук `useBodyScrollLock`** (reference-counted, сохраняет/восстанавливает прежние стили, компенсирует ширину скроллбара на `body` и фиксированной шапке). На него переведены и поиск, и мобильный сайдбар — раньше у сайдбара был свой ad-hoc лок без компенсации скроллбара и с безусловным сбросом `overflow`.

## Проверка

`npx turbo build` и `npx turbo check` — зелёные. Дрейфа сгенерированных файлов нет.