### PR TITLE
Лента обновлений: JSON Feed 1.1 рядом с RSS

### DIFF
--- a/apps/docs/app/feed.json/route.ts
+++ b/apps/docs/app/feed.json/route.ts
@@ -1,0 +1,104 @@
+import { loadUpdates, loadReleases, type ParsedRelease } from '@/lib/updates-parser';
+import { parseOpenAPI } from '@/lib/openapi/parser';
+import { resolveEndpointLinks } from '@/lib/openapi/resolve-links';
+import { toSlug } from '@/lib/utils/transliterate';
+import {
+  PRODUCT_TITLES,
+  extractSummary,
+  markdownToHtml,
+  releaseChangesHtml,
+  releaseSummary,
+} from '@/lib/feed-content';
+
+const BASE_URL = 'https://dev.pachca.com';
+const MAX_ITEMS = 20;
+
+/**
+ * JSON Feed item (spec subset we emit). See https://www.jsonfeed.org/version/1.1/
+ */
+interface JsonFeedItem {
+  id: string;
+  url: string;
+  title: string;
+  summary?: string;
+  content_html: string;
+  date_published: string;
+  tags?: string[];
+}
+
+/** ISO date (YYYY-MM-DD) → RFC 3339 timestamp required by JSON Feed. */
+function toRfc3339(date: string): string {
+  return new Date(date).toISOString();
+}
+
+function releaseToJsonItem(release: ParsedRelease, baseUrl: string): JsonFeedItem {
+  return {
+    id: `${baseUrl}/releases/${release.product}/${release.version}`,
+    url: `${baseUrl}/updates/${release.date}#releases-${release.date}`,
+    title: `${PRODUCT_TITLES[release.product]} v${release.version}`,
+    summary: releaseSummary(release),
+    content_html: releaseChangesHtml(release, baseUrl),
+    date_published: toRfc3339(release.date),
+    tags: [PRODUCT_TITLES[release.product]],
+  };
+}
+
+export async function GET(): Promise<Response> {
+  const baseUrl = BASE_URL;
+
+  const updates = loadUpdates();
+  const releases = loadReleases();
+  const api = await parseOpenAPI();
+
+  // Build update items
+  const updateItems = updates.map((update) => {
+    const slug = toSlug(update.title);
+    const link = `${baseUrl}/updates/${update.date}#${slug}`;
+
+    const resolvedContent = resolveEndpointLinks(update.content, api.endpoints);
+
+    return {
+      date: update.date,
+      item: {
+        id: link,
+        url: link,
+        title: update.title,
+        summary: extractSummary(resolvedContent),
+        content_html: markdownToHtml(resolvedContent, baseUrl),
+        date_published: toRfc3339(update.date),
+      } satisfies JsonFeedItem,
+    };
+  });
+
+  // Build release items
+  const releaseItems = releases.map((release) => ({
+    date: release.date,
+    item: releaseToJsonItem(release, baseUrl),
+  }));
+
+  // Merge and sort by date descending, limit to MAX_ITEMS
+  const items = [...updateItems, ...releaseItems]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, MAX_ITEMS)
+    .map((i) => i.item);
+
+  const feed = {
+    version: 'https://jsonfeed.org/version/1.1',
+    title: 'Пачка API — Обновления',
+    home_page_url: `${baseUrl}/updates`,
+    feed_url: `${baseUrl}/feed.json`,
+    description: 'История изменений и новые возможности API Пачки',
+    language: 'ru',
+    icon: `${baseUrl}/web-app-manifest-192x192.png`,
+    favicon: `${baseUrl}/favicon.ico`,
+    authors: [{ name: 'Пачка', url: baseUrl }],
+    items,
+  };
+
+  return new Response(JSON.stringify(feed, null, 2), {
+    headers: {
+      'Content-Type': 'application/feed+json; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate, s-maxage=86400',
+    },
+  });
+}

--- a/apps/docs/app/feed.xml/route.ts
+++ b/apps/docs/app/feed.xml/route.ts
@@ -2,6 +2,13 @@ import { loadUpdates, loadReleases, type ParsedRelease } from '@/lib/updates-par
 import { parseOpenAPI } from '@/lib/openapi/parser';
 import { resolveEndpointLinks } from '@/lib/openapi/resolve-links';
 import { toSlug } from '@/lib/utils/transliterate';
+import {
+  PRODUCT_TITLES,
+  extractSummary,
+  markdownToHtml,
+  releaseChangesHtml,
+  releaseSummary,
+} from '@/lib/feed-content';
 
 const BASE_URL = 'https://dev.pachca.com';
 const MAX_ITEMS = 20;
@@ -15,154 +22,13 @@ function escapeXml(str: string): string {
     .replace(/'/g, '&apos;');
 }
 
-/**
- * Convert inline markdown (bold, code, links) to HTML.
- * Relative URLs are made absolute.
- */
-function inlineMarkdownToHtml(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/`(.+?)`/g, '<code>$1</code>')
-    .replace(/\[(.+?)\]\((.+?)\)/g, (_match, linkText: string, url: string) => {
-      // Resolved API links from resolveEndpointLinks: "GET:/api/profile/get" → absolute URL
-      const methodPrefixMatch = url.match(/^(?:GET|POST|PUT|PATCH|DELETE):(.+)/);
-      if (methodPrefixMatch) {
-        return `<a href="${BASE_URL}${methodPrefixMatch[1]}">${linkText}</a>`;
-      }
-      // Relative URLs → absolute
-      const absoluteUrl = url.startsWith('/') ? `${BASE_URL}${url}` : url;
-      return `<a href="${absoluteUrl}">${linkText}</a>`;
-    });
-}
-
-/**
- * Strip all markdown formatting from text, returning plain text.
- * Used for <description> summary.
- */
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, '$1')
-    .replace(/`(.+?)`/g, '$1')
-    .replace(/\[(.+?)\]\(.+?\)/g, '$1');
-}
-
-/**
- * Extract first paragraph from markdown as plain text summary for <description>.
- */
-function extractSummary(markdown: string): string {
-  const lines = markdown.split('\n');
-  const paragraphLines: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    // Stop at first empty line after collecting text, or at list/heading
-    if (trimmed === '' && paragraphLines.length > 0) break;
-    if (trimmed.startsWith('-') || trimmed.startsWith('#')) break;
-    if (trimmed === '') continue;
-    paragraphLines.push(trimmed);
-  }
-
-  if (paragraphLines.length === 0) {
-    // Fallback: take first non-empty line
-    const firstLine = lines.find((l) => l.trim() !== '');
-    return firstLine ? stripMarkdown(firstLine.trim()) : '';
-  }
-
-  return stripMarkdown(paragraphLines.join(' '));
-}
-
-/**
- * Convert markdown content to HTML for RSS <content:encoded>.
- * Handles paragraphs, bullet lists (with nesting), bold, code, links.
- */
-function markdownToHtml(markdown: string): string {
-  const lines = markdown.split('\n');
-  const html: string[] = [];
-  let inList = false;
-  let inSubList = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Nested list item (2+ spaces indent)
-    const subListMatch = line.match(/^(\s{2,})-\s+(.+)/);
-    if (subListMatch) {
-      if (!inSubList) {
-        inSubList = true;
-        html.push('<ul>');
-      }
-      html.push(`<li>${inlineMarkdownToHtml(subListMatch[2])}</li>`);
-      continue;
-    }
-
-    // Close sub-list if we're no longer in one
-    if (inSubList) {
-      inSubList = false;
-      html.push('</ul>');
-    }
-
-    // Top-level list item
-    const listMatch = line.match(/^-\s+(.+)/);
-    if (listMatch) {
-      if (!inList) {
-        inList = true;
-        html.push('<ul>');
-      }
-      html.push(`<li>${inlineMarkdownToHtml(listMatch[1])}</li>`);
-      continue;
-    }
-
-    // Close list if we're no longer in one
-    if (inList) {
-      inList = false;
-      html.push('</ul>');
-    }
-
-    // Empty line — skip (paragraph separator)
-    if (line.trim() === '') {
-      continue;
-    }
-
-    // Regular text → paragraph
-    html.push(`<p>${inlineMarkdownToHtml(line)}</p>`);
-  }
-
-  // Close any open lists
-  if (inSubList) html.push('</ul>');
-  if (inList) html.push('</ul>');
-
-  return html.join('\n');
-}
-
-const PRODUCT_TITLES: Record<ParsedRelease['product'], string> = {
-  cli: 'CLI',
-  sdk: 'SDK',
-  generator: 'Generator',
-  n8n: 'n8n Node',
-};
-
-const CHANGE_TYPE_PREFIX: Record<string, string> = {
-  '+': 'Добавлено: ',
-  '~': 'Изменено: ',
-  '-': 'Исправлено: ',
-};
-
 function releaseToRssItem(release: ParsedRelease, baseUrl: string): string {
   const title = `${PRODUCT_TITLES[release.product]} v${release.version}`;
   const link = `${baseUrl}/updates/${release.date}#releases-${release.date}`;
   const guid = `${baseUrl}/releases/${release.product}/${release.version}`;
 
-  const summary = release.changes
-    .slice(0, 2)
-    .map((c) => stripMarkdown(c.description))
-    .join('; ');
-
-  const listHtml = release.changes
-    .map(
-      (c) => `<li>${CHANGE_TYPE_PREFIX[c.type] || ''}${inlineMarkdownToHtml(c.description)}</li>`
-    )
-    .join('\n');
-  const contentHtml = `<ul>\n${listHtml}\n</ul>`;
+  const summary = releaseSummary(release);
+  const contentHtml = releaseChangesHtml(release, baseUrl);
 
   return `    <item>
       <title>${escapeXml(title)}</title>
@@ -189,7 +55,7 @@ export async function GET(): Promise<Response> {
 
     const resolvedContent = resolveEndpointLinks(update.content, api.endpoints);
     const summary = extractSummary(resolvedContent);
-    const contentHtml = markdownToHtml(resolvedContent);
+    const contentHtml = markdownToHtml(resolvedContent, baseUrl);
 
     return {
       date: update.date,

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -115,6 +115,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           title="Пачка API — Обновления"
           href="/feed.xml"
         />
+        <link
+          rel="alternate"
+          type="application/feed+json"
+          title="Пачка API — Обновления"
+          href="/feed.json"
+        />
         <link rel="llms-txt" type="text/plain" title="llms.txt" href="/llms.txt" />
         <link rel="llms-full-txt" type="text/plain" title="llms-full.txt" href="/llms-full.txt" />
         {/* Per-page <link rel="alternate" type="text/markdown"> is emitted by

--- a/apps/docs/components/api/markdown-actions.tsx
+++ b/apps/docs/components/api/markdown-actions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Check, Copy, ChevronDown, FileText, Link, Bot, Rss } from 'lucide-react';
+import { Check, Copy, ChevronDown, FileText, Link, Bot, Rss, Braces } from 'lucide-react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { CopiedTooltip } from './copied-tooltip';
 
@@ -109,6 +109,15 @@ export function MarkdownActions({ pageUrl }: MarkdownActionsProps) {
           >
             <Rss className="w-3.5 h-3.5 shrink-0" strokeWidth={2} />
             <span>RSS</span>
+          </a>
+          <a
+            href="/feed.json"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex h-7 items-center gap-1 text-text-secondary! font-medium hover:text-text-primary! transition-colors duration-200 text-nowrap no-underline!"
+          >
+            <Braces className="w-3.5 h-3.5 shrink-0" strokeWidth={2} />
+            <span>JSON</span>
           </a>
         </>
       )}

--- a/apps/docs/lib/feed-content.ts
+++ b/apps/docs/lib/feed-content.ts
@@ -1,0 +1,164 @@
+import type { ParsedRelease } from './updates-parser';
+
+/**
+ * Shared content helpers for the syndication feeds (RSS `/feed.xml` and
+ * JSON Feed `/feed.json`). Both feeds render the same updates + releases, so the
+ * markdown→HTML / summary logic lives here to avoid drift between formats.
+ */
+
+export const PRODUCT_TITLES: Record<ParsedRelease['product'], string> = {
+  cli: 'CLI',
+  sdk: 'SDK',
+  generator: 'Generator',
+  n8n: 'n8n Node',
+};
+
+export const CHANGE_TYPE_PREFIX: Record<string, string> = {
+  '+': 'Добавлено: ',
+  '~': 'Изменено: ',
+  '-': 'Исправлено: ',
+};
+
+/**
+ * Convert inline markdown (bold, code, links) to HTML.
+ * Relative URLs and resolved endpoint links are made absolute against baseUrl.
+ */
+export function inlineMarkdownToHtml(text: string, baseUrl: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/`(.+?)`/g, '<code>$1</code>')
+    .replace(/\[(.+?)\]\((.+?)\)/g, (_match, linkText: string, url: string) => {
+      // Resolved API links from resolveEndpointLinks: "GET:/api/profile/get" → absolute URL
+      const methodPrefixMatch = url.match(/^(?:GET|POST|PUT|PATCH|DELETE):(.+)/);
+      if (methodPrefixMatch) {
+        return `<a href="${baseUrl}${methodPrefixMatch[1]}">${linkText}</a>`;
+      }
+      // Relative URLs → absolute
+      const absoluteUrl = url.startsWith('/') ? `${baseUrl}${url}` : url;
+      return `<a href="${absoluteUrl}">${linkText}</a>`;
+    });
+}
+
+/**
+ * Strip all markdown formatting from text, returning plain text.
+ * Used for plain-text summaries (RSS <description>, JSON Feed content_text).
+ */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/`(.+?)`/g, '$1')
+    .replace(/\[(.+?)\]\(.+?\)/g, '$1');
+}
+
+/**
+ * Extract first paragraph from markdown as plain text summary.
+ */
+export function extractSummary(markdown: string): string {
+  const lines = markdown.split('\n');
+  const paragraphLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Stop at first empty line after collecting text, or at list/heading
+    if (trimmed === '' && paragraphLines.length > 0) break;
+    if (trimmed.startsWith('-') || trimmed.startsWith('#')) break;
+    if (trimmed === '') continue;
+    paragraphLines.push(trimmed);
+  }
+
+  if (paragraphLines.length === 0) {
+    // Fallback: take first non-empty line
+    const firstLine = lines.find((l) => l.trim() !== '');
+    return firstLine ? stripMarkdown(firstLine.trim()) : '';
+  }
+
+  return stripMarkdown(paragraphLines.join(' '));
+}
+
+/**
+ * Convert markdown content to HTML for feed bodies (RSS <content:encoded>,
+ * JSON Feed content_html). Handles paragraphs, bullet lists (with nesting),
+ * bold, code, links.
+ */
+export function markdownToHtml(markdown: string, baseUrl: string): string {
+  const lines = markdown.split('\n');
+  const html: string[] = [];
+  let inList = false;
+  let inSubList = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Nested list item (2+ spaces indent)
+    const subListMatch = line.match(/^(\s{2,})-\s+(.+)/);
+    if (subListMatch) {
+      if (!inSubList) {
+        inSubList = true;
+        html.push('<ul>');
+      }
+      html.push(`<li>${inlineMarkdownToHtml(subListMatch[2], baseUrl)}</li>`);
+      continue;
+    }
+
+    // Close sub-list if we're no longer in one
+    if (inSubList) {
+      inSubList = false;
+      html.push('</ul>');
+    }
+
+    // Top-level list item
+    const listMatch = line.match(/^-\s+(.+)/);
+    if (listMatch) {
+      if (!inList) {
+        inList = true;
+        html.push('<ul>');
+      }
+      html.push(`<li>${inlineMarkdownToHtml(listMatch[1], baseUrl)}</li>`);
+      continue;
+    }
+
+    // Close list if we're no longer in one
+    if (inList) {
+      inList = false;
+      html.push('</ul>');
+    }
+
+    // Empty line — skip (paragraph separator)
+    if (line.trim() === '') {
+      continue;
+    }
+
+    // Regular text → paragraph
+    html.push(`<p>${inlineMarkdownToHtml(line, baseUrl)}</p>`);
+  }
+
+  // Close any open lists
+  if (inSubList) html.push('</ul>');
+  if (inList) html.push('</ul>');
+
+  return html.join('\n');
+}
+
+/**
+ * Build the HTML body for a release (a bullet list of its changes), shared by
+ * both feeds.
+ */
+export function releaseChangesHtml(release: ParsedRelease, baseUrl: string): string {
+  const listHtml = release.changes
+    .map(
+      (c) =>
+        `<li>${CHANGE_TYPE_PREFIX[c.type] || ''}${inlineMarkdownToHtml(c.description, baseUrl)}</li>`
+    )
+    .join('\n');
+  return `<ul>\n${listHtml}\n</ul>`;
+}
+
+/**
+ * Plain-text summary of a release (first two changes), shared by both feeds.
+ */
+export function releaseSummary(release: ParsedRelease): string {
+  return release.changes
+    .slice(0, 2)
+    .map((c) => stripMarkdown(c.description))
+    .join('; ');
+}


### PR DESCRIPTION
## Что

Добавляет JSON Feed для ленты обновлений рядом с существующим RSS.

- **Новый роут `/feed.json`** — генерит ленту в формате [JSON Feed 1.1](https://www.jsonfeed.org/version/1.1/) из тех же `updates/*.md` + `releases.json`, что и `/feed.xml`. Всегда актуален (собирается на запрос).
- **Общая логика вынесена в `lib/feed-content.ts`** — markdown→HTML, summary, рендер релизов. RSS и JSON теперь импортируют её, чтобы форматы не разъезжались.
- **Авто-дискавери** — `<link rel="alternate" type="application/feed+json">` в `layout.tsx` рядом с RSS.
- **Видимая ссылка «JSON»** рядом с «RSS» на странице `/updates`.

## Зачем

JSON-фид парсится агентами/ботами/n8n проще, чем XML — это нативный машиночитаемый канал для нашей агентской аудитории. По стандарту 1.1: `language: ru`, `authors`, `application/feed+json`, `date_published` в RFC 3339.

## Проверки

- `npx turbo build` — ✅
- `npx turbo check` (lint + typecheck + knip + format + tests) — ✅
- Runtime: `/feed.json` → 200, валидный JSON Feed 1.1, 20 записей, обязательные поля на месте. `/feed.xml` после рефактора — без изменений, 200, 20 записей.