### PR TITLE
Обновления: кастомные темы пространства (18.06.26)

### DIFF
--- a/apps/docs/components/mdx/mdx-components.tsx
+++ b/apps/docs/components/mdx/mdx-components.tsx
@@ -493,8 +493,8 @@ export async function ScopeRoles() {
 
 // Update manually when a new product release goes out
 const LATEST_PRODUCT_UPDATE = {
-  date: '18 мая 2026',
-  title: 'Новое окно прочитавших и поставивших реакцию',
+  date: '18 июня 2026',
+  title: 'Кастомные темы пространства',
 };
 
 export function ProductUpdatesLink() {


### PR DESCRIPTION
Добавил запись на странице обновлений о новой возможности самой Пачки — кастомных темах пространства.

- Новый файл `apps/docs/content/updates/2026-06-18.md` (свободный формат, не-API обновление)
- Сборка обновила сгенерированные артефакты: `public/updates/2026-06-18.md`, `public/updates.md`, `public/updates/season/summer-2026.md`, `public/llms.txt`
- `LATEST_PRODUCT_UPDATE` в `mdx-components.tsx` синхронизирован на новую запись